### PR TITLE
Update homepage featured game to Space Adventure

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,10 +185,10 @@
   Aventure dans l'espace
 </h2>
 <p class="featured-game__description"
-   data-fr="Un jeu d’arcade inspiré de classiques comme Galaga et Space Invaders, avec un pilotage simple adapté aux switches et au contrôle oculaire, et deux niveaux de difficulté pensés autant pour les joueurs occasionnels que pour les joueurs experts."
-   data-en="An arcade game inspired by classics like Galaga and Space Invaders, with simple controls adapted for switches and eye-gaze, plus two difficulty modes designed for both casual and hardcore players."
-   data-ja="Galaga や Space Invaders のような名作に着想を得たアーケードゲームで、スイッチ入力や視線操作でも遊びやすいシンプルな操作に加え、カジュアルなプレイヤーから上級者まで楽しめる2つの難易度を用意しています。">
-  Un jeu d’arcade inspiré de classiques comme Galaga et Space Invaders, avec un pilotage simple adapté aux switches et au contrôle oculaire, et deux niveaux de difficulté pensés autant pour les joueurs occasionnels que pour les joueurs experts.
+   data-fr="Un jeu d’arcade inspiré de classiques comme Galaga et Space Invaders, avec un pilotage simple adapté aux switches et au contrôle oculaire, et trois niveaux de difficulté pensés autant pour les joueurs occasionnels que pour les joueurs experts."
+   data-en="An arcade game inspired by classics like Galaga and Space Invaders, with simple controls adapted for switches and eye-gaze, plus three difficulty levels designed for both casual and hardcore players."
+   data-ja="Galaga や Space Invaders のような名作に着想を得たアーケードゲームで、スイッチ入力や視線操作でも遊びやすいシンプルな操作に加え、カジュアルなプレイヤーから上級者まで楽しめる3つの難易度を用意しています。">
+  Un jeu d’arcade inspiré de classiques comme Galaga et Space Invaders, avec un pilotage simple adapté aux switches et au contrôle oculaire, et trois niveaux de difficulté pensés autant pour les joueurs occasionnels que pour les joueurs experts.
 </p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -185,10 +185,10 @@
   Aventure dans l'espace
 </h2>
 <p class="featured-game__description"
-   data-fr="Un jeu d’arcade inspiré des classiques spatiaux, avec un pilotage simple adapté aux switches et au contrôle oculaire."
-   data-en="An arcade game inspired by classic space shooters, with simple controls adapted for switches and eye-gaze."
-   data-ja="クラシックなスペースシューティングに着想を得たアーケードゲームで、スイッチ入力や視線操作でも遊びやすいシンプルな操作です。">
-  Un jeu d’arcade inspiré des classiques spatiaux, avec un pilotage simple adapté aux switches et au contrôle oculaire.
+   data-fr="Un jeu d’arcade inspiré de classiques comme Galaga et Space Invaders, avec un pilotage simple adapté aux switches et au contrôle oculaire, et deux niveaux de difficulté pensés autant pour les joueurs occasionnels que pour les joueurs experts."
+   data-en="An arcade game inspired by classics like Galaga and Space Invaders, with simple controls adapted for switches and eye-gaze, plus two difficulty modes designed for both casual and hardcore players."
+   data-ja="Galaga や Space Invaders のような名作に着想を得たアーケードゲームで、スイッチ入力や視線操作でも遊びやすいシンプルな操作に加え、カジュアルなプレイヤーから上級者まで楽しめる2つの難易度を用意しています。">
+  Un jeu d’arcade inspiré de classiques comme Galaga et Space Invaders, avec un pilotage simple adapté aux switches et au contrôle oculaire, et deux niveaux de difficulté pensés autant pour les joueurs occasionnels que pour les joueurs experts.
 </p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -165,8 +165,8 @@
   </section>
 
   <section class="featured-game" aria-labelledby="featured-game-title">
-    <a href="arcade/mariomovie/index.html" class="featured-game__inner featured-game__inner-link">
-      <img src="images/arcade/mariomoviecover.png"
+    <a href="arcade/space-invaders-fruits/index.html" class="featured-game__inner featured-game__inner-link">
+      <img src="images/spaceadventure.png"
            alt="Illustration du jeu vedette"
            class="featured-game__thumb">
       <div class="featured-game__content">
@@ -179,16 +179,16 @@
           </span>
 <h2 id="featured-game-title"
     class="featured-game__title"
-    data-fr="Mario Arcade — Parcours de Peach"
-    data-en="Mario Arcade — Peach’s obstacle course"
-    data-ja="Mario Arcade — スイッチ対応のピーチ姫の障害物コース">
-  Mario Arcade — le parcours d’obstacles de Peach adapté aux switchs
+    data-fr="Aventure dans l'espace"
+    data-en="Space Adventure"
+    data-ja="スペースアドベンチャー">
+  Aventure dans l'espace
 </h2>
 <p class="featured-game__description"
-   data-fr="Une nouvelle formule de jeu inspirée de classiques d’arcade comme Dragon’s Lair, basée sur des séquences vidéo ponctuées d’arrêts où le joueur doit intervenir au bon moment. Ce type de mécanique fonctionne particulièrement bien avec une switch, et d’autres exemples suivront."
-   data-en="A new game format inspired by arcade classics like Dragon’s Lair, built around video sequences interrupted by key pauses where the player must act at the right moment. This kind of mechanic works especially well with a single switch, and more examples are on the way."
-   data-ja="Dragon’s Lair のようなアーケードの名作に着想を得た新しいゲーム形式で、映像シーンの途中に止まる場面が入り、プレイヤーが適切なタイミングで操作します。この仕組みは1つのスイッチ操作と特に相性がよく、今後もこのタイプのゲームを増やしていく予定です。">
-  Une nouvelle formule de jeu inspirée de classiques d’arcade comme Dragon’s Lair, basée sur des séquences vidéo ponctuées d’arrêts où le joueur doit intervenir au bon moment. Ce type de mécanique fonctionne particulièrement bien avec un seul switch, et d’autres exemples suivront.
+   data-fr="Un jeu d’arcade inspiré des classiques spatiaux, avec un pilotage simple adapté aux switches et au contrôle oculaire."
+   data-en="An arcade game inspired by classic space shooters, with simple controls adapted for switches and eye-gaze."
+   data-ja="クラシックなスペースシューティングに着想を得たアーケードゲームで、スイッチ入力や視線操作でも遊びやすいシンプルな操作です。">
+  Un jeu d’arcade inspiré des classiques spatiaux, avec un pilotage simple adapté aux switches et au contrôle oculaire.
 </p>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Replace the homepage featured game (previously Mario Arcade) with the Space Adventure entry so the site highlights the space shooter instead of the Mario card.

### Description
- Updated `index.html` to point the featured-game link to `arcade/space-invaders-fruits/index.html` and swapped the thumbnail to `images/spaceadventure.png`.
- Replaced the visible title and localized title/description attributes (FR/EN/JA) to reflect Space Adventure and adjusted the short description copy.

### Testing
- No unit or integration test suite was run for this content-only change.
- Performed content verification with `rg` and file inspection (`nl -ba index.html`) to confirm the link, image and localized strings were updated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1176965083259b4a5eea2577a6db)