### PR TITLE
Tune eyegaze hard/master ascent and spawn speed

### DIFF
--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -196,12 +196,14 @@
     }
 
     #game-over.switch-score-screen .eyegaze-action-button-wrap {
-      width: min(100%, 140px);
+      width: min(100%, 220px);
+      aspect-ratio: auto;
+      height: 56px;
     }
 
     #game-over.switch-score-screen .eyegaze-action-button-wrap .button {
-      border-radius: 16px;
-      padding: 8px;
+      border-radius: 14px;
+      padding: 8px 14px;
       font-size: 11px;
       line-height: 1.2;
     }

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -799,7 +799,7 @@
       const EYEGAZE_DANGER_HOLD_MS = 4000;
       const EYEGAZE_ATTACK_RISE_SPEED = 220;
       const EYEGAZE_RISE_SPEED_MULTIPLIER = { normal: 1, hard: 1.25, competitive: 1.4 };
-      const EYEGAZE_ROW_STEP_SPEED_MULTIPLIER = { normal: 1, hard: 1, competitive: 1.4 };
+      const EYEGAZE_ROW_STEP_SPEED_MULTIPLIER = { normal: 1, hard: 1.4, competitive: 1.25 };
       const EYEGAZE_ATTACK_SHAKE_MS = 320;
       const EYEGAZE_SHIELD_FLASH_MS = 1350;
       const GAME_OVER_DELAY_MS = 900;
@@ -1326,9 +1326,9 @@ function findEnemyById(id) {
         if (inputMode !== 'eyegaze') return baseDelay;
 
         const spawnSpeedMultiplier = difficulty === 'hard'
-          ? 1.25
+          ? 1.4
           : difficulty === 'competitive'
-            ? 1.4
+            ? 1.25
             : 1;
         return baseDelay / spawnSpeedMultiplier;
       }

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -799,7 +799,7 @@
       const EYEGAZE_DANGER_HOLD_MS = 4000;
       const EYEGAZE_ATTACK_RISE_SPEED = 220;
       const EYEGAZE_RISE_SPEED_MULTIPLIER = { normal: 1, hard: 1.25, competitive: 1.4 };
-      const EYEGAZE_ROW_STEP_SPEED_MULTIPLIER = { normal: 1, hard: 1.4, competitive: 1.25 };
+      const EYEGAZE_ROW_STEP_SPEED_MULTIPLIER = { normal: 1, hard: 1.4, competitive: 1.5625 };
       const EYEGAZE_ATTACK_SHAKE_MS = 320;
       const EYEGAZE_SHIELD_FLASH_MS = 1350;
       const GAME_OVER_DELAY_MS = 900;
@@ -1328,7 +1328,7 @@ function findEnemyById(id) {
         const spawnSpeedMultiplier = difficulty === 'hard'
           ? 1.4
           : difficulty === 'competitive'
-            ? 1.25
+            ? 1.5625
             : 1;
         return baseDelay / spawnSpeedMultiplier;
       }

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -195,6 +195,21 @@
       z-index: 2;
     }
 
+    #game-over.switch-score-screen .eyegaze-action-button-wrap {
+      width: min(100%, 140px);
+    }
+
+    #game-over.switch-score-screen .eyegaze-action-button-wrap .button {
+      border-radius: 16px;
+      padding: 8px;
+      font-size: 11px;
+      line-height: 1.2;
+    }
+
+    #game-over.switch-score-screen .eyegaze-action-fill {
+      border-radius: 16px;
+    }
+
     #continue-button {
       width: min(100%, 280px);
       margin: 10px auto 0;
@@ -782,6 +797,7 @@
       const EYEGAZE_DANGER_HOLD_MS = 4000;
       const EYEGAZE_ATTACK_RISE_SPEED = 220;
       const EYEGAZE_RISE_SPEED_MULTIPLIER = { normal: 1, hard: 1.25, competitive: 1.4 };
+      const EYEGAZE_ROW_STEP_SPEED_MULTIPLIER = { normal: 1, hard: 1, competitive: 1.4 };
       const EYEGAZE_ATTACK_SHAKE_MS = 320;
       const EYEGAZE_SHIELD_FLASH_MS = 1350;
       const GAME_OVER_DELAY_MS = 900;
