### PR TITLE
Add eyegaze game-over UI, score submission and leaderboard support

### DIFF
--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -167,24 +167,30 @@
 
     .eyegaze-action-button-wrap {
       position: relative;
-      width: min(100%, 260px);
+      width: min(100%, 180px);
+      aspect-ratio: 1 / 1;
       margin-top: 4px;
     }
 
     .eyegaze-action-button-wrap .button {
       width: 100%;
+      height: 100%;
       margin-top: 0;
       position: relative;
       z-index: 1;
+      border-radius: 20px;
+      white-space: normal;
+      line-height: 1.3;
+      padding: 12px;
     }
 
     .eyegaze-action-fill {
       position: absolute;
       inset: 0;
-      border-radius: 999px;
+      border-radius: 20px;
       background: rgba(255, 52, 52, 0.42);
-      transform: scaleX(0);
-      transform-origin: left center;
+      transform: scale(0);
+      transform-origin: center;
       pointer-events: none;
       z-index: 2;
     }
@@ -2606,8 +2612,8 @@ function findEnemyById(id) {
       function resetScoreEyegazeFills() {
         scoreSubmitHoverStartAt = 0;
         scoreRetryHoverStartAt = 0;
-        if (scoreSubmitFill) scoreSubmitFill.style.transform = 'scaleX(0)';
-        if (scoreRetryFill) scoreRetryFill.style.transform = 'scaleX(0)';
+        if (scoreSubmitFill) scoreSubmitFill.style.transform = 'scale(0)';
+        if (scoreRetryFill) scoreRetryFill.style.transform = 'scale(0)';
       }
 
       function startEyegazeScoreMonitor() {
@@ -2626,9 +2632,9 @@ function findEnemyById(id) {
           if (overSubmit) {
             if (!scoreSubmitHoverStartAt) scoreSubmitHoverStartAt = now;
             const progress = Math.max(0, Math.min(1, (now - scoreSubmitHoverStartAt) / EYEGAZE_DWELL_MS));
-            if (scoreSubmitFill) scoreSubmitFill.style.transform = `scaleX(${progress})`;
+            if (scoreSubmitFill) scoreSubmitFill.style.transform = `scale(${progress})`;
             scoreRetryHoverStartAt = 0;
-            if (scoreRetryFill) scoreRetryFill.style.transform = 'scaleX(0)';
+            if (scoreRetryFill) scoreRetryFill.style.transform = 'scale(0)';
             if (progress >= 1) {
               handleScoreSubmission();
               return;
@@ -2636,9 +2642,9 @@ function findEnemyById(id) {
           } else if (overRetry) {
             if (!scoreRetryHoverStartAt) scoreRetryHoverStartAt = now;
             const progress = Math.max(0, Math.min(1, (now - scoreRetryHoverStartAt) / EYEGAZE_DWELL_MS));
-            if (scoreRetryFill) scoreRetryFill.style.transform = `scaleX(${progress})`;
+            if (scoreRetryFill) scoreRetryFill.style.transform = `scale(${progress})`;
             scoreSubmitHoverStartAt = 0;
-            if (scoreSubmitFill) scoreSubmitFill.style.transform = 'scaleX(0)';
+            if (scoreSubmitFill) scoreSubmitFill.style.transform = 'scale(0)';
             if (progress >= 1) {
               playSfx('retry');
               startGame();

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -111,19 +111,25 @@
       line-height: 1.5;
     }
 
-    #retry-eyegaze-tile {
+    .retry-eyegaze-tiles {
+      display: none;
+      width: min(88vw, 680px);
+      margin: 12px auto 0;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+
+    .retry-eyegaze-tile {
       width: min(42vw, 320px);
       aspect-ratio: 1 / 1;
-      margin: 12px auto 0;
       border: 4px solid rgba(255,255,255,0.75);
       border-radius: 20px;
       background: rgba(255,255,255,0.1);
       position: relative;
-      display: none;
       overflow: hidden;
     }
 
-    #retry-eyegaze-tile img {
+    .retry-eyegaze-tile img {
       width: 82%;
       height: 82%;
       object-fit: contain;
@@ -134,7 +140,7 @@
       z-index: 1;
     }
 
-    #retry-eyegaze-fill {
+    .retry-eyegaze-fill {
       position: absolute;
       inset: 0;
       background: rgba(255, 52, 52, 0.42);
@@ -142,6 +148,55 @@
       transform-origin: center;
       pointer-events: none;
       z-index: 2;
+    }
+
+    .retry-eyegaze-label {
+      position: absolute;
+      left: 10px;
+      right: 10px;
+      bottom: 12px;
+      z-index: 3;
+      text-align: center;
+      color: #fff;
+      font-family: 'Press Start 2P', cursive;
+      font-size: 11px;
+      line-height: 1.5;
+      text-shadow: 0 0 8px rgba(0, 0, 0, 0.8);
+      pointer-events: none;
+    }
+
+    .eyegaze-action-button-wrap {
+      position: relative;
+      width: min(100%, 260px);
+      margin-top: 4px;
+    }
+
+    .eyegaze-action-button-wrap .button {
+      width: 100%;
+      margin-top: 0;
+      position: relative;
+      z-index: 1;
+    }
+
+    .eyegaze-action-fill {
+      position: absolute;
+      inset: 0;
+      border-radius: 999px;
+      background: rgba(255, 52, 52, 0.42);
+      transform: scaleX(0);
+      transform-origin: left center;
+      pointer-events: none;
+      z-index: 2;
+    }
+
+    #continue-button {
+      width: min(100%, 280px);
+      margin: 10px auto 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      line-height: 1.2;
     }
 
     .ship-select-panel {
@@ -498,9 +553,41 @@
     <div class="results-panel stop-action-results-panel">
       <p id="game-over-score"></p>
       <p id="retry-hint" class="retry-hint"></p>
-      <div id="retry-eyegaze-tile" aria-hidden="true">
-        <div id="retry-eyegaze-fill"></div>
-        <img src="../../images/spaceadventure/blueship.png" alt="Retry ship">
+      <div id="retry-eyegaze-tiles" class="retry-eyegaze-tiles" aria-hidden="true">
+        <div id="retry-eyegaze-tile" class="retry-eyegaze-tile">
+          <div id="retry-eyegaze-fill" class="retry-eyegaze-fill"></div>
+          <img src="../../images/spaceadventure/blueship.png" alt="Retry ship">
+          <p id="retry-eyegaze-label" class="retry-eyegaze-label"></p>
+        </div>
+        <div id="register-eyegaze-tile" class="retry-eyegaze-tile">
+          <div id="register-eyegaze-fill" class="retry-eyegaze-fill"></div>
+          <img src="../../images/spaceadventure/redship.png" alt="Register score ship">
+          <p id="register-eyegaze-label" class="retry-eyegaze-label"></p>
+        </div>
+      </div>
+      <div id="score-ui-layout" class="stop-action-results-layout">
+        <section class="stop-action-results-column stop-action-results-column-score" aria-label="Score summary">
+          <div id="score-register-panel" class="score-register-panel hidden" aria-live="polite">
+            <p id="score-register-question" class="stop-action-results-metric"></p>
+            <div class="score-register-form">
+              <label id="score-player-name-label" for="score-player-name" class="score-player-name-label"></label>
+              <input id="score-player-name" class="score-player-name-input" type="text" maxlength="20" autocomplete="name" />
+              <div class="eyegaze-action-button-wrap">
+                <button id="score-submit" type="button" class="button"></button>
+                <div id="score-submit-fill" class="eyegaze-action-fill" aria-hidden="true"></div>
+              </div>
+              <div class="eyegaze-action-button-wrap">
+                <button id="score-retry" type="button" class="button"></button>
+                <div id="score-retry-fill" class="eyegaze-action-fill" aria-hidden="true"></div>
+              </div>
+            </div>
+            <p id="score-register-status" class="score-register-status" role="status"></p>
+          </div>
+        </section>
+        <section id="leaderboard-panel" class="stop-action-results-column leaderboard-panel hidden" aria-live="polite" aria-label="Leaderboard">
+          <h3 id="leaderboard-title" class="leaderboard-title"></h3>
+          <ol id="leaderboard-list" class="leaderboard-list"></ol>
+        </section>
       </div>
       <button id="continue-button" class="button translate" data-fr="Recommencer" data-en="Restart" data-ja="もう一度">Recommencer</button>
     </div>
@@ -525,8 +612,13 @@
       const gameOverScreen = document.getElementById('game-over');
       const restartButton = document.getElementById('continue-button');
       const retryHint = document.getElementById('retry-hint');
+      const retryEyegazeTiles = document.getElementById('retry-eyegaze-tiles');
       const retryEyegazeTile = document.getElementById('retry-eyegaze-tile');
       const retryEyegazeFill = document.getElementById('retry-eyegaze-fill');
+      const retryEyegazeLabel = document.getElementById('retry-eyegaze-label');
+      const registerEyegazeTile = document.getElementById('register-eyegaze-tile');
+      const registerEyegazeFill = document.getElementById('register-eyegaze-fill');
+      const registerEyegazeLabel = document.getElementById('register-eyegaze-label');
       const music = document.getElementById('bg-music');
       const menuMusic = document.getElementById('menu-music');
       const languageToggleButton = document.getElementById('language-toggle');
@@ -538,6 +630,19 @@
       const ammoMeter = document.getElementById('ammo-meter');
       const ammoMeterFill = document.getElementById('ammo-meter-fill');
       const ammoMeterTrack = document.querySelector('#ammo-meter .ammo-meter-track');
+      const scoreRegisterPanel = document.getElementById('score-register-panel');
+      const scoreUiLayout = document.getElementById('score-ui-layout');
+      const scoreRegisterQuestion = document.getElementById('score-register-question');
+      const scorePlayerNameLabel = document.getElementById('score-player-name-label');
+      const scorePlayerNameInput = document.getElementById('score-player-name');
+      const scoreSubmitButton = document.getElementById('score-submit');
+      const scoreRetryButton = document.getElementById('score-retry');
+      const scoreSubmitFill = document.getElementById('score-submit-fill');
+      const scoreRetryFill = document.getElementById('score-retry-fill');
+      const scoreRegisterStatus = document.getElementById('score-register-status');
+      const leaderboardPanel = document.getElementById('leaderboard-panel');
+      const leaderboardTitle = document.getElementById('leaderboard-title');
+      const leaderboardList = document.getElementById('leaderboard-list');
 
       const shipCards = Array.from(document.querySelectorAll('.ship-card'));
       const shipSelectTitle = document.getElementById('ship-select-title');
@@ -621,6 +726,12 @@
       const menuBaseMusicPath = '../../songs/space/spacequest1.mp3';
       const BG_MUSIC_VOLUME = 0.5;
       const MENU_MUSIC_VOLUME = 0.28;
+      const SCORE_API_BASE = 'https://score-api-2.gui98789.workers.dev';
+      const SCORE_TOP_LIMIT = 5;
+      const SCORE_GAMES = {
+        switch: 'space-adventure-switch',
+        eyegaze: 'space-adventure-eyegaze'
+      };
 
       let selectedShip = 'blue';
       let inputMode = 'switch';
@@ -644,12 +755,19 @@
       let shieldFlashStartedAt = 0;
       let projectileFlashUntil = 0;
       let retryHoverStartAt = 0;
+      let registerHoverStartAt = 0;
       let retryRafId = null;
+      let scoreRafId = null;
       let musicStartTimeoutId = null;
       let gameOverPending = false;
       let gameOverPendingAt = 0;
       let screenShakeUntil = 0;
       let screenShakeStrength = 0;
+      let scoreSubmissionState = 'idle';
+      let gameOverMenuVisible = false;
+      let switchIsDown = false;
+      let scoreSubmitHoverStartAt = 0;
+      let scoreRetryHoverStartAt = 0;
 
       const EYEGAZE_DWELL_MS = 1000;
       const EYEGAZE_ROW_STEP_MS = 10000;
@@ -2387,6 +2505,270 @@ function findEnemyById(id) {
         if (hasLimitedLives()) livesNode.textContent = `${livesLabel}: ${lives}`;
       }
 
+      function getScoreGameKey() {
+        return inputMode === 'eyegaze' ? SCORE_GAMES.eyegaze : SCORE_GAMES.switch;
+      }
+
+      function getSelectedModeForScoreboard() {
+        return ['normal', 'hard', 'competitive'].includes(difficulty) ? difficulty : 'normal';
+      }
+
+      function getScorePanelCopy() {
+        const lang = getCurrentLanguage();
+        const copy = {
+          fr: {
+            registerQuestion: 'Enregistre ton score dans le classement.',
+            nameLabel: 'Votre nom',
+            submit: 'Enregistrer',
+            retry: 'Recommencer',
+            sending: 'Enregistrement du score...',
+            submitSuccess: 'Score enregistré.',
+            submitError: 'Impossible d\'enregistrer le score pour le moment.',
+            emptyName: 'Veuillez entrer un nom.',
+            leaderboardTitle: (mode) => `Top ${SCORE_TOP_LIMIT} (${mode})`,
+            emptyLeaderboard: 'Aucun score pour le moment.',
+            loadingLeaderboard: 'Chargement du classement...',
+            leaderboardError: 'Impossible de charger le classement.',
+            anonymous: 'Anonyme',
+            modes: { normal: 'Normal', hard: 'Difficile', competitive: 'Maître' }
+          },
+          en: {
+            registerQuestion: 'Save your score to the leaderboard.',
+            nameLabel: 'Your name',
+            submit: 'Submit score',
+            retry: 'Retry',
+            sending: 'Submitting score...',
+            submitSuccess: 'Score submitted.',
+            submitError: 'Unable to submit score right now.',
+            emptyName: 'Please enter a name.',
+            leaderboardTitle: (mode) => `Top ${SCORE_TOP_LIMIT} (${mode})`,
+            emptyLeaderboard: 'No scores yet.',
+            loadingLeaderboard: 'Loading leaderboard...',
+            leaderboardError: 'Unable to load leaderboard.',
+            anonymous: 'Anonymous',
+            modes: { normal: 'Normal', hard: 'Hard', competitive: 'Master' }
+          },
+          ja: {
+            registerQuestion: 'スコアをランキングに登録します。',
+            nameLabel: '名前',
+            submit: 'スコア登録',
+            retry: 'もう一度',
+            sending: 'スコアを送信中...',
+            submitSuccess: 'スコアを登録しました。',
+            submitError: '現在スコアを登録できません。',
+            emptyName: '名前を入力してください。',
+            leaderboardTitle: (mode) => `トップ${SCORE_TOP_LIMIT}（${mode}）`,
+            emptyLeaderboard: 'まだスコアがありません。',
+            loadingLeaderboard: 'ランキングを読み込み中...',
+            leaderboardError: 'ランキングを読み込めません。',
+            anonymous: '匿名',
+            modes: { normal: 'ノーマル', hard: 'ハード', competitive: 'マスター' }
+          }
+        };
+        return copy[lang] || copy.en;
+      }
+
+      function getModeLabelForLeaderboard(mode, copy) {
+        return copy?.modes?.[mode] || mode;
+      }
+
+      function setScoreStatusMessage(message, isError) {
+        if (!scoreRegisterStatus) return;
+        scoreRegisterStatus.textContent = message || '';
+        scoreRegisterStatus.classList.toggle('is-error', Boolean(isError));
+      }
+
+      function updateScorePanelCopy() {
+        const copy = getScorePanelCopy();
+        if (scoreRegisterQuestion) scoreRegisterQuestion.textContent = copy.registerQuestion;
+        if (scorePlayerNameLabel) scorePlayerNameLabel.textContent = copy.nameLabel;
+        if (scoreSubmitButton) scoreSubmitButton.textContent = copy.submit;
+        if (scoreRetryButton) scoreRetryButton.textContent = copy.retry;
+        if (scoreSubmissionState === 'sending') setScoreStatusMessage(copy.sending, false);
+      }
+
+      function updateGameOverOptionLabels() {
+        const lang = getCurrentLanguage();
+        if (retryEyegazeLabel) {
+          retryEyegazeLabel.textContent =
+            lang === 'fr' ? 'Réessayer' :
+            lang === 'ja' ? 'もう一度' :
+            'Retry';
+        }
+        if (registerEyegazeLabel) {
+          registerEyegazeLabel.textContent =
+            lang === 'fr' ? 'Entrer ton score' :
+            lang === 'ja' ? 'スコアを登録' :
+            'Enter your score';
+        }
+      }
+
+      function resetScoreEyegazeFills() {
+        scoreSubmitHoverStartAt = 0;
+        scoreRetryHoverStartAt = 0;
+        if (scoreSubmitFill) scoreSubmitFill.style.transform = 'scaleX(0)';
+        if (scoreRetryFill) scoreRetryFill.style.transform = 'scaleX(0)';
+      }
+
+      function startEyegazeScoreMonitor() {
+        if (inputMode !== 'eyegaze') return;
+        if (scoreRafId) cancelAnimationFrame(scoreRafId);
+        resetScoreEyegazeFills();
+
+        const loop = () => {
+          if (running || !gameOverScreen || gameOverScreen.style.display !== 'flex' || gameOverMenuVisible || inputMode !== 'eyegaze') return;
+          const now = performance.now();
+          const submitRect = scoreSubmitButton?.getBoundingClientRect();
+          const retryRect = scoreRetryButton?.getBoundingClientRect();
+          const overSubmit = submitRect && gazeX >= submitRect.left && gazeX <= submitRect.right && gazeY >= submitRect.top && gazeY <= submitRect.bottom;
+          const overRetry = retryRect && gazeX >= retryRect.left && gazeX <= retryRect.right && gazeY >= retryRect.top && gazeY <= retryRect.bottom;
+
+          if (overSubmit) {
+            if (!scoreSubmitHoverStartAt) scoreSubmitHoverStartAt = now;
+            const progress = Math.max(0, Math.min(1, (now - scoreSubmitHoverStartAt) / EYEGAZE_DWELL_MS));
+            if (scoreSubmitFill) scoreSubmitFill.style.transform = `scaleX(${progress})`;
+            scoreRetryHoverStartAt = 0;
+            if (scoreRetryFill) scoreRetryFill.style.transform = 'scaleX(0)';
+            if (progress >= 1) {
+              handleScoreSubmission();
+              return;
+            }
+          } else if (overRetry) {
+            if (!scoreRetryHoverStartAt) scoreRetryHoverStartAt = now;
+            const progress = Math.max(0, Math.min(1, (now - scoreRetryHoverStartAt) / EYEGAZE_DWELL_MS));
+            if (scoreRetryFill) scoreRetryFill.style.transform = `scaleX(${progress})`;
+            scoreSubmitHoverStartAt = 0;
+            if (scoreSubmitFill) scoreSubmitFill.style.transform = 'scaleX(0)';
+            if (progress >= 1) {
+              playSfx('retry');
+              startGame();
+              return;
+            }
+          } else {
+            resetScoreEyegazeFills();
+          }
+
+          scoreRafId = requestAnimationFrame(loop);
+        };
+
+        scoreRafId = requestAnimationFrame(loop);
+      }
+
+      function setScoreUiVisible(showScorePanel) {
+        const show = Boolean(showScorePanel);
+        gameOverMenuVisible = inputMode === 'switch' ? true : !show;
+        if (scoreUiLayout) scoreUiLayout.style.display = show ? 'grid' : 'none';
+        if (scoreRegisterPanel) {
+          scoreRegisterPanel.classList.toggle('hidden', !show);
+          scoreRegisterPanel.style.display = show ? 'block' : 'none';
+        }
+        if (leaderboardPanel) {
+          leaderboardPanel.classList.toggle('hidden', !show);
+          leaderboardPanel.style.display = show ? 'flex' : 'none';
+        }
+        restartButton.style.display = inputMode === 'switch' ? 'inline-flex' : 'none';
+        if (retryEyegazeTiles) retryEyegazeTiles.style.display = show || inputMode !== 'eyegaze' ? 'none' : 'grid';
+      }
+
+      async function submitScore(game, playerName, scoreValue, mode) {
+        const response = await fetch(SCORE_API_BASE + '/score', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ game, playerName, score: scoreValue, mode })
+        });
+        if (!response.ok) throw new Error('submit_failed');
+        return response.json();
+      }
+
+      async function getLeaderboard(game, mode, limit) {
+        const params = new URLSearchParams({ game, mode, limit: String(limit) });
+        const response = await fetch(SCORE_API_BASE + '/leaderboard?' + params.toString());
+        if (!response.ok) throw new Error('leaderboard_failed');
+        return response.json();
+      }
+
+      async function renderLeaderboard() {
+        if (!leaderboardPanel || !leaderboardList || !leaderboardTitle) return;
+        const copy = getScorePanelCopy();
+        const mode = getSelectedModeForScoreboard();
+        leaderboardTitle.textContent = copy.leaderboardTitle(getModeLabelForLeaderboard(mode, copy));
+        leaderboardPanel.classList.remove('hidden');
+        leaderboardList.innerHTML = '';
+        const loadingItem = document.createElement('li');
+        loadingItem.textContent = copy.loadingLeaderboard;
+        leaderboardList.appendChild(loadingItem);
+        try {
+          const data = await getLeaderboard(getScoreGameKey(), mode, SCORE_TOP_LIMIT);
+          const rows = Array.isArray(data?.rows) ? data.rows : [];
+          leaderboardList.innerHTML = '';
+          if (!rows.length) {
+            const empty = document.createElement('li');
+            empty.textContent = copy.emptyLeaderboard;
+            leaderboardList.appendChild(empty);
+            return;
+          }
+          rows.slice(0, SCORE_TOP_LIMIT).forEach((row, index) => {
+            const item = document.createElement('li');
+            const medal = index === 0 ? '🥇 ' : index === 1 ? '🥈 ' : index === 2 ? '🥉 ' : '';
+            const name = typeof row?.player_name === 'string' && row.player_name.trim() ? row.player_name.trim() : copy.anonymous;
+            const value = Number.isFinite(Number(row?.score)) ? Number(row.score) : 0;
+            item.textContent = `${medal}${name} — ${value}`;
+            leaderboardList.appendChild(item);
+          });
+        } catch (_) {
+          leaderboardList.innerHTML = '';
+          const error = document.createElement('li');
+          error.textContent = copy.leaderboardError;
+          leaderboardList.appendChild(error);
+        }
+      }
+
+      function resetScorePanel() {
+        scoreSubmissionState = 'idle';
+        if (scorePlayerNameInput) {
+          scorePlayerNameInput.disabled = false;
+          scorePlayerNameInput.value = '';
+        }
+        if (scoreSubmitButton) scoreSubmitButton.disabled = false;
+        if (scoreRetryButton) scoreRetryButton.disabled = false;
+        resetScoreEyegazeFills();
+        setScoreStatusMessage('', false);
+        updateScorePanelCopy();
+      }
+
+      async function handleScoreSubmission() {
+        if (scoreSubmissionState === 'sending' || scoreSubmissionState === 'submitted') return;
+        const copy = getScorePanelCopy();
+        const playerName = (scorePlayerNameInput?.value || '').trim();
+        if (!playerName) {
+          setScoreStatusMessage(copy.emptyName, true);
+          scorePlayerNameInput?.focus();
+          return;
+        }
+
+        scoreSubmissionState = 'sending';
+        if (scoreSubmitButton) scoreSubmitButton.disabled = true;
+        if (scoreRetryButton) scoreRetryButton.disabled = true;
+        setScoreStatusMessage(copy.sending, false);
+
+        try {
+          await submitScore(getScoreGameKey(), playerName.slice(0, 20), score, getSelectedModeForScoreboard());
+          scoreSubmissionState = 'submitted';
+          if (scorePlayerNameInput) scorePlayerNameInput.disabled = true;
+          if (scoreRetryButton) scoreRetryButton.disabled = true;
+          setScoreStatusMessage(copy.submitSuccess, false);
+          await renderLeaderboard();
+          setTimeout(() => {
+            if (!running) startGame();
+          }, 900);
+        } catch (_) {
+          scoreSubmissionState = 'idle';
+          if (scoreSubmitButton) scoreSubmitButton.disabled = false;
+          if (scoreRetryButton) scoreRetryButton.disabled = false;
+          setScoreStatusMessage(copy.submitError, true);
+        }
+      }
+
       function getStartingShields() {
         if (difficulty === 'hard') return selectedShip === 'blue' ? 6 : 5;
         if (difficulty === 'competitive') return selectedShip === 'blue' ? 3 : 2;
@@ -2527,11 +2909,18 @@ function findEnemyById(id) {
         if (languageToggleButton) languageToggleButton.style.display = 'none';
         if (retryRafId) cancelAnimationFrame(retryRafId);
         retryRafId = null;
+        if (scoreRafId) cancelAnimationFrame(scoreRafId);
+        scoreRafId = null;
         retryHoverStartAt = 0;
+        registerHoverStartAt = 0;
+        resetScoreEyegazeFills();
         if (retryEyegazeFill) retryEyegazeFill.style.transform = 'scale(0)';
-        if (retryEyegazeTile) retryEyegazeTile.style.display = 'none';
+        if (registerEyegazeFill) registerEyegazeFill.style.transform = 'scale(0)';
+        if (retryEyegazeTiles) retryEyegazeTiles.style.display = 'none';
         if (retryHint) retryHint.textContent = '';
         if (restartButton) restartButton.style.display = 'none';
+        setScoreUiVisible(false);
+        resetScorePanel();
 
         score = 0;
         lives = getStartingShields();
@@ -2593,17 +2982,28 @@ function findEnemyById(id) {
 
         if (retryRafId) cancelAnimationFrame(retryRafId);
         retryRafId = null;
+        if (scoreRafId) cancelAnimationFrame(scoreRafId);
+        scoreRafId = null;
         retryHoverStartAt = 0;
+        registerHoverStartAt = 0;
+        resetScoreEyegazeFills();
         if (retryEyegazeFill) retryEyegazeFill.style.transform = 'scale(0)';
+        if (registerEyegazeFill) registerEyegazeFill.style.transform = 'scale(0)';
         if (restartButton) restartButton.style.display = 'none';
+        resetScorePanel();
+        updateGameOverOptionLabels();
 
         if (inputMode === 'eyegaze') {
+          setScoreUiVisible(false);
           if (retryHint) retryHint.textContent = lang === 'fr' ? 'Réessayer ?' : lang === 'ja' ? 'もう一度？' : 'Try again?';
-          if (retryEyegazeTile) retryEyegazeTile.style.display = 'block';
+          if (retryEyegazeTiles) retryEyegazeTiles.style.display = 'grid';
           startEyegazeRetryMonitor();
         } else {
+          setScoreUiVisible(true);
           if (retryHint) retryHint.textContent = lang === 'fr' ? 'Appuie sur ton switch pour recommencer' : lang === 'ja' ? 'スイッチで再開' : 'Press your switch to retry';
-          if (retryEyegazeTile) retryEyegazeTile.style.display = 'none';
+          if (retryEyegazeTiles) retryEyegazeTiles.style.display = 'none';
+          if (restartButton) restartButton.style.display = 'inline-flex';
+          renderLeaderboard();
         }
 
         gameOverScreen.style.display = 'flex';
@@ -2611,26 +3011,59 @@ function findEnemyById(id) {
         updateGazePointer(gazeX, gazeY);
       }
 
+      function showScoreEntryScreen() {
+        if (!gameOverScreen || gameOverScreen.style.display !== 'flex') return;
+        if (retryRafId) cancelAnimationFrame(retryRafId);
+        retryRafId = null;
+        if (scoreRafId) cancelAnimationFrame(scoreRafId);
+        scoreRafId = null;
+        retryHoverStartAt = 0;
+        registerHoverStartAt = 0;
+        if (retryEyegazeFill) retryEyegazeFill.style.transform = 'scale(0)';
+        if (registerEyegazeFill) registerEyegazeFill.style.transform = 'scale(0)';
+        setScoreUiVisible(true);
+        scorePlayerNameInput?.focus();
+        renderLeaderboard();
+        startEyegazeScoreMonitor();
+      }
+
       function startEyegazeRetryMonitor() {
         if (inputMode !== 'eyegaze') return;
         const loop = () => {
-          if (running || !gameOverScreen || gameOverScreen.style.display !== 'flex') return;
-          const rect = retryEyegazeTile?.getBoundingClientRect();
-          if (!rect) return;
-          const inside = gazeX >= rect.left && gazeX <= rect.right && gazeY >= rect.top && gazeY <= rect.bottom;
+          if (running || !gameOverScreen || gameOverScreen.style.display !== 'flex' || !gameOverMenuVisible) return;
+          const retryRect = retryEyegazeTile?.getBoundingClientRect();
+          const registerRect = registerEyegazeTile?.getBoundingClientRect();
+          if (!retryRect || !registerRect) return;
           const now = performance.now();
-          if (inside) {
+          const insideRetry = gazeX >= retryRect.left && gazeX <= retryRect.right && gazeY >= retryRect.top && gazeY <= retryRect.bottom;
+          const insideRegister = gazeX >= registerRect.left && gazeX <= registerRect.right && gazeY >= registerRect.top && gazeY <= registerRect.bottom;
+
+          if (insideRetry) {
             if (!retryHoverStartAt) retryHoverStartAt = now;
             const progress = Math.max(0, Math.min(1, (now - retryHoverStartAt) / EYEGAZE_DWELL_MS));
             if (retryEyegazeFill) retryEyegazeFill.style.transform = `scale(${progress})`;
+            registerHoverStartAt = 0;
+            if (registerEyegazeFill) registerEyegazeFill.style.transform = 'scale(0)';
             if (progress >= 1) {
               playSfx('retry');
               startGame();
               return;
             }
-          } else {
+          } else if (insideRegister) {
+            if (!registerHoverStartAt) registerHoverStartAt = now;
+            const progress = Math.max(0, Math.min(1, (now - registerHoverStartAt) / EYEGAZE_DWELL_MS));
+            if (registerEyegazeFill) registerEyegazeFill.style.transform = `scale(${progress})`;
             retryHoverStartAt = 0;
             if (retryEyegazeFill) retryEyegazeFill.style.transform = 'scale(0)';
+            if (progress >= 1) {
+              showScoreEntryScreen();
+              return;
+            }
+          } else {
+            retryHoverStartAt = 0;
+            registerHoverStartAt = 0;
+            if (retryEyegazeFill) retryEyegazeFill.style.transform = 'scale(0)';
+            if (registerEyegazeFill) registerEyegazeFill.style.transform = 'scale(0)';
           }
           retryRafId = requestAnimationFrame(loop);
         };
@@ -2688,11 +3121,19 @@ function findEnemyById(id) {
 
         if (event.key === ' ' || event.code === 'Space') {
           event.preventDefault();
+          if (switchIsDown) return;
+          switchIsDown = true;
           if (running && !gameOverPending) shoot();
-          else if (!running && inputMode !== 'eyegaze' && gameOverScreen?.style.display === 'flex') {
+          else if (!running && inputMode !== 'eyegaze' && gameOverScreen?.style.display === 'flex' && gameOverMenuVisible) {
             playSfx('retry');
             startGame();
           }
+        }
+      });
+
+      document.addEventListener('keyup', (event) => {
+        if (event.key === ' ' || event.code === 'Space') {
+          switchIsDown = false;
         }
       });
 
@@ -2730,11 +3171,25 @@ function findEnemyById(id) {
         startGame();
       });
 
+      scoreSubmitButton?.addEventListener('click', handleScoreSubmission);
+      scoreRetryButton?.addEventListener('click', () => {
+        playSfx('retry');
+        startGame();
+      });
+      scorePlayerNameInput?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          handleScoreSubmission();
+        }
+      });
+
       document.getElementById('language-toggle')?.addEventListener('pointerup', () => {
         toggleLanguage();
         updateHudLanguage();
         applyDifficulty(difficulty);
         updateShipPanelLanguage();
+        updateScorePanelCopy();
+        updateGameOverOptionLabels();
       });
 
       Array.from(document.querySelectorAll('.input-mode-btn')).forEach((button) => {
@@ -2774,6 +3229,8 @@ function findEnemyById(id) {
       updateHudLanguage();
       updateShipPanelLanguage();
       updateAmmoMeter();
+      updateScorePanelCopy();
+      updateGameOverOptionLabels();
       refreshStartButtonState();
       drawStars();
       drawPlayer();

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -2816,8 +2816,8 @@ function findEnemyById(id) {
       }
 
       function updateCursorVisibility() {
-        const eyegazeActive = inputMode === 'eyegaze' && (running || gameOverScreen?.style.display === 'flex');
-        document.body.style.cursor = eyegazeActive ? 'none' : '';
+        const inGameplayFlow = running || gameOverScreen?.style.display === 'flex';
+        document.body.style.cursor = inGameplayFlow ? 'none' : '';
       }
 
       function playSfx(type) {


### PR DESCRIPTION
### Motivation
- Extend the game-over flow to support eyegaze input for retry and score registration and to let players submit and view leaderboard scores for different modes.
- Provide localized copy and visual feedback for eyegaze dwell interactions and make the score UI accessible for switch input too.

### Description
- Added new DOM/CSS for eyegaze retry/register tiles and a score registration / leaderboard layout, including eyegaze fills, action button fills, labels and responsive layout changes.
- Implemented score API integration with `SCORE_API_BASE`, functions to `submitScore`, `getLeaderboard`, and `renderLeaderboard`, plus UI copy localization via `getScorePanelCopy` and `updateScorePanelCopy`.
- Added eyegaze monitoring loops: `startEyegazeRetryMonitor` (retry/register) and `startEyegazeScoreMonitor` (submit/retry buttons), plus `showScoreEntryScreen`, `setScoreUiVisible`, and related state/reset helpers to manage transitions and visual fills.
- Wire up event handlers for score submission, retry, input-mode handling, language updates, Enter key submit, and improved spacebar handling (`switchIsDown` and keyup) to avoid repeated triggers.

### Testing
- No automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc180e25f0832596413bdd8d3d3262)