### PR TITLE
Rename Space Fruit to Space Adventure; swap enemy/player images and randomize music

### DIFF
--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title class="translate" data-fr="Arcade : Fruits de l'espace" data-en="Arcade: Space Fruit Blaster" data-ja="アーケード：スペースフルーツブラスター">Arcade: Space Fruit Blaster</title>
+  <title class="translate" data-fr="Arcade : Space Adventure" data-en="Arcade: Space Adventure" data-ja="アーケード：スペースアドベンチャー">Arcade: Space Adventure</title>
   <link rel="stylesheet" href="../../css/control-panel.css">
   <link rel="stylesheet" href="../../css/games.css">
   <link rel="stylesheet" href="../../css/gaming.css">
@@ -148,13 +148,13 @@
         <div class="game-menu-main">
           <div id="options-title-bar">
             <h1 id="options-arcade-title">Arcade</h1>
-            <h2 id="options-main-title" class="translate" data-fr="Fruits de l'espace" data-en="Space Fruit Blaster" data-ja="スペースフルーツブラスター">Fruits de l'espace</h2>
+            <h2 id="options-main-title" class="translate" data-fr="Space Adventure" data-en="Space Adventure" data-ja="スペースアドベンチャー">Space Adventure</h2>
           </div>
 
           <p id="control-panel-instructions" class="control-panel-instructions translate"
-             data-fr="Des aliens-fruits apparaissent toutes les 10 secondes. Appuie sur espace pour tirer et les détruire !"
-             data-en="Fruit aliens appear every 10 seconds. Press space to shoot them down!"
-             data-ja="10秒ごとにフルーツエイリアンが現れます。スペースキーで撃ち落とそう！">
+             data-fr="Des ennemis spatiaux apparaissent toutes les 10 secondes. Appuie sur espace pour les détruire !"
+             data-en="Space enemies appear every 10 seconds. Press space to destroy them!"
+             data-ja="10秒ごとに宇宙の敵が現れます。スペースキーで撃ち落とそう！">
           </p>
 
           <div id="mode-divider"></div>
@@ -253,15 +253,19 @@
       const ctx = canvas.getContext('2d');
 
       const enemySprites = [];
-      const fruitPaths = [
-        '../../images/pictos/apple.png',
-        '../../images/pictos/orange.png',
-        '../../images/pictos/banana.png',
-        '../../images/pictos/strawberry.png',
-        '../../images/pictos/kiwi.png',
-        '../../images/pictos/grapes.png',
-        '../../images/pictos/lemon.png',
-        '../../images/pictos/pineapple.png'
+      const enemyPaths = [
+        '../../images/spaceadventure/enemy1.png',
+        '../../images/spaceadventure/enemy2.png',
+        '../../images/spaceadventure/enemy3.png',
+        '../../images/spaceadventure/enemy4.png',
+        '../../images/spaceadventure/enemy5.png',
+        '../../images/spaceadventure/enemy6.png'
+      ];
+      const playerSprite = new Image();
+      playerSprite.src = '../../images/spaceadventure/blueship.png';
+      const musicPlaylist = [
+        '../../songs/space/spacequest1.mp3',
+        '../../songs/space/spacequestfast2.mp3'
       ];
 
       let inputMode = 'switch';
@@ -351,11 +355,18 @@
       }
 
       function loadSprites() {
-        fruitPaths.forEach((path) => {
+        enemyPaths.forEach((path) => {
           const img = new Image();
           img.src = path;
           enemySprites.push(img);
         });
+      }
+
+      function pickBackgroundTrack() {
+        const choice = musicPlaylist[Math.floor(Math.random() * musicPlaylist.length)];
+        if (music.src.endsWith(choice)) return;
+        music.src = choice;
+        music.load();
       }
 
       function spawnEnemy() {
@@ -757,25 +768,20 @@
       function drawPlayer() {
         const x = player.x;
         const y = player.y;
-
-        ctx.save();
-        ctx.translate(x, y);
+        if (playerSprite.complete && playerSprite.naturalWidth > 0) {
+          const width = player.width * 1.8;
+          const height = width * (playerSprite.naturalHeight / playerSprite.naturalWidth);
+          ctx.drawImage(playerSprite, x - width * 0.5, y - height * 0.5, width, height);
+          return;
+        }
 
         ctx.fillStyle = '#21e0ff';
         ctx.beginPath();
-        ctx.moveTo(0, -26);
-        ctx.lineTo(-22, 18);
-        ctx.lineTo(22, 18);
+        ctx.moveTo(x, y - 26);
+        ctx.lineTo(x - 22, y + 18);
+        ctx.lineTo(x + 22, y + 18);
         ctx.closePath();
         ctx.fill();
-
-        ctx.fillStyle = '#005d8e';
-        ctx.fillRect(-34, 18, 68, 10);
-
-        ctx.fillStyle = '#ffffff';
-        ctx.fillRect(-8, -3, 16, 8);
-
-        ctx.restore();
       }
 
       function drawBullets() {
@@ -1183,6 +1189,7 @@
 
         spawnEnemy();
         playSfx('start');
+        pickBackgroundTrack();
         try { music.currentTime = 0; music.play(); } catch (_) {}
         if (!document.fullscreenElement) {
           document.documentElement.requestFullscreen?.().catch(() => {});


### PR DESCRIPTION
### Motivation
- Rebrand the arcade stop-action game from "Space Fruit" to "Space Adventure" and replace fruit-themed visuals with new space-themed assets.
- Use the provided `images/spaceadventure` sprites for enemies and the player ship to match new artwork and improve consistency.
- Make the background music selection less repetitive by choosing randomly between the existing track and `spacequestfast2` at game start.

### Description
- Updated the document title, in-game menu title, and instructions text in `arcade/space-invaders-fruits/index.html` to reflect the `Space Adventure` name and messaging.
- Replaced the fruit sprite list with `enemyPaths` pointing to `../../images/spaceadventure/enemy1.png` through `enemy6.png` and adjusted `loadSprites()` to load them into `enemySprites`.
- Added `playerSprite` loading from `../../images/spaceadventure/blueship.png` and changed `drawPlayer()` to render the image when available while keeping a simple vector fallback.
- Introduced `musicPlaylist` and `pickBackgroundTrack()` to randomly select between `../../songs/space/spacequest1.mp3` and `spacequestfast2.mp3`, and invoked it during `startGame()`.

### Testing
- Ran `git -C /workspace/jeux.adaptatech diff --check` and it completed without issues.
- Ran `git -C /workspace/jeux.adaptatech status --short` to confirm the modified file is staged/committed and it completed successfully.
- Ran `git -C /workspace/jeux.adaptatech show --stat --oneline HEAD` to verify the change summary and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f2c44b8883258edfbd5be126339b)