### PR TITLE
Add prerecorded songs mode and synchronized punk-rock preset

### DIFF
--- a/css/eyegaze-music-maker.css
+++ b/css/eyegaze-music-maker.css
@@ -1,0 +1,186 @@
+#tile-container.music-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--music-columns, 3), minmax(180px, 1fr));
+  gap: 32px;
+  width: min(1200px, 90vw);
+  margin: 0 auto;
+  padding: 24px;
+  box-sizing: border-box;
+  align-items: center;
+  justify-items: center;
+}
+
+#tile-container.music-grid .tile {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 3px solid #ffffff;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#tile-container.music-grid .tile.playing {
+  border-color: #00e676;
+  box-shadow: 0 0 18px rgba(0, 230, 118, 0.5);
+  transform: scale(1.03);
+  animation: musicPulse 1.4s ease-in-out infinite;
+  animation-delay: calc(var(--pulse-phase, 0ms) * -1);
+}
+
+#tile-container.music-grid .tile .caption {
+  font-size: 18px;
+  font-weight: bold;
+}
+
+@keyframes musicPulse {
+  0%, 100% {
+    transform: scale(1.03);
+    box-shadow: 0 0 18px rgba(0, 230, 118, 0.5);
+  }
+  50% {
+    transform: scale(1.06);
+    box-shadow: 0 0 26px rgba(0, 230, 118, 0.9);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #tile-container.music-grid .tile.playing {
+    animation: none;
+  }
+}
+
+#tile-container.music-grid .music-line {
+  position: fixed;
+  left: 12px;
+  right: 12px;
+  bottom: 0;
+  height: 80px;
+  padding: 8px 12px 16px;
+  box-sizing: border-box;
+  z-index: 4;
+  pointer-events: none;
+}
+
+#tile-container.music-grid .music-line-track {
+  position: relative;
+  height: 100%;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+#tile-container.music-grid .music-line-bars {
+  position: absolute;
+  inset: 12px 20px;
+  display: grid;
+  grid-template-columns: repeat(32, 1fr);
+  gap: 6px;
+  align-items: end;
+}
+
+#tile-container.music-grid .music-line-bar {
+  width: 100%;
+  height: 20%;
+  border-radius: 6px 6px 2px 2px;
+  background-color: #22c55e;
+  box-shadow: 0 0 10px rgba(34, 197, 94, 0.5);
+  transition: height 0.12s ease-out;
+}
+
+#tile-container.music-grid .stop-all-tile {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 110px;
+  height: 110px;
+  border-radius: 16px;
+  border: 3px solid #ff5252;
+  background: rgba(255, 82, 82, 0.2);
+  color: #ff5252;
+  font-size: 48px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 5;
+}
+
+#tile-container.music-grid .stop-all-tile:hover {
+  background: rgba(255, 82, 82, 0.35);
+}
+
+#preset-picker {
+  width: 100%;
+  margin: 10px 0 20px;
+}
+
+#preset-picker .preset-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #111;
+  margin-bottom: 10px;
+}
+
+#preset-picker-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+}
+
+.preset-tile {
+  width: 180px;
+  height: 180px;
+  border-radius: 12px;
+  border: 2px solid #009688;
+  background-size: cover;
+  background-position: center;
+  background-color: #f0fdfa;
+  cursor: pointer;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 6px;
+}
+
+.preset-tile:hover {
+  border-color: #00796b;
+}
+
+.button-orange {
+  background-color: #ff9800;
+}
+
+.button-orange:hover {
+  background-color: #f57c00;
+}
+
+.preset-caption {
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 4px 6px;
+  border-radius: 6px;
+}
+
+@media (max-width: 900px) {
+  #tile-container.music-grid {
+    grid-template-columns: repeat(var(--music-columns, 2), minmax(140px, 1fr));
+    gap: 20px;
+  }
+
+  #tile-container.music-grid .stop-all-tile {
+    width: 90px;
+    height: 90px;
+    font-size: 40px;
+  }
+}
+
+@media (max-width: 600px) {
+  #tile-container.music-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/eyegaze/index.html
+++ b/eyegaze/index.html
@@ -126,6 +126,14 @@
       </a>
     </div>
     <div class="tile">
+      <a href="music-maker/index.html">
+        <img src="../images/notes-musicales.png" alt="Music maker">
+        <div class="tile-title">
+          <h3 data-fr="Créateur musical" data-en="Music Maker" data-ja="音楽メーカー">Créateur musical</h3>
+        </div>
+      </a>
+    </div>
+    <div class="tile">
       <a href="paint/index.html">
         <img src="../images/ocularart.png" alt="Art">
         <div class="tile-title">

--- a/eyegaze/music-maker/index.html
+++ b/eyegaze/music-maker/index.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title class="translate" data-fr="Créateur musical" data-en="Music Maker" data-ja="音楽メーカー">Music Maker</title>
+  <link rel="stylesheet" href="../../css/choiceeyegaze.css" />
+  <link rel="stylesheet" href="../../css/eyegaze-music-maker.css" />
+  <style>
+    #language-toggle {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      z-index: 99999;
+      padding: 6px 10px;
+      border-radius: 10px;
+      border: 2px solid #009688;
+      background: #fff;
+      color: #009688;
+      font-weight: 700;
+      cursor: pointer;
+      user-select: none;
+    }
+  </style>
+</head>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-B45TJG4GBJ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);} 
+  gtag('js', new Date());
+  gtag('config', 'G-B45TJG4GBJ');
+</script>
+<body>
+  <button id="language-toggle" title="Changer de langue / Change language">FR / EN</button>
+  <div id="game-options" class="modal" style="display: flex;">
+    <div id="control-panel-options">
+      <div id="options-title-bar">
+        <h2 id="options-main-title" class="translate"
+          data-fr="Expérience musicale pour contrôle oculaire"
+          data-en="Eyegaze Music Experience"
+          data-ja="視線入力の音楽体験">
+          Expérience musicale
+        </h2>
+      </div>
+
+      <div id="mode-divider"></div>
+
+      <div id="options-inline-container">
+        <div id="advanced-options-section">
+          <div class="advanced-options-container">
+            <div class="option-item">
+              <label for="background-color" class="teal-label">
+                <span class="translate" data-fr="Couleur de fond:" data-en="Background color:" data-ja="背景色：">Couleur de fond:</span>
+              </label>
+              <select id="background-color" class="styled-select">
+                <option value="#000000" selected>Black</option>
+                <option value="#0f172a">Navy</option>
+                <option value="#1b4332">Forest</option>
+                <option value="#4c1d95">Purple</option>
+                <option value="#7f1d1d">Burgundy</option>
+                <option value="#111827">Charcoal</option>
+              </select>
+            </div>
+            <div class="option-item">
+              <label for="music-volume" class="teal-label">
+                <span class="translate" data-fr="Volume:" data-en="Volume:" data-ja="音量：">Volume:</span>
+                <span id="music-volume-value" class="slider-value no-lang">60</span>
+              </label>
+              <input type="range" id="music-volume" min="0" max="100" value="60" class="styled-slider" />
+            </div>
+            <div class="option-item">
+              <label for="enable-stop-all" class="teal-label">
+                <input type="checkbox" id="enable-stop-all" />
+                <span class="translate" data-fr="Bouton arrêter tout" data-en="Stop all button" data-ja="すべて停止ボタン">Bouton arrêter tout</span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div id="game-options-controls">
+          <div class="option-item" id="tile-slider-container">
+            <label for="tile-count" class="control-label">
+              <span class="translate" data-fr="Nombre d'instruments:" data-en="Number of instruments:" data-ja="楽器の数：">Nombre d'instruments:</span>
+              <span id="tile-count-value" class="slider-value no-lang">3</span>
+            </label>
+            <input type="range" id="tile-count" min="1" max="6" value="3" class="styled-slider" />
+          </div>
+        </div>
+
+        <div id="sliders-column">
+          <div class="option-item">
+            <label for="fixation-time" class="teal-label">
+              <span class="translate" data-fr="Temps de fixation:" data-en="Fixation Time:" data-ja="注視時間：">Temps de fixation:</span>
+              <span id="fixation-time-value" class="no-lang">2000</span> ms
+            </label>
+            <input type="range" id="fixation-time" min="500" max="5000" step="100" value="2000" class="styled-slider" />
+          </div>
+
+          <div class="option-item gp-compact">
+            <label class="teal-label">
+              <input type="checkbox" id="showGazePointer" checked />
+              <span class="translate"
+                data-fr="Afficher le pointeur (cache la souris)"
+                data-en="Show gaze pointer (hide mouse)"
+                data-ja="視線ポインターを表示（マウスを非表示）">
+                Afficher le pointeur (cache la souris)
+              </span>
+            </label>
+
+            <details id="gpDetails">
+              <summary class="gp-summary">
+                <span class="translate" data-fr="Options avancées du pointeur" data-en="Pointer advanced options" data-ja="ポインターの詳細設定">
+                  Options avancées du pointeur
+                </span>
+              </summary>
+              <div class="gp-advanced">
+                <div class="gp-row">
+                  <label for="gazeSize" class="teal-label gp-label">
+                    <span class="translate" data-fr="Taille" data-en="Size" data-ja="サイズ">Taille</span>:
+                    <span id="gazeSizeVal">36</span> px
+                  </label>
+                  <input type="range" id="gazeSize" class="styled-slider gp-range" min="16" max="100" step="2" value="36" />
+                </div>
+                <div class="gp-row">
+                  <label for="gazeOpacity" class="teal-label gp-label">
+                    <span class="translate" data-fr="Opacité" data-en="Opacity" data-ja="不透明度">Opacité</span>:
+                    <span id="gazeOpacityVal">100</span>%
+                  </label>
+                  <input type="range" id="gazeOpacity" class="styled-slider gp-range" min="20" max="100" step="5" value="100" />
+                </div>
+              </div>
+            </details>
+          </div>
+        </div>
+      </div>
+
+      <div id="mode-divider"></div>
+
+      <div class="actions-row">
+        <button id="choose-tiles-button" class="button translate" data-fr="Choix des instruments" data-en="Choose instruments" data-ja="楽器を選ぶ">
+          Choix des instruments
+        </button>
+        <button id="choose-presets-button" class="button button-orange translate" data-fr="Musiques préenregistrées" data-en="Prerecorded songs" data-ja="録音済みの曲">
+          Musiques préenregistrées
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div id="tile-picker-modal" class="modal" style="display: none;">
+    <div id="control-panel-options">
+      <div id="control-panel-title-wrapper">
+        <h2 id="control-panel-title" class="translate" data-fr="Choisir les instruments" data-en="Choose instruments" data-ja="楽器を選択">
+          Choisir les instruments
+        </h2>
+      </div>
+      <div id="control-panel-instructions" style="margin-top:10px;">
+        <span class="translate" data-fr="Choisir" data-en="Choose" data-ja="選ぶ">Choisir</span>
+        <span id="tile-count-display" class="no-lang"></span>
+        <span class="translate" data-fr="instruments." data-en="instruments." data-ja="楽器。"> instruments.</span>
+      </div>
+      <div id="preset-picker">
+        <div class="preset-title translate" data-fr="Présélections" data-en="Presets" data-ja="プリセット">Présélections</div>
+        <div id="preset-picker-grid"></div>
+      </div>
+      <div id="tile-picker-grid"></div>
+      <button id="start-game-button" class="button translate" data-fr="Commencer" data-en="Start" data-ja="開始" disabled>
+        Commencer
+      </button>
+    </div>
+  </div>
+
+  <div id="tile-container" style="display: none;"></div>
+
+  <div id="gazePointerOverlay" aria-hidden="true">
+    <div id="gazePointer"></div>
+  </div>
+
+  <script src="../../js/eyegazeMusicMaker.js"></script>
+  <script src="../../js/translationmain.js"></script>
+  <script>
+    document.getElementById('language-toggle')?.addEventListener('pointerup', toggleLanguage);
+  </script>
+</body>
+</html>

