### PR TITLE
Polish payment UI: image backgrounds, sizing, shadows and disabled states

### DIFF
--- a/pedagogique/paiementprudent/index.html
+++ b/pedagogique/paiementprudent/index.html
@@ -411,6 +411,24 @@ body.advanced-wallet .counter.bad{
   font-size: clamp(2.2rem, 1.8rem + 2.6vw, 4.4rem);
   font-weight:800;cursor:pointer;text-align:center;
   transition:transform .15s;
+  min-height: calc(var(--tileSize) * 1.05);
+  min-width: clamp(140px, 28vw, 220px);
+  width: clamp(140px, 32vw, 240px);
+  border-radius:14px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding: 0.35rem 1rem;
+  color:#fff;
+  text-shadow:0 2px 6px rgba(0,0,0,.55);
+  background-image:
+    linear-gradient(rgba(18,24,42,.28),rgba(18,24,42,.28)),
+    url("../../images/paiement/Prix%20(final).png");
+  background-size:cover;
+  background-position:center;
+  background-repeat:no-repeat;
+  border:none;
+  box-shadow:0 4px 10px rgba(0,0,0,.2);
 }
 body.advanced-wallet #priceZone{
   margin-top:clamp(0.2rem, 0.7vh, 0.6rem);
@@ -434,32 +452,52 @@ body.advanced-wallet #priceStatus{min-height:1.4rem;}
 #priceButtons{display:flex;justify-content:center;flex-wrap:wrap;width:100%;gap:clamp(0.8rem, 2.4vw, 1rem);}
 body.advanced-wallet #priceButtons{gap:clamp(0.6rem, 1.8vw, 0.8rem);}
 #priceButtons button{
-  min-height: calc(var(--tileSize) * 0.95);
+  min-height: calc(var(--tileSize) * 1.05);
   min-width: clamp(140px, 28vw, 220px);
   width: clamp(140px, 32vw, 240px);
-  padding: 0.4rem 1rem;
+  padding: 0.35rem 1rem;
   font-size: clamp(1.2rem, 1rem + 1vmin, 1.8rem);
   line-height: 1.1;
   border:none;border-radius:14px;color:#fff;cursor:pointer;
+  text-shadow:0 2px 6px rgba(0,0,0,.55);
+  background-size:cover;
+  background-position:center;
+  background-repeat:no-repeat;
+  box-shadow:0 4px 10px rgba(0,0,0,.2);
 }
-#verifyBtn{background:#2e7d32;}
-#verifyBtn:disabled{background:#9fbca1;cursor:not-allowed;}
-#payBtn{background:#c65629;}
-#payBtn:disabled,#payBtn.dim{background:#d79a85;cursor:not-allowed;}
+#verifyBtn{
+  background-image:
+    linear-gradient(rgba(18,24,42,.28),rgba(18,24,42,.28)),
+    url("../../images/paiement/v%C3%A9rifier%20(final).png");
+}
+#verifyBtn:disabled{filter:grayscale(.55) brightness(.8);cursor:not-allowed;}
+#payBtn{
+  background-image:
+    linear-gradient(rgba(18,24,42,.28),rgba(18,24,42,.28)),
+    url("../../images/paiement/payer%20(final).png");
+}
+#payBtn:disabled,#payBtn.dim{filter:grayscale(.55) brightness(.8);cursor:not-allowed;}
 
 #studentSetPriceBtn{
   margin:0;
-  min-height: calc(var(--tileSize) * 0.95);
+  min-height: calc(var(--tileSize) * 1.05);
   min-width: clamp(140px, 28vw, 220px);
   width: clamp(140px, 32vw, 240px);
   font-size: clamp(1.1rem, 1rem + 1vmin, 1.6rem);
   line-height: 1.1;
-  padding: 0.4rem 1rem;
+  padding: 0.35rem 1rem;
 
   border-radius:14px;
   border:none;
-  background:#244774;
+  background-image:
+    linear-gradient(rgba(18,24,42,.28),rgba(18,24,42,.28)),
+    url("../../images/paiement/combine%20%C3%A7a%20co%C3%BBte%20(final).png");
+  background-size:cover;
+  background-position:center;
+  background-repeat:no-repeat;
   color:#fff;
+  text-shadow:0 2px 6px rgba(0,0,0,.55);
+  box-shadow:0 4px 10px rgba(0,0,0,.2);
 
   cursor:pointer;
   transition:transform .1s, filter .12s;
@@ -467,7 +505,7 @@ body.advanced-wallet #priceButtons{gap:clamp(0.6rem, 1.8vw, 0.8rem);}
 }
 #studentSetPriceBtn:hover{ filter: brightness(1.06); }
 #studentSetPriceBtn:active{ transform: scale(.98); }
-#studentSetPriceBtn.active{ background:#1c3558;color:#fff; }
+#studentSetPriceBtn.active{ filter:brightness(.92);color:#fff; }
 
 /* Modales génériques */
 .modalBox{


### PR DESCRIPTION
### Motivation
- Modernize and unify the payment UI visuals by replacing flat color buttons with image-backed tiles and improving sizing and contrast.
- Ensure controls scale consistently with `--tileSize` and responsive clamps for better layout across viewports.

### Description
- Updated `pedagogique/paiementprudent/index.html` CSS to restyle `#priceTag`, action buttons and `#studentSetPriceBtn` to use image-based `background-image`, `background-size: cover`, `text-shadow`, and `box-shadow` for a richer visual appearance.
- Increased minimum heights from `calc(var(--tileSize) * 0.95)` to `calc(var(--tileSize) * 1.05)` and adjusted paddings and widths for `#priceTag`, `#priceButtons button`, and `#studentSetPriceBtn` to improve touch targets and alignment.
- Replaced color-only disabled styles with `filter: grayscale(...) brightness(...)` for `#verifyBtn`, `#payBtn`, and related disabled/dim states, and adjusted the active state of `#studentSetPriceBtn` to use `filter:brightness(...)`.
- Added specific selectors for `#verifyBtn` and `#payBtn` to assign their respective background images and refined layout properties (centering and padding) for the price tile.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da43a7fe388325a8254dfa8a450f9f)