### PR TITLE
Increase Space Invaders normal-mode eyegaze enemy tile size by 30%

### DIFF
--- a/arcade/space-invaders-fruits/index.html
+++ b/arcade/space-invaders-fruits/index.html
@@ -1612,7 +1612,8 @@ function findEnemyById(id) {
         const byWidth = canvas.width * (cols === 2 ? 0.44 : 0.34);
         const fieldHeight = canvas.height * 0.62;
         const byHeight = (fieldHeight - EYEGAZE_ROW_GAP_PX * (rows - 1)) / rows;
-        return Math.max(110, Math.min(byWidth, byHeight));
+        const baseSize = Math.max(110, Math.min(byWidth, byHeight));
+        return difficulty === 'normal' ? baseSize * 1.3 : baseSize;
       }
 
       function getEyegazeIntroDurationMs(tileSize) {


### PR DESCRIPTION
### Motivation
- Make enemy tiles larger in the Space Invaders-style arcade game when playing in normal difficulty to improve visibility and usability for eyegaze input by increasing tile size by 30%.

### Description
- Updated `getEyegazeTileSize()` in `arcade/space-invaders-fruits/index.html` to compute a `baseSize` from the existing layout constraints and return `baseSize * 1.3` when `difficulty === 'normal'` while returning `baseSize` for other difficulties.
- The prior bounds (`Math.max(110, Math.min(byWidth, byHeight))`) are preserved and only eyegaze tile sizing for normal difficulty is affected.

### Testing
- Ran a quick static verification with `git diff -- arcade/space-invaders-fruits/index.html` and inspected the modified lines with `nl -ba arcade/space-invaders-fruits/index.html | sed -n '1606,1622p'`, which showed the intended change and succeeded.
- No automated unit or browser-rendering tests were available for this single-file UI tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd69ed15448325aa6a12248256cd7a)