@@ -1618,17 +1634,23 @@ function findEnemyById(id) {
         return lanes.filter((lane) => !occupied.has(lane));
       }
 
+      function getEyegazeRowStepMs() {
+        const speedMultiplier = EYEGAZE_ROW_STEP_SPEED_MULTIPLIER[difficulty] || 1;
+        return EYEGAZE_ROW_STEP_MS / speedMultiplier;
+      }
+
       function getEyegazeAnimatedY(elapsedMs) {
         const top = getEyegazeRowY(0);
         const second = getEyegazeRowY(1);
+        const rowStepMs = getEyegazeRowStepMs();
         const isNormalGrid = difficulty === 'normal';
 
         if (isNormalGrid) {
-          const bottomStartMs = EYEGAZE_ROW_STEP_MS + EYEGAZE_ROW_TRANSITION_MS;
+          const bottomStartMs = rowStepMs + EYEGAZE_ROW_TRANSITION_MS;
           const bottomEndMs = bottomStartMs + EYEGAZE_DANGER_HOLD_MS;
-          if (elapsedMs < EYEGAZE_ROW_STEP_MS) return top;
-          if (elapsedMs < EYEGAZE_ROW_STEP_MS + EYEGAZE_ROW_TRANSITION_MS) {
-            const t = (elapsedMs - EYEGAZE_ROW_STEP_MS) / EYEGAZE_ROW_TRANSITION_MS;
+          if (elapsedMs < rowStepMs) return top;
+          if (elapsedMs < rowStepMs + EYEGAZE_ROW_TRANSITION_MS) {
+            const t = (elapsedMs - rowStepMs) / EYEGAZE_ROW_TRANSITION_MS;
             return top + (second - top) * t;
           }
           if (elapsedMs < bottomEndMs) return second;
@@ -1637,17 +1659,17 @@ function findEnemyById(id) {
 
         const middle = second;
         const bottom = getEyegazeRowY(2);
-        const bottomStartMs = EYEGAZE_ROW_STEP_MS * 2 + EYEGAZE_ROW_TRANSITION_MS;
+        const bottomStartMs = rowStepMs * 2 + EYEGAZE_ROW_TRANSITION_MS;
         const bottomEndMs = bottomStartMs + EYEGAZE_DANGER_HOLD_MS;
 
-        if (elapsedMs < EYEGAZE_ROW_STEP_MS) return top;
-        if (elapsedMs < EYEGAZE_ROW_STEP_MS + EYEGAZE_ROW_TRANSITION_MS) {
-          const t = (elapsedMs - EYEGAZE_ROW_STEP_MS) / EYEGAZE_ROW_TRANSITION_MS;
+        if (elapsedMs < rowStepMs) return top;
+        if (elapsedMs < rowStepMs + EYEGAZE_ROW_TRANSITION_MS) {
+          const t = (elapsedMs - rowStepMs) / EYEGAZE_ROW_TRANSITION_MS;
           return top + (middle - top) * t;
         }
-        if (elapsedMs < EYEGAZE_ROW_STEP_MS * 2) return middle;
-        if (elapsedMs < EYEGAZE_ROW_STEP_MS * 2 + EYEGAZE_ROW_TRANSITION_MS) {
-          const t = (elapsedMs - EYEGAZE_ROW_STEP_MS * 2) / EYEGAZE_ROW_TRANSITION_MS;
+        if (elapsedMs < rowStepMs * 2) return middle;
+        if (elapsedMs < rowStepMs * 2 + EYEGAZE_ROW_TRANSITION_MS) {
+          const t = (elapsedMs - rowStepMs * 2) / EYEGAZE_ROW_TRANSITION_MS;
           return middle + (bottom - middle) * t;
         }
         if (elapsedMs < bottomEndMs) return bottom;
@@ -2676,6 +2698,7 @@ function findEnemyById(id) {
       function setScoreUiVisible(showScorePanel) {
         const show = Boolean(showScorePanel);
         gameOverMenuVisible = inputMode === 'switch' ? true : !show;
+        gameOverScreen?.classList.toggle('switch-score-screen', show && inputMode === 'switch');
         if (scoreUiLayout) scoreUiLayout.style.display = show ? 'grid' : 'none';
         if (scoreRegisterPanel) {
           scoreRegisterPanel.classList.toggle('hidden', !show);
@@ -2828,7 +2851,15 @@ function findEnemyById(id) {
         return (difficulty === 'hard' || difficulty === 'competitive') && inputMode !== 'eyegaze';
       }
 
+      function isSwitchScoreScreenVisible() {
+        return inputMode === 'switch' && gameOverScreen?.classList.contains('switch-score-screen');
+      }
+
       function updateCursorVisibility() {
+        if (isSwitchScoreScreenVisible()) {
+          document.body.style.cursor = '';
+          return;
+        }
         const inGameplayFlow = running || gameOverScreen?.style.display === 'flex';
         document.body.style.cursor = inGameplayFlow ? 'none' : '';
       }

--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -781,6 +781,7 @@
       const EYEGAZE_ROW_GAP_PX = 24;
       const EYEGAZE_DANGER_HOLD_MS = 4000;
       const EYEGAZE_ATTACK_RISE_SPEED = 220;
+      const EYEGAZE_RISE_SPEED_MULTIPLIER = { normal: 1, hard: 1.25, competitive: 1.4 };
       const EYEGAZE_ATTACK_SHAKE_MS = 320;
       const EYEGAZE_SHIELD_FLASH_MS = 1350;
       const GAME_OVER_DELAY_MS = 900;
@@ -1298,9 +1299,20 @@ function findEnemyById(id) {
       }
 
       function getSpawnDelayMs() {
-        if (difficulty === 'hard') return 5000 + Math.random() * 3000;
-        if (difficulty === 'competitive') return 3000 + Math.random() * 1000;
-        return 10000;
+        const baseDelay = difficulty === 'hard'
+          ? 5000 + Math.random() * 3000
+          : difficulty === 'competitive'
+            ? 3000 + Math.random() * 1000
+            : 10000;
+
+        if (inputMode !== 'eyegaze') return baseDelay;
+
+        const spawnSpeedMultiplier = difficulty === 'hard'
+          ? 1.25
+          : difficulty === 'competitive'
+            ? 1.4
+            : 1;
+        return baseDelay / spawnSpeedMultiplier;
       }
 
       function shoot() {
@@ -1435,7 +1447,8 @@ function findEnemyById(id) {
               const now = performance.now();
               if (e.attackState === 'ascending') {
                 const dangerY = getDangerLineY();
-                e.y += EYEGAZE_ATTACK_RISE_SPEED * dt;
+                const riseMultiplier = EYEGAZE_RISE_SPEED_MULTIPLIER[difficulty] || 1;
+                e.y += EYEGAZE_ATTACK_RISE_SPEED * riseMultiplier * dt;
                 const bottomEdge = e.y + e.size * 0.5;
                 if (bottomEdge >= dangerY) {
                   e.attackState = 'shaking';


### PR DESCRIPTION
### Motivation
- Make the eye-gaze control harder by increasing the ascent speed of eyegaze enemies and increasing spawn frequency for Hard and Master (competitive) difficulties, using the requested +25% for Hard and +40% for Master.
- Apply the changes only for `eyegaze` input mode so non-eyegaze gameplay remains unchanged.

### Description
- Added `EYEGAZE_RISE_SPEED_MULTIPLIER = { normal: 1, hard: 1.25, competitive: 1.4 }` and used it to scale ascent speed during eyegaze enemy `ascending` state by multiplying `EYEGAZE_ATTACK_RISE_SPEED` with the per-difficulty multiplier.
- Reworked `getSpawnDelayMs()` to compute a `baseDelay` and, when `inputMode === 'eyegaze'`, reduce that delay by a `spawnSpeedMultiplier` (`1.25` for `hard`, `1.4` for `competitive`) so spawn speed increases proportionally for eyegaze mode.
- Changes are localized to `arcade/space-invaders-fruits/index.html` and preserve existing behavior for non-eyegaze input modes.

### Testing
- Performed static code inspection with `rg` to locate eyegaze constants and confirm the new `EYEGAZE_RISE_SPEED_MULTIPLIER` and updated `getSpawnDelayMs` logic were present; the searches completed successfully.
- Printed the edited file regions with `sed` to validate the inserted lines where ascent and spawn-delay logic are applied; the file excerpts showed the expected replacements.
- No runtime or unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2d532f288325b6fa558bb16bcb7f)