--- a/js/eyegazeMusicMaker.js
+++ b/js/eyegazeMusicMaker.js
@@ -1,0 +1,532 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const gameOptionsModal = document.getElementById('game-options');
+  const tilePickerModal = document.getElementById('tile-picker-modal');
+  const tilePickerGrid = document.getElementById('tile-picker-grid');
+  const presetPickerGrid = document.getElementById('preset-picker-grid');
+  const tileContainer = document.getElementById('tile-container');
+  const chooseTilesButton = document.getElementById('choose-tiles-button');
+  const choosePresetsButton = document.getElementById('choose-presets-button');
+  const startGameButton = document.getElementById('start-game-button');
+  const pickerInstructions = document.getElementById('control-panel-instructions');
+  const tileCountInput = document.getElementById('tile-count');
+  const tileCountValueSpan = document.getElementById('tile-count-value');
+  const tileCountDisplay = document.getElementById('tile-count-display');
+  const volumeInput = document.getElementById('music-volume');
+  const volumeValue = document.getElementById('music-volume-value');
+  const stopAllToggle = document.getElementById('enable-stop-all');
+  const backgroundSelect = document.getElementById('background-color');
+  const fixationTimeInput = document.getElementById('fixation-time');
+  const fixationTimeValue = document.getElementById('fixation-time-value');
+  const showGazePointer = document.getElementById('showGazePointer');
+  const gazeSize = document.getElementById('gazeSize');
+  const gazeSizeVal = document.getElementById('gazeSizeVal');
+  const gazeOpacity = document.getElementById('gazeOpacity');
+  const gazeOpacityVal = document.getElementById('gazeOpacityVal');
+  const gazePointer = document.getElementById('gazePointer');
+  const languageToggle = document.getElementById('language-toggle');
+
+  const instruments = [
+    { id: 'drum', label: 'Drum', image: '../../images/pictos/balloon.png', sound: '../../sounds/beatles.mp3', color: '#ef4444' },
+    { id: 'bell', label: 'Bell', image: '../../images/pictos/apple.png', sound: '../../sounds/beatles.mp3', color: '#f59e0b' },
+    { id: 'piano', label: 'Piano', image: '../../images/pictos/avocado.png', sound: '../../sounds/beatles.mp3', color: '#10b981' },
+    { id: 'guitar', label: 'Guitar', image: '../../images/pictos/banana.png', sound: '../../sounds/beatles.mp3', color: '#3b82f6' },
+    { id: 'marimba', label: 'Marimba', image: '../../images/pictos/almond.png', sound: '../../sounds/beatles.mp3', color: '#8b5cf6' },
+    { id: 'synth', label: 'Synth', image: '../../images/pictos/assistivebike.png', sound: '../../sounds/beatles.mp3', color: '#ec4899' },
+    { id: 'flute', label: 'Flute', image: '../../images/pictos/assistiveswitches.png', sound: '../../sounds/beatles.mp3', color: '#22c55e' },
+    { id: 'bass', label: 'Bass', image: '../../images/pictos/angry.png', sound: '../../sounds/beatles.mp3', color: '#0ea5e9' },
+    { id: 'pad', label: 'Pad', image: '../../images/pictos/OSD.png', sound: '../../sounds/beatles.mp3', color: '#eab308' },
+    { id: 'vocals', label: 'Vocals', image: '../../images/pictos/OSD.png', sound: '../../sounds/beatles.mp3', color: '#f97316' }
+  ];
+  const presets = [
+    {
+      id: 'percussion',
+      label: 'Percussions',
+      image: '../../images/pictos/assistiveswitches.png',
+      instrumentIds: ['drum', 'marimba', 'bell'],
+      mode: 'instrument',
+    },
+    {
+      id: 'rock',
+      label: 'Rock band',
+      image: '../../images/pictos/assistivebike.png',
+      instrumentIds: ['drum', 'guitar', 'bass'],
+      mode: 'instrument',
+    },
+    {
+      id: 'ambient',
+      label: 'Ambient',
+      image: '../../images/pictos/OSD.png',
+      instrumentIds: ['pad', 'synth', 'flute'],
+      mode: 'instrument',
+    },
+    {
+      id: 'punk-rock',
+      label: 'Punk rock',
+      image: '../../images/pictos/balloon.png',
+      instrumentIds: ['drum', 'guitar', 'bass', 'vocals'],
+      mode: 'song',
+      tracks: {
+        drum: '../../sounds/beatles.mp3',
+        guitar: '../../sounds/arthur.mp3',
+        bass: '../../sounds/africaflute.mp3',
+        vocals: '../../sounds/belleetbete.mp3',
+      },
+    },
+  ];
+
+  let desiredTileCount = parseInt(tileCountInput.value, 10) || 3;
+  let fixationDelay = parseInt(fixationTimeInput.value, 10) || 2000;
+  let currentVolume = parseInt(volumeInput.value, 10) || 60;
+  let selectedIds = [];
+  let audioMap = new Map();
+  let tileMap = new Map();
+  let inGame = false;
+  let musicLine = null;
+  let equalizerBars = [];
+  let equalizerTimer = null;
+  let activeInstrumentIds = new Set();
+  let pickerMode = 'instrument';
+  let currentPreset = null;
+  let isSongMode = false;
+
+  function getInstrumentSound(instrument) {
+    if (currentPreset?.tracks?.[instrument.id]) {
+      return currentPreset.tracks[instrument.id];
+    }
+    return instrument.sound;
+  }
+
+  function startGame() {
+    tilePickerModal.style.display = 'none';
+    tileContainer.style.display = 'grid';
+    requestFullscreen();
+    inGame = true;
+    if (languageToggle) {
+      languageToggle.style.display = 'none';
+    }
+    buildGameTiles();
+    updatePointerStyle();
+  }
+
+  function updateVolumeDisplay() {
+    volumeValue.textContent = currentVolume;
+  }
+
+  function updateTileCountDisplay() {
+    tileCountValueSpan.textContent = desiredTileCount;
+    tileCountDisplay.textContent = desiredTileCount;
+  }
+
+  function updateFixationDisplay() {
+    fixationTimeValue.textContent = fixationDelay;
+    document.documentElement.style.setProperty('--hover-duration', `${fixationDelay}ms`);
+  }
+
+  function ensurePointerOverlay() {
+    if (!gazePointer) return;
+    const overlay = document.getElementById('gazePointerOverlay');
+    if (overlay && gazePointer.parentElement !== overlay) {
+      overlay.appendChild(gazePointer);
+    }
+  }
+
+  function updatePointerStyle() {
+    if (!gazePointer) return;
+    const size = parseInt(gazeSize.value, 10) || 36;
+    const opacity = parseInt(gazeOpacity.value, 10) || 100;
+    gazeSizeVal.textContent = size;
+    gazeOpacityVal.textContent = opacity;
+    gazePointer.style.setProperty('--gp-size', `${size}px`);
+    const pointerVisible = inGame && showGazePointer.checked;
+    gazePointer.style.opacity = pointerVisible ? opacity / 100 : 0;
+    document.body.classList.toggle('hide-native-cursor', pointerVisible);
+    if (!pointerVisible) {
+      gazePointer.classList.remove('gp-dwell');
+    }
+  }
+
+  function updateAudioVolume() {
+    audioMap.forEach(audio => {
+      audio.volume = currentVolume / 100;
+    });
+  }
+
+  function updateBackground() {
+    if (!backgroundSelect) return;
+    document.body.style.backgroundColor = backgroundSelect.value;
+  }
+
+  function trimSelections() {
+    if (selectedIds.length <= desiredTileCount) return;
+    selectedIds = selectedIds.slice(0, desiredTileCount);
+  }
+
+  function renderPicker() {
+    tilePickerGrid.innerHTML = '';
+    instruments.forEach(instrument => {
+      const tile = document.createElement('div');
+      tile.className = 'tile';
+      tile.style.backgroundImage = `url(${instrument.image})`;
+      tile.dataset.id = instrument.id;
+
+      const caption = document.createElement('span');
+      caption.className = 'caption';
+      caption.textContent = instrument.label;
+      tile.appendChild(caption);
+
+      if (selectedIds.includes(instrument.id)) {
+        tile.classList.add('selected');
+      }
+
+      tile.addEventListener('click', () => {
+        if (selectedIds.includes(instrument.id)) {
+          selectedIds = selectedIds.filter(id => id !== instrument.id);
+        } else if (selectedIds.length < desiredTileCount) {
+          selectedIds.push(instrument.id);
+        }
+        renderPicker();
+        updateStartState();
+      });
+
+      tilePickerGrid.appendChild(tile);
+    });
+  }
+
+  function applyPreset(preset) {
+    if (!preset) return;
+    currentPreset = preset;
+    isSongMode = preset.mode === 'song';
+    desiredTileCount = preset.instrumentIds.length;
+    tileCountInput.value = desiredTileCount;
+    selectedIds = [...preset.instrumentIds];
+    updateTileCountDisplay();
+    renderPicker();
+    updateStartState();
+  }
+
+  function renderPresets() {
+    if (!presetPickerGrid) return;
+    presetPickerGrid.innerHTML = '';
+    const filteredPresets = presets.filter(preset => (
+      pickerMode === 'preset' ? preset.mode === 'song' : preset.mode !== 'song'
+    ));
+    filteredPresets.forEach(preset => {
+      const tile = document.createElement('button');
+      tile.type = 'button';
+      tile.className = 'preset-tile';
+      tile.style.backgroundImage = `url(${preset.image})`;
+      tile.setAttribute('aria-label', preset.label);
+
+      const caption = document.createElement('span');
+      caption.className = 'preset-caption';
+      caption.textContent = preset.label;
+      tile.appendChild(caption);
+
+      tile.addEventListener('click', () => {
+        applyPreset(preset);
+        if (pickerMode === 'preset') {
+          startGame();
+        }
+      });
+
+      presetPickerGrid.appendChild(tile);
+    });
+  }
+
+  function updateStartState() {
+    const ready = selectedIds.length === desiredTileCount;
+    startGameButton.disabled = !ready;
+  }
+
+  function requestFullscreen() {
+    const element = document.documentElement;
+    if (element.requestFullscreen) {
+      element.requestFullscreen();
+    } else if (element.webkitRequestFullscreen) {
+      element.webkitRequestFullscreen();
+    } else if (element.msRequestFullscreen) {
+      element.msRequestFullscreen();
+    }
+  }
+
+  function toggleInstrument(tile, instrument) {
+    const audio = audioMap.get(instrument.id);
+    if (!audio) return;
+
+    if (audio.paused) {
+      audio.currentTime = 0;
+      if (isSongMode) {
+        audio.volume = 1;
+        if (audio.paused) {
+          const playPromise = audio.play();
+          if (playPromise && typeof playPromise.catch === 'function') {
+            playPromise.catch(() => {});
+          }
+        }
+      } else {
+        audio.play();
+      }
+      tile.classList.add('playing');
+      activeInstrumentIds.add(instrument.id);
+      updateEqualizerState();
+    } else {
+      if (isSongMode) {
+        audio.volume = 0;
+      } else {
+        audio.pause();
+        audio.currentTime = 0;
+      }
+      tile.classList.remove('playing');
+      activeInstrumentIds.delete(instrument.id);
+      updateEqualizerState();
+    }
+  }
+
+  function updateEqualizerState() {
+    if (activeInstrumentIds.size > 0) {
+      startEqualizer();
+    } else {
+      stopEqualizer();
+      setEqualizerBars(0.15);
+    }
+  }
+
+  function stopAllSounds() {
+    audioMap.forEach(audio => {
+      if (isSongMode) {
+        audio.volume = 0;
+      } else {
+        audio.pause();
+        audio.currentTime = 0;
+      }
+    });
+    tileMap.forEach(tile => {
+      tile.classList.remove('playing');
+    });
+    activeInstrumentIds.clear();
+    updateEqualizerState();
+  }
+
+  function setEqualizerBars(level = 0.2) {
+    const clamped = Math.max(0, Math.min(1, level));
+    equalizerBars.forEach(bar => {
+      const height = (20 + clamped * 80) * (0.7 + Math.random() * 0.6);
+      bar.style.height = `${Math.min(height, 100)}%`;
+      const normalized = Math.min(height / 100, 1);
+      const hue = 120 - 120 * normalized;
+      const lightness = 40 + 20 * (1 - normalized);
+      bar.style.backgroundColor = `hsl(${hue} 85% ${lightness}%)`;
+      bar.style.boxShadow = `0 0 10px hsl(${hue} 85% 55% / 0.65)`;
+    });
+  }
+
+  function startEqualizer() {
+    if (equalizerTimer) return;
+    equalizerTimer = window.setInterval(() => {
+      const total = Math.max(1, tileMap.size);
+      const ratio = Math.min(1, activeInstrumentIds.size / total);
+      const baseLevel = 0.15 + ratio * 0.75;
+      setEqualizerBars(baseLevel);
+    }, 140);
+  }
+
+  function stopEqualizer() {
+    if (equalizerTimer) {
+      window.clearInterval(equalizerTimer);
+      equalizerTimer = null;
+    }
+  }
+
+  function startSongPlayback() {
+    audioMap.forEach(audio => {
+      audio.loop = true;
+      audio.volume = 0;
+      audio.currentTime = 0;
+      const playPromise = audio.play();
+      if (playPromise && typeof playPromise.catch === 'function') {
+        playPromise.catch(() => {});
+      }
+    });
+  }
+
+  function buildGameTiles() {
+    tileContainer.innerHTML = '';
+    tileContainer.classList.add('music-grid');
+    tileContainer.style.setProperty('--pulse-phase', `${Math.floor(performance.now() % 1400)}ms`);
+    audioMap = new Map();
+    tileMap = new Map();
+    activeInstrumentIds = new Set();
+    stopEqualizer();
+    equalizerBars = [];
+    musicLine = document.createElement('div');
+    musicLine.className = 'music-line';
+    const musicLineTrack = document.createElement('div');
+    musicLineTrack.className = 'music-line-track music-eq';
+    const musicLineBars = document.createElement('div');
+    musicLineBars.className = 'music-line-bars';
+
+    const selected = instruments.filter(instrument => selectedIds.includes(instrument.id));
+    const columns = Math.min(3, Math.max(1, selected.length));
+    tileContainer.style.setProperty('--music-columns', columns);
+
+    const lineBarCount = 32;
+
+    selected.forEach(instrument => {
+      const tile = document.createElement('div');
+      tile.className = 'tile';
+      tile.style.backgroundImage = `url(${instrument.image})`;
+      tile.dataset.instrumentId = instrument.id;
+
+      const caption = document.createElement('span');
+      caption.className = 'caption';
+      caption.textContent = instrument.label;
+      tile.appendChild(caption);
+
+      const audio = new Audio(getInstrumentSound(instrument));
+      audio.loop = true;
+      audio.volume = currentVolume / 100;
+      audioMap.set(instrument.id, audio);
+
+      let hoverTimeout = null;
+
+      tile.addEventListener('pointerenter', () => {
+        if (gazePointer) gazePointer.classList.add('gp-dwell');
+        hoverTimeout = window.setTimeout(() => {
+          toggleInstrument(tile, instrument);
+          if (gazePointer) gazePointer.classList.remove('gp-dwell');
+        }, fixationDelay);
+      });
+
+      tile.addEventListener('pointerleave', () => {
+        if (hoverTimeout) {
+          window.clearTimeout(hoverTimeout);
+        }
+        if (gazePointer) gazePointer.classList.remove('gp-dwell');
+      });
+
+      tileContainer.appendChild(tile);
+      tileMap.set(instrument.id, tile);
+    });
+
+    for (let i = 0; i < lineBarCount; i += 1) {
+      const bar = document.createElement('div');
+      bar.className = 'music-line-bar';
+      musicLineBars.appendChild(bar);
+      equalizerBars.push(bar);
+    }
+
+    musicLineTrack.appendChild(musicLineBars);
+    musicLine.appendChild(musicLineTrack);
+    tileContainer.appendChild(musicLine);
+    updateEqualizerState();
+    if (isSongMode) {
+      startSongPlayback();
+    }
+
+    if (stopAllToggle?.checked) {
+      const stopTile = document.createElement('div');
+      stopTile.className = 'tile stop-all-tile';
+      stopTile.setAttribute('role', 'button');
+      stopTile.setAttribute('aria-label', 'Stop all');
+      stopTile.textContent = '✕';
+
+      let hoverTimeout = null;
+      stopTile.addEventListener('pointerenter', () => {
+        if (gazePointer) gazePointer.classList.add('gp-dwell');
+        hoverTimeout = window.setTimeout(() => {
+          stopAllSounds();
+          if (gazePointer) gazePointer.classList.remove('gp-dwell');
+        }, fixationDelay);
+      });
+
+      stopTile.addEventListener('pointerleave', () => {
+        if (hoverTimeout) {
+          window.clearTimeout(hoverTimeout);
+        }
+        if (gazePointer) gazePointer.classList.remove('gp-dwell');
+      });
+
+      tileContainer.appendChild(stopTile);
+    }
+  }
+
+  function openPicker(mode) {
+    pickerMode = mode;
+    if (pickerMode === 'preset') {
+      tilePickerGrid.style.display = 'none';
+      if (pickerInstructions) {
+        pickerInstructions.style.display = 'none';
+      }
+      startGameButton.style.display = 'none';
+    } else {
+      tilePickerGrid.style.display = '';
+      if (pickerInstructions) {
+        pickerInstructions.style.display = '';
+      }
+      startGameButton.style.display = '';
+    }
+    renderPresets();
+    renderPicker();
+  }
+
+  chooseTilesButton.addEventListener('click', () => {
+    openPicker('instrument');
+    desiredTileCount = parseInt(tileCountInput.value, 10) || 3;
+    trimSelections();
+    updateTileCountDisplay();
+    updateStartState();
+    gameOptionsModal.style.display = 'none';
+    tilePickerModal.style.display = 'flex';
+  });
+
+  choosePresetsButton?.addEventListener('click', () => {
+    openPicker('preset');
+    currentPreset = null;
+    isSongMode = false;
+    gameOptionsModal.style.display = 'none';
+    tilePickerModal.style.display = 'flex';
+  });
+
+  startGameButton.addEventListener('click', () => {
+    startGame();
+  });
+
+  tileCountInput.addEventListener('input', () => {
+    desiredTileCount = parseInt(tileCountInput.value, 10) || 3;
+    updateTileCountDisplay();
+    trimSelections();
+    renderPicker();
+    updateStartState();
+  });
+
+  volumeInput.addEventListener('input', () => {
+    currentVolume = parseInt(volumeInput.value, 10) || 0;
+    updateVolumeDisplay();
+    updateAudioVolume();
+  });
+
+  backgroundSelect?.addEventListener('change', updateBackground);
+
+  fixationTimeInput.addEventListener('input', () => {
+    fixationDelay = parseInt(fixationTimeInput.value, 10) || 2000;
+    updateFixationDisplay();
+  });
+
+  showGazePointer.addEventListener('change', updatePointerStyle);
+  gazeSize.addEventListener('input', updatePointerStyle);
+  gazeOpacity.addEventListener('input', updatePointerStyle);
+
+  document.addEventListener('pointermove', event => {
+    if (!gazePointer || !showGazePointer.checked) return;
+    gazePointer.style.transform = `translate(${event.clientX}px, ${event.clientY}px) translate(-50%, -50%)`;
+  });
+
+  ensurePointerOverlay();
+  updateVolumeDisplay();
+  updateTileCountDisplay();
+  updateFixationDisplay();
+  updatePointerStyle();
+  updateBackground();
+  openPicker('instrument');
+  updateStartState();
+});


### PR DESCRIPTION
### Motivation
- Provide a presets-only "Prerecorded songs" mode alongside the existing instrument picker so users can launch predefined song tracks quickly.
- Add a placeholder punk rock preset that exposes four tracks (drum, guitar, bass, vocals) and keeps tracks synchronized while allowing individual activation.
- Improve equalizer visuals so each bar is colored according to its own height (low stays green while taller bars shift toward red) for clearer meter-like feedback.

### Description
- Added a new orange mode button and picker flow in `eyegaze/music-maker/index.html` and a new site entry in `eyegaze/index.html` to launch the Music Maker page.
- Introduced `css/eyegaze-music-maker.css` with `.button-orange` styling and all layout/CSS for the music grid, presets, and equalizer visuals.
- Implemented presets and song-mode logic in `js/eyegazeMusicMaker.js`, including a `punk-rock` preset with `mode: 'song'` and per-track `tracks` URLs, a `pickerMode` state, `applyPreset`, `openPicker`, `startGame`, and `getInstrumentSound` helpers.
- Added synchronized playback support by starting all song-mode `Audio` objects looping with volume `0` (`startSongPlayback`) and toggling track volume to `1` when the tile is activated (handled in `toggleInstrument`), plus safe `audio.play()` promise handling for autoplay restrictions.
- Updated tile/audio creation in `buildGameTiles` to use `getInstrumentSound` so presets can override instrument sounds, and adjusted `stopAllSounds` and `toggleInstrument` behavior for song-mode.
- Adjusted equalizer code so `setEqualizerBars` computes a per-bar `height` and sets `backgroundColor`/`boxShadow` by normalized height, and `startEqualizer` uses the ratio of active tiles to determine base level.

### Testing
- Launched a static server with `python -m http.server 8000` and ran a Playwright script that opened `http://127.0.0.1:8000/eyegaze/music-maker/index.html` and captured a screenshot, which completed successfully and produced `artifacts/music-maker-buttons.png`.
- No unit tests or automated integration tests beyond the Playwright screenshot were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6967ab1a163483259af41cf7f8334829)