### PR TITLE
Rename Space Fruit to Space Adventure; swap sprites and randomize music

### DIFF
--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -750,7 +750,11 @@
       }
 
       function getDangerLineY() {
-        return getEyegazeRowY(getEyegazeRowCount() - 1) + getEyegazeTileSize() * 0.5 + 18;
+        const baseY = getEyegazeRowY(getEyegazeRowCount() - 1) + getEyegazeTileSize() * 0.5 + 18;
+        const { drawHeight } = getPlayerRenderSize();
+        const playerTop = player.y - drawHeight * 0.55;
+        const maxSafeY = playerTop - Math.max(16, drawHeight * 0.12);
+        return Math.min(baseY, maxSafeY);
       }
 
       function getEyegazeColumnLanes() {
@@ -761,13 +765,21 @@
         return difficulty === 'normal' ? 2 : 3;
       }
 
+      function getPlayerRenderSize() {
+        if (playerSprite.complete && playerSprite.naturalWidth > 0) {
+          const drawWidth = Math.max(140, canvas.width * PLAYER_SHIP_VW);
+          const drawHeight = drawWidth * (playerSprite.naturalHeight / playerSprite.naturalWidth || 0.8);
+          return { drawWidth, drawHeight };
+        }
+        return { drawWidth: 44, drawHeight: 44 };
+      }
+
       function drawPlayer() {
         const x = player.x;
         const y = player.y;
 
         if (playerSprite.complete && playerSprite.naturalWidth > 0) {
-          const drawWidth = Math.max(140, canvas.width * PLAYER_SHIP_VW);
-          const drawHeight = drawWidth * (playerSprite.naturalHeight / playerSprite.naturalWidth || 0.8);
+          const { drawWidth, drawHeight } = getPlayerRenderSize();
           ctx.drawImage(playerSprite, x - drawWidth * 0.5, y - drawHeight * 0.55, drawWidth, drawHeight);
           return;
         }

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -750,11 +750,7 @@
       }
 
       function getDangerLineY() {
-        const baseY = getEyegazeRowY(getEyegazeRowCount() - 1) + getEyegazeTileSize() * 0.5 + 18;
-        const { drawHeight } = getPlayerRenderSize();
-        const playerTop = player.y - drawHeight * 0.55;
-        const maxSafeY = playerTop - Math.max(16, drawHeight * 0.12);
-        return Math.min(baseY, maxSafeY);
+        return getEyegazeRowY(getEyegazeRowCount() - 1) + getEyegazeTileSize() * 0.5 + 18;
       }
 
       function getEyegazeColumnLanes() {
@@ -767,7 +763,9 @@
 
       function getPlayerRenderSize() {
         if (playerSprite.complete && playerSprite.naturalWidth > 0) {
-          const drawWidth = Math.max(140, canvas.width * PLAYER_SHIP_VW);
+          const shipVw = canvas.width < 1280 ? PLAYER_SHIP_VW * 0.8 : PLAYER_SHIP_VW;
+          const minWidth = canvas.width < 1280 ? 110 : 140;
+          const drawWidth = Math.max(minWidth, canvas.width * shipVw);
           const drawHeight = drawWidth * (playerSprite.naturalHeight / playerSprite.naturalWidth || 0.8);
           return { drawWidth, drawHeight };
         }

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -248,6 +248,7 @@
       const gameOverScore = document.getElementById('game-over-score');
       const ammoMeter = document.getElementById('ammo-meter');
       const ammoMeterFill = document.getElementById('ammo-meter-fill');
+      const ammoMeterTrack = ammoMeter?.querySelector('.ammo-meter-track');
 
       const canvas = document.getElementById('game-canvas');
       const ctx = canvas.getContext('2d');
@@ -263,6 +264,8 @@
       ];
       const playerSprite = new Image();
       playerSprite.src = '../../images/spaceadventure/blueship.png';
+      const tankEnemySprite = new Image();
+      tankEnemySprite.src = '../../images/spaceadventure/enemy2.png';
       const musicPlaylist = [
         '../../songs/space/spacequest1.mp3',
         '../../songs/space/spacequestfast2.mp3'
@@ -289,6 +292,7 @@
       let projectileFlashUntil = 0;
       let retryHoverStartAt = 0;
       let retryRafId = null;
+      let musicStartTimeoutId = null;
       const EYEGAZE_DWELL_MS = 1000;
       const EYEGAZE_ROW_STEP_MS = 10000;
       const EYEGAZE_ROW_TRANSITION_MS = 2000;
@@ -366,7 +370,7 @@
       }
 
       function spawnEnemy() {
-        const image = enemySprites[Math.floor(Math.random() * enemySprites.length)] || null;
+        const enemyImage = enemySprites[Math.floor(Math.random() * enemySprites.length)] || null;
         const size = 48;
         if (inputMode === 'eyegaze') {
           const tileSize = getEyegazeTileSize();
@@ -380,7 +384,7 @@
             y: rowY,
             size: tileSize,
             speed: 0,
-            image,
+            image: enemyImage,
             type: 'normal',
             hp: 1,
             eyegazeTile: true,
@@ -397,16 +401,18 @@
         const baseSpeed = 58;
         const speedMultiplier = difficulty === 'competitive' ? 1.5 : difficulty === 'hard' ? 1.25 : 1;
         const switchSize = Math.max(120, canvas.width * SWITCH_ENEMY_VW);
+        const tankSize = switchSize * 1.5;
+        const activeSize = isTank ? tankSize : switchSize;
         const leftSafeZone = canvas.width * 0.1; // keep left 1/10 clear for UI (ammo column)
-        const minX = Math.max(leftSafeZone + switchSize * 0.5, 30 + switchSize * 0.5);
-        const maxX = Math.max(minX, canvas.width - Math.max(60, switchSize * 0.5 + 20));
+        const minX = Math.max(leftSafeZone + activeSize * 0.5, 30 + activeSize * 0.5);
+        const maxX = Math.max(minX, canvas.width - Math.max(60, activeSize * 0.5 + 20));
         enemies.push({
           id: nextEnemyId++,
           x: minX + Math.random() * Math.max(0, maxX - minX),
           y: 70,
-          size: switchSize,
+          size: activeSize,
           speed: baseSpeed * speedMultiplier,
-          image,
+          image: isTank ? tankEnemySprite : enemyImage,
           type: isTank ? 'tank' : 'normal',
           hp: isTank ? 2 : 1
         });
@@ -596,6 +602,10 @@
                 break;
               }
               e.hp -= 1;
+              if (e.type === 'tank' && e.hp === 1) {
+                e.speed *= 0.5;
+                spawnTankSmokeBurst(e.x, e.y, e.size);
+              }
               if (e.hp <= 0) {
                 enemies.splice(i, 1);
                 score += e.type === 'tank' ? 20 : 10;
@@ -905,12 +915,14 @@
 
           if (e.image && e.image.complete) {
             ctx.drawImage(e.image, e.x - e.size * 0.5, e.y - e.size * 0.5, e.size, e.size);
-            if (e.type === 'tank') {
-              ctx.strokeStyle = 'rgba(255, 110, 110, 0.95)';
-              ctx.lineWidth = 3;
+            if (e.type === 'tank' && e.hp === 1) {
+              ctx.save();
+              ctx.globalCompositeOperation = 'lighter';
+              ctx.fillStyle = 'rgba(255, 160, 120, 0.22)';
               ctx.beginPath();
-              ctx.arc(e.x, e.y, e.size * 0.38, 0, Math.PI * 2);
-              ctx.stroke();
+              ctx.arc(e.x, e.y, e.size * 0.48, 0, Math.PI * 2);
+              ctx.fill();
+              ctx.restore();
             }
           } else {
             ctx.fillStyle = '#ff3b6b';
@@ -955,6 +967,8 @@
               ctx.fillStyle = `rgba(110, 190, 255, ${0.62 * alpha})`;
             } else if (burst.color === 'gold') {
               ctx.fillStyle = `rgba(255, 210, 90, ${0.72 * alpha})`;
+            } else if (burst.color === 'smoke') {
+              ctx.fillStyle = `rgba(170, 175, 190, ${0.55 * alpha})`;
             } else {
               ctx.fillStyle = `rgba(255, 110, 70, ${0.65 * alpha})`;
             }
@@ -1024,6 +1038,23 @@
         }
         triggerShieldFlash();
         fxBursts.push({ life: 0.65, maxLife: 0.65, particles, type: 'particles', color: 'blue' });
+      }
+
+      function spawnTankSmokeBurst(x, y, size) {
+        const particles = [];
+        const count = 12;
+        for (let i = 0; i < count; i += 1) {
+          const a = Math.random() * Math.PI * 2;
+          const speed = 24 + Math.random() * 36;
+          particles.push({
+            x: x + (Math.random() - 0.5) * size * 0.3,
+            y: y + (Math.random() - 0.5) * size * 0.3,
+            vx: Math.cos(a) * speed,
+            vy: Math.sin(a) * speed - 12,
+            r: Math.max(2, size * 0.05 + Math.random() * 2)
+          });
+        }
+        fxBursts.push({ life: 0.55, maxLife: 0.55, particles, type: 'particles', color: 'smoke', drag: 0.965 });
       }
 
       function triggerShieldFlash(now = performance.now()) {
@@ -1150,6 +1181,26 @@
       function updateAmmoMeter() {
         if (!ammoMeter || !ammoMeterFill) return;
         ammoMeter.style.display = usesAmmoMeter() ? 'block' : 'none';
+        if (inputMode === 'switch') {
+          const shieldY = getDangerLineY();
+          ammoMeter.style.left = '20px';
+          ammoMeter.style.top = `${shieldY + 18}px`;
+          ammoMeter.style.bottom = 'auto';
+          ammoMeter.style.transform = 'none';
+          if (ammoMeterTrack) {
+            ammoMeterTrack.style.width = '58px';
+            ammoMeterTrack.style.height = '190px';
+          }
+        } else {
+          ammoMeter.style.left = '20px';
+          ammoMeter.style.top = '50%';
+          ammoMeter.style.bottom = 'auto';
+          ammoMeter.style.transform = 'translateY(-50%)';
+          if (ammoMeterTrack) {
+            ammoMeterTrack.style.width = '72px';
+            ammoMeterTrack.style.height = '260px';
+          }
+        }
         const percent = Math.round(ammoEnergy * 100);
         const hue = Math.round(ammoEnergy * 120); // 0 red -> 120 green
         ammoMeterFill.style.height = `${percent}%`;
@@ -1209,7 +1260,11 @@
         spawnEnemy();
         playSfx('start');
         pickBackgroundTrack();
-        try { music.currentTime = 0; music.play(); } catch (_) {}
+        if (musicStartTimeoutId) clearTimeout(musicStartTimeoutId);
+        musicStartTimeoutId = setTimeout(() => {
+          musicStartTimeoutId = null;
+          try { music.currentTime = 0; music.play(); } catch (_) {}
+        }, 3000);
         if (!document.fullscreenElement) {
           document.documentElement.requestFullscreen?.().catch(() => {});
         }
@@ -1222,6 +1277,10 @@
       function endGame() {
         running = false;
         cancelAnimationFrame(rafId);
+        if (musicStartTimeoutId) {
+          clearTimeout(musicStartTimeoutId);
+          musicStartTimeoutId = null;
+        }
         music.pause();
         updateCursorVisibility();
         if (gazePointer) gazePointer.style.opacity = '0';

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -767,8 +767,8 @@
           let drawWidth;
 
           if (canvas.height <= 800) {
-            const smallScreenWidth = Math.min(canvas.width * 0.1, (canvas.height * 0.17) / aspectRatio);
-            drawWidth = Math.max(84, smallScreenWidth);
+            const smallScreenWidth = Math.min(canvas.width * 0.12, (canvas.height * 0.2) / aspectRatio);
+            drawWidth = Math.max(96, smallScreenWidth);
           } else {
             const shipVw = canvas.width < 1280 ? PLAYER_SHIP_VW * 0.8 : PLAYER_SHIP_VW;
             const minWidth = canvas.width < 1280 ? 110 : 140;

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -267,6 +267,7 @@
         '../../songs/space/spacequest1.mp3',
         '../../songs/space/spacequestfast2.mp3'
       ];
+      const BG_MUSIC_VOLUME = 0.5;
 
       let inputMode = 'switch';
       let difficulty = 'normal';
@@ -303,6 +304,8 @@
       const fxBursts = [];
       let nextEnemyId = 1;
       const STAR_COUNT = 220;
+      const SWITCH_ENEMY_VW = 0.15;
+      const PLAYER_SHIP_VW = 0.22;
 
       const player = {
         x: 0,
@@ -393,7 +396,7 @@
           || (difficulty === 'competitive' && Math.random() < 0.5);
         const baseSpeed = 58;
         const speedMultiplier = difficulty === 'competitive' ? 1.5 : difficulty === 'hard' ? 1.25 : 1;
-        const switchSize = size * 3;
+        const switchSize = Math.max(120, canvas.width * SWITCH_ENEMY_VW);
         const leftSafeZone = canvas.width * 0.1; // keep left 1/10 clear for UI (ammo column)
         const minX = Math.max(leftSafeZone + switchSize * 0.5, 30 + switchSize * 0.5);
         const maxX = Math.max(minX, canvas.width - Math.max(60, switchSize * 0.5 + 20));
@@ -763,8 +766,8 @@
         const y = player.y;
 
         if (playerSprite.complete && playerSprite.naturalWidth > 0) {
-          const drawWidth = 104;
-          const drawHeight = 82;
+          const drawWidth = Math.max(140, canvas.width * PLAYER_SHIP_VW);
+          const drawHeight = drawWidth * (playerSprite.naturalHeight / playerSprite.naturalWidth || 0.8);
           ctx.drawImage(playerSprite, x - drawWidth * 0.5, y - drawHeight * 0.55, drawWidth, drawHeight);
           return;
         }
@@ -783,6 +786,7 @@
 
       function pickBackgroundTrack() {
         const selectedTrack = musicPlaylist[Math.floor(Math.random() * musicPlaylist.length)] || musicPlaylist[0];
+        music.volume = BG_MUSIC_VOLUME;
         if (music.src.endsWith(selectedTrack)) return;
         music.src = selectedTrack;
         music.load();

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title class="translate" data-fr="Arcade : Fruits de l'espace" data-en="Arcade: Space Fruit Blaster" data-ja="アーケード：スペースフルーツブラスター">Arcade: Space Fruit Blaster</title>
+  <title class="translate" data-fr="Arcade : Space Adventure" data-en="Arcade: Space Adventure" data-ja="アーケード：スペースアドベンチャー">Arcade: Space Adventure</title>
   <link rel="stylesheet" href="../../css/control-panel.css">
   <link rel="stylesheet" href="../../css/games.css">
   <link rel="stylesheet" href="../../css/gaming.css">
@@ -148,13 +148,13 @@
         <div class="game-menu-main">
           <div id="options-title-bar">
             <h1 id="options-arcade-title">Arcade</h1>
-            <h2 id="options-main-title" class="translate" data-fr="Fruits de l'espace" data-en="Space Fruit Blaster" data-ja="スペースフルーツブラスター">Fruits de l'espace</h2>
+            <h2 id="options-main-title" class="translate" data-fr="Space Adventure" data-en="Space Adventure" data-ja="スペースアドベンチャー">Space Adventure</h2>
           </div>
 
           <p id="control-panel-instructions" class="control-panel-instructions translate"
-             data-fr="Des aliens-fruits apparaissent toutes les 10 secondes. Appuie sur espace pour tirer et les détruire !"
-             data-en="Fruit aliens appear every 10 seconds. Press space to shoot them down!"
-             data-ja="10秒ごとにフルーツエイリアンが現れます。スペースキーで撃ち落とそう！">
+             data-fr="Des ennemis apparaissent toutes les 10 secondes. Appuie sur espace pour tirer et les détruire !"
+             data-en="Enemies appear every 10 seconds. Press space to shoot them down!"
+             data-ja="10秒ごとに敵が現れます。スペースキーで撃ち落とそう！">
           </p>
 
           <div id="mode-divider"></div>
@@ -220,7 +220,7 @@
     </div>
   </div>
 
-  <audio id="bg-music" src="../../songs/space/spacequest1.mp3" preload="auto" loop></audio>
+  <audio id="bg-music" preload="auto" loop></audio>
   <audio id="sfx-launch" src="../../sounds/spaceadventure/missile.mp3" preload="auto"></audio>
   <audio id="sfx-hit" src="../../sounds/spaceadventure/hit.mp3" preload="auto"></audio>
   <audio id="sfx-destroy" src="../../sounds/spaceadventure/shipdestroyed.mp3" preload="auto"></audio>
@@ -253,15 +253,19 @@
       const ctx = canvas.getContext('2d');
 
       const enemySprites = [];
-      const fruitPaths = [
-        '../../images/pictos/apple.png',
-        '../../images/pictos/orange.png',
-        '../../images/pictos/banana.png',
-        '../../images/pictos/strawberry.png',
-        '../../images/pictos/kiwi.png',
-        '../../images/pictos/grapes.png',
-        '../../images/pictos/lemon.png',
-        '../../images/pictos/pineapple.png'
+      const enemyImagePaths = [
+        '../../images/spaceadventure/enemy1.png',
+        '../../images/spaceadventure/enemy2.png',
+        '../../images/spaceadventure/enemy3.png',
+        '../../images/spaceadventure/enemy4.png',
+        '../../images/spaceadventure/enemy5.png',
+        '../../images/spaceadventure/enemy6.png'
+      ];
+      const playerSprite = new Image();
+      playerSprite.src = '../../images/spaceadventure/blueship.png';
+      const musicPlaylist = [
+        '../../songs/space/spacequest1.mp3',
+        '../../songs/space/spacequestfast2.mp3'
       ];
 
       let inputMode = 'switch';
@@ -351,7 +355,7 @@
       }
 
       function loadSprites() {
-        fruitPaths.forEach((path) => {
+        enemyImagePaths.forEach((path) => {
           const img = new Image();
           img.src = path;
           enemySprites.push(img);
@@ -758,24 +762,30 @@
         const x = player.x;
         const y = player.y;
 
+        if (playerSprite.complete && playerSprite.naturalWidth > 0) {
+          const drawWidth = 104;
+          const drawHeight = 82;
+          ctx.drawImage(playerSprite, x - drawWidth * 0.5, y - drawHeight * 0.55, drawWidth, drawHeight);
+          return;
+        }
+
         ctx.save();
         ctx.translate(x, y);
-
-        ctx.fillStyle = '#21e0ff';
+        ctx.fillStyle = '#2f8bff';
         ctx.beginPath();
         ctx.moveTo(0, -26);
         ctx.lineTo(-22, 18);
         ctx.lineTo(22, 18);
         ctx.closePath();
         ctx.fill();
-
-        ctx.fillStyle = '#005d8e';
-        ctx.fillRect(-34, 18, 68, 10);
-
-        ctx.fillStyle = '#ffffff';
-        ctx.fillRect(-8, -3, 16, 8);
-
         ctx.restore();
+      }
+
+      function pickBackgroundTrack() {
+        const selectedTrack = musicPlaylist[Math.floor(Math.random() * musicPlaylist.length)] || musicPlaylist[0];
+        if (music.src.endsWith(selectedTrack)) return;
+        music.src = selectedTrack;
+        music.load();
       }
 
       function drawBullets() {
@@ -1183,6 +1193,7 @@
 
         spawnEnemy();
         playSfx('start');
+        pickBackgroundTrack();
         try { music.currentTime = 0; music.play(); } catch (_) {}
         if (!document.fullscreenElement) {
           document.documentElement.requestFullscreen?.().catch(() => {});

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -764,17 +764,9 @@
       function getPlayerRenderSize() {
         if (playerSprite.complete && playerSprite.naturalWidth > 0) {
           const aspectRatio = playerSprite.naturalHeight / playerSprite.naturalWidth || 0.8;
-          let drawWidth;
-
-          if (canvas.height <= 800) {
-            const smallScreenWidth = Math.min(canvas.width * 0.12, (canvas.height * 0.2) / aspectRatio);
-            drawWidth = Math.max(96, smallScreenWidth);
-          } else {
-            const shipVw = canvas.width < 1280 ? PLAYER_SHIP_VW * 0.8 : PLAYER_SHIP_VW;
-            const minWidth = canvas.width < 1280 ? 110 : 140;
-            drawWidth = Math.max(minWidth, canvas.width * shipVw);
-          }
-
+          const baseShipWidth = Math.max(140, canvas.width * PLAYER_SHIP_VW);
+          const smallScreenScale = Math.max(0.9, Math.min(1, canvas.height / 1080));
+          const drawWidth = baseShipWidth * smallScreenScale;
           const drawHeight = drawWidth * aspectRatio;
           return { drawWidth, drawHeight };
         }

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -763,10 +763,19 @@
 
       function getPlayerRenderSize() {
         if (playerSprite.complete && playerSprite.naturalWidth > 0) {
-          const shipVw = canvas.width < 1280 ? PLAYER_SHIP_VW * 0.8 : PLAYER_SHIP_VW;
-          const minWidth = canvas.width < 1280 ? 110 : 140;
-          const drawWidth = Math.max(minWidth, canvas.width * shipVw);
-          const drawHeight = drawWidth * (playerSprite.naturalHeight / playerSprite.naturalWidth || 0.8);
+          const aspectRatio = playerSprite.naturalHeight / playerSprite.naturalWidth || 0.8;
+          let drawWidth;
+
+          if (canvas.height <= 800) {
+            const smallScreenWidth = Math.min(canvas.width * 0.1, (canvas.height * 0.17) / aspectRatio);
+            drawWidth = Math.max(84, smallScreenWidth);
+          } else {
+            const shipVw = canvas.width < 1280 ? PLAYER_SHIP_VW * 0.8 : PLAYER_SHIP_VW;
+            const minWidth = canvas.width < 1280 ? 110 : 140;
+            drawWidth = Math.max(minWidth, canvas.width * shipVw);
+          }
+
+          const drawHeight = drawWidth * aspectRatio;
           return { drawWidth, drawHeight };
         }
         return { drawWidth: 44, drawHeight: 44 };


### PR DESCRIPTION
### Motivation
- Rebrand the small arcade title from the fruit-themed variant to a space adventure and use new artwork found in `images/spaceadventure` for a cohesive look.  
- Replace the procedurally drawn player ship with a dedicated sprite and update enemies to match the new visual direction.  
- Make background music a randomized choice so each run alternates between the existing track and a faster variant.

### Description
- Update in-page presentation text and metadata by changing the page title, menu heading and instructions (FR/EN/JA) to use "Space Adventure".  
- Replace the enemy asset list with `../../images/spaceadventure/enemy1.png` through `enemy6.png` and wire those into `loadSprites()` so enemies load from the new paths.  
- Add a `playerSprite` (`../../images/spaceadventure/blueship.png`) and draw it in `drawPlayer()` with a simple fallback shape if the image has not loaded.  
- Remove the fixed `bg-music` `src` and add a `musicPlaylist` plus a `pickBackgroundTrack()` helper that randomly selects between `spacequest1.mp3` and `spacequestfast2.mp3` and is invoked at game start.

### Testing
- Searched the codebase with `rg` to locate and verify occurrences of titles, player drawing, enemy loading and music usages and confirmed the expected replacements succeeded.  
- Inspected relevant file regions with `sed -n` and `nl` to validate the inserted `enemyImagePaths`, `playerSprite`, `musicPlaylist`, `pickBackgroundTrack()` and the `drawPlayer()` changes.  
- Confirmed the new image assets exist by listing `images/spaceadventure` entries via file search commands.  
- Applied and verified the patch updated `arcade/space-invaders-fruits/index.html` without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f2c44b8883258edfbd5be126339b)