### PR TITLE
Add communication tiles activity for tactile and eye-gaze

### DIFF
--- a/css/communication-tiles.css
+++ b/css/communication-tiles.css
@@ -1,0 +1,141 @@
+:root {
+  --ct-bg: #f6fbff;
+  --ct-panel: #ffffff;
+  --ct-border: #c6e0f9;
+  --ct-highlight: #0a66c2;
+  --ct-pending: #ffd666;
+  --ct-text: #17324d;
+}
+
+body.communication-tiles-page {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: var(--ct-bg);
+  color: var(--ct-text);
+}
+
+.communication-app {
+  padding: 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.communication-header {
+  margin-bottom: 1rem;
+}
+
+.communication-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  background: var(--ct-panel);
+  border: 2px solid var(--ct-border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.communication-controls label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.95rem;
+  gap: 0.25rem;
+}
+
+.communication-controls select,
+.communication-controls input,
+.communication-controls button {
+  font-size: 1rem;
+  padding: 0.4rem;
+  border-radius: 8px;
+  border: 1px solid #96bddf;
+}
+
+.sentence-strip {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  border: 2px solid var(--ct-border);
+  background: var(--ct-panel);
+  border-radius: 12px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+  min-height: 3.25rem;
+}
+
+.sentence-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.sentence-actions button {
+  border: 1px solid #96bddf;
+  border-radius: 8px;
+  background: #fff;
+  font-size: 0.95rem;
+  padding: 0.4rem 0.6rem;
+}
+
+.tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.85rem;
+}
+
+.com-tile {
+  min-height: 150px;
+  border: 3px solid var(--ct-border);
+  border-radius: 14px;
+  background: var(--ct-panel);
+  color: var(--ct-text);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  transition: transform 0.1s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.com-tile .symbol {
+  font-size: clamp(2.3rem, 6vw, 4rem);
+}
+
+.com-tile .label {
+  font-size: clamp(1.1rem, 2.4vw, 1.6rem);
+  text-transform: capitalize;
+}
+
+.com-tile:hover,
+.com-tile:focus {
+  border-color: var(--ct-highlight);
+  transform: translateY(-2px);
+}
+
+.com-tile.pending {
+  border-color: var(--ct-pending);
+  background: #fff9e9;
+}
+
+.com-tile.dwell-active {
+  box-shadow: inset 0 -14px 0 rgba(10, 102, 194, 0.26);
+  border-color: var(--ct-highlight);
+}
+
+.mode-note {
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .sentence-strip {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .tile-grid {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
+}

--- a/documentation/communication-tiles/index.html
+++ b/documentation/communication-tiles/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Communication Tiles Setup</title>
+  <link rel="stylesheet" href="../../css/global.css" />
+  <link rel="stylesheet" href="../../css/layout.css" />
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; }
+    main { max-width: 900px; margin: 0 auto; padding: 1rem; }
+    code { background: #f2f2f2; padding: 0.1rem 0.3rem; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Communication Tiles: Setup and Use</h1>
+
+    <p>
+      This activity is available in two versions with the same communication model:
+      <a href="../../tactile/communication-tiles/index.html">tactile/communication-tiles/</a>
+      and
+      <a href="../../eyegaze/communication-tiles/index.html">eyegaze/communication-tiles/</a>.
+    </p>
+
+    <h2>Included content model</h2>
+    <ul>
+      <li><strong>Basic set:</strong> eat, drink, bathroom, break, more, stop, help, pain, happy, sad.</li>
+      <li><strong>Expanded set:</strong> adds hot, cold, yes, no, finished, and music.</li>
+      <li><strong>Sentence strip:</strong> combines starter + selected words, for example: <code>I want + drink</code>.</li>
+    </ul>
+
+    <h2>Configuration options</h2>
+    <ul>
+      <li><strong>Vocabulary set:</strong> switch between basic and expanded.</li>
+      <li><strong>Spoken feedback:</strong> use TTS, pre-recorded audio (if tile audio URLs are provided), or none.</li>
+      <li><strong>Confirmation mode:</strong> click confirmation or dwell confirmation.</li>
+      <li><strong>Dwell duration:</strong> tune dwell delay from 400ms to 3000ms.</li>
+      <li><strong>Sentence starter:</strong> choose from “I want”, “I need”, and “I feel”.</li>
+    </ul>
+
+    <h2>Editing vocabulary</h2>
+    <p>
+      Edit shared vocabulary in <code>js/communication-tiles-data.js</code>. Both tactile and eye-gaze pages use this same file.
+      To add pre-recorded audio, add an <code>audio</code> URL on any item object.
+    </p>
+  </main>
+</body>
+</html>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -108,6 +108,13 @@
         </a>
       </div>
 
+      <div class="tile-main">
+        <a href="communication-tiles/index.html">
+          <img src="../images/choixeyegaze.png" alt="Communication tiles">
+          <div class="tile-main-title" data-fr="Tuiles de communication (tactile + oculaire)" data-en="Communication tiles (touch + eye gaze)" data-ja="コミュニケーションタイル（タッチ＋視線）"></div>
+        </a>
+      </div>
+
     </div>
   </main>
 

--- a/eyegaze/communication-tiles/index.html
+++ b/eyegaze/communication-tiles/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Communication Tiles (Eye Gaze)</title>
+  <link rel="stylesheet" href="../../css/communication-tiles.css">
+</head>
+<body class="communication-tiles-page">
+  <main id="communication-app" class="communication-app">
+    <header class="communication-header">
+      <h1>Communication Tiles (Eye Gaze)</h1>
+      <p>Large symbol tiles for common requests with dwell-friendly activation.</p>
+      <p class="mode-note"><strong>Eye-gaze mode:</strong> Dwell confirmation is default and can be tuned for each user.</p>
+    </header>
+
+    <section class="communication-controls">
+      <label>Vocabulary set
+        <select data-role="vocab">
+          <option value="basic">Basic (10 requests)</option>
+          <option value="expanded">Expanded</option>
+        </select>
+      </label>
+
+      <label>Feedback
+        <select data-role="feedback">
+          <option value="tts">Spoken feedback (TTS)</option>
+          <option value="audio">Pre-recorded audio</option>
+          <option value="none">No feedback</option>
+        </select>
+      </label>
+
+      <label>Confirmation mode
+        <select data-role="confirm">
+          <option value="dwell">Dwell confirmation</option>
+          <option value="click">Click confirmation</option>
+        </select>
+      </label>
+
+      <label>Dwell duration: <span data-role="dwell-value">1200 ms</span>
+        <input data-role="dwell" type="range" min="400" max="3000" step="100" value="1200">
+      </label>
+
+      <label>Sentence starter
+        <select data-role="starter"></select>
+      </label>
+    </section>
+
+    <section class="sentence-strip">
+      <div data-role="sentence-text" aria-live="polite"></div>
+      <div class="sentence-actions">
+        <button type="button" data-role="undo-sentence">Undo</button>
+        <button type="button" data-role="clear-sentence">Clear</button>
+      </div>
+    </section>
+
+    <section class="tile-grid" data-role="grid"></section>
+  </main>
+
+  <script src="../../js/communication-tiles-data.js"></script>
+  <script src="../../js/communication-tiles-app.js"></script>
+  <script>
+    window.CommunicationTilesApp.mount({ mode: 'eyegaze' });
+  </script>
+</body>
+</html>

--- a/eyegaze/index.html
+++ b/eyegaze/index.html
@@ -187,6 +187,14 @@
       </a>
     </div>
 
+    <div class="tile">
+      <a href="communication-tiles/index.html">
+        <img src="../images/choixeyegaze.png" alt="Communication tiles">
+        <div class="tile-title">
+          <h3 data-fr="Tuiles de communication" data-en="Communication tiles" data-ja="コミュニケーションタイル">Tuiles de communication</h3>
+        </div>
+      </a>
+    </div>
 
 
   </div>

--- a/js/communication-tiles-app.js
+++ b/js/communication-tiles-app.js
@@ -1,0 +1,224 @@
+(function initCommunicationTiles(global) {
+  const data = global.CommunicationTilesData;
+
+  function createAudioFeedbackController() {
+    const synth = global.speechSynthesis;
+    return {
+      speak(text, enabled) {
+        if (!enabled || !text) return;
+        if (synth && typeof SpeechSynthesisUtterance !== 'undefined') {
+          synth.cancel();
+          synth.speak(new SpeechSynthesisUtterance(text));
+        }
+      },
+      playAudio(url, enabled) {
+        if (!enabled || !url) return;
+        const audio = new Audio(url);
+        audio.play().catch(() => {});
+      }
+    };
+  }
+
+  function mount(options) {
+    const {
+      mode,
+      rootSelector = '#communication-app'
+    } = options;
+
+    const root = document.querySelector(rootSelector);
+    if (!root || !data) return;
+
+    const state = {
+      mode,
+      vocabSet: 'basic',
+      feedbackMode: 'tts',
+      confirmMode: mode === 'eyegaze' ? 'dwell' : 'click',
+      dwellMs: Number(global.eyegazeSettings?.dwellTime) || 1200,
+      starter: 'I want',
+      sentenceItems: [],
+      pendingChoiceId: null,
+      dwellTimerById: new Map()
+    };
+
+    const feedback = createAudioFeedbackController();
+
+    function getChoices() {
+      return data.vocabSets[state.vocabSet] || [];
+    }
+
+    function selectTile(id) {
+      const choice = getChoices().find(item => item.id === id);
+      if (!choice) return;
+
+      state.sentenceItems.push(choice.sentence);
+      if (state.feedbackMode === 'tts') {
+        feedback.speak(choice.label, true);
+      } else if (state.feedbackMode === 'audio') {
+        feedback.playAudio(choice.audio, true);
+      }
+
+      renderSentence();
+    }
+
+    function renderSentence() {
+      const stripText = root.querySelector('[data-role="sentence-text"]');
+      if (!stripText) return;
+      const payload = state.sentenceItems.join(' + ');
+      stripText.textContent = payload ? `${state.starter} + ${payload}` : `${state.starter} + ...`;
+    }
+
+    function clearDwell(id) {
+      const timer = state.dwellTimerById.get(id);
+      if (timer) {
+        clearTimeout(timer);
+        state.dwellTimerById.delete(id);
+      }
+    }
+
+    function bindTile(tile, id) {
+      const activate = () => {
+        if (state.confirmMode === 'click') {
+          if (state.pendingChoiceId === id) {
+            selectTile(id);
+            state.pendingChoiceId = null;
+          } else {
+            state.pendingChoiceId = id;
+          }
+          renderTiles();
+          return;
+        }
+        selectTile(id);
+      };
+
+      if (state.confirmMode === 'dwell') {
+        const start = () => {
+          clearDwell(id);
+          tile.classList.add('dwell-active');
+          state.dwellTimerById.set(id, setTimeout(() => {
+            tile.classList.remove('dwell-active');
+            state.dwellTimerById.delete(id);
+            selectTile(id);
+          }, state.dwellMs));
+        };
+        const stop = () => {
+          tile.classList.remove('dwell-active');
+          clearDwell(id);
+        };
+
+        tile.addEventListener('mouseenter', start);
+        tile.addEventListener('mouseleave', stop);
+        tile.addEventListener('focus', start);
+        tile.addEventListener('blur', stop);
+        if (mode === 'tactile') {
+          tile.addEventListener('pointerdown', start);
+          tile.addEventListener('pointerup', stop);
+          tile.addEventListener('pointercancel', stop);
+        }
+      } else {
+        tile.addEventListener('click', activate);
+      }
+    }
+
+    function renderTiles() {
+      const grid = root.querySelector('[data-role="grid"]');
+      if (!grid) return;
+
+      state.dwellTimerById.forEach(timer => clearTimeout(timer));
+      state.dwellTimerById.clear();
+
+      const items = getChoices();
+      grid.innerHTML = '';
+      items.forEach(item => {
+        const tile = document.createElement('button');
+        tile.className = 'com-tile';
+        tile.type = 'button';
+        tile.dataset.id = item.id;
+        if (state.pendingChoiceId === item.id) {
+          tile.classList.add('pending');
+        }
+        tile.innerHTML = `<span class="symbol">${item.symbol}</span><span class="label">${item.label}</span>`;
+        bindTile(tile, item.id);
+        grid.appendChild(tile);
+      });
+    }
+
+    function wireControls() {
+      const vocab = root.querySelector('[data-role="vocab"]');
+      const feedbackMode = root.querySelector('[data-role="feedback"]');
+      const confirmMode = root.querySelector('[data-role="confirm"]');
+      const dwell = root.querySelector('[data-role="dwell"]');
+      const dwellValue = root.querySelector('[data-role="dwell-value"]');
+      const starter = root.querySelector('[data-role="starter"]');
+      const clearButton = root.querySelector('[data-role="clear-sentence"]');
+      const undoButton = root.querySelector('[data-role="undo-sentence"]');
+
+      if (vocab) {
+        vocab.value = state.vocabSet;
+        vocab.addEventListener('change', () => {
+          state.vocabSet = vocab.value;
+          state.pendingChoiceId = null;
+          renderTiles();
+        });
+      }
+
+      if (feedbackMode) {
+        feedbackMode.value = state.feedbackMode;
+        feedbackMode.addEventListener('change', () => {
+          state.feedbackMode = feedbackMode.value;
+        });
+      }
+
+      if (confirmMode) {
+        confirmMode.value = state.confirmMode;
+        confirmMode.addEventListener('change', () => {
+          state.confirmMode = confirmMode.value;
+          state.pendingChoiceId = null;
+          renderTiles();
+        });
+      }
+
+      if (dwell && dwellValue) {
+        dwell.value = String(state.dwellMs);
+        dwellValue.textContent = `${state.dwellMs} ms`;
+        dwell.addEventListener('input', () => {
+          state.dwellMs = Number(dwell.value) || 1200;
+          dwellValue.textContent = `${state.dwellMs} ms`;
+        });
+      }
+
+      if (starter) {
+        data.starterOptions.forEach(option => {
+          const opt = document.createElement('option');
+          opt.value = option.label;
+          opt.textContent = option.label;
+          starter.appendChild(opt);
+        });
+        starter.value = state.starter;
+        starter.addEventListener('change', () => {
+          state.starter = starter.value;
+          renderSentence();
+        });
+      }
+
+      if (clearButton) {
+        clearButton.addEventListener('click', () => {
+          state.sentenceItems = [];
+          renderSentence();
+        });
+      }
+
+      if (undoButton) {
+        undoButton.addEventListener('click', () => {
+          state.sentenceItems.pop();
+          renderSentence();
+        });
+      }
+    }
+
+    wireControls();
+    renderTiles();
+    renderSentence();
+  }
+
+  global.CommunicationTilesApp = { mount };
+})(window);

--- a/js/communication-tiles-data.js
+++ b/js/communication-tiles-data.js
@@ -1,0 +1,37 @@
+(function attachCommunicationTilesData(global) {
+  const baseItems = [
+    { id: 'eat', symbol: '🍽️', label: 'eat', sentence: 'eat' },
+    { id: 'drink', symbol: '🥤', label: 'drink', sentence: 'drink' },
+    { id: 'bathroom', symbol: '🚻', label: 'bathroom', sentence: 'to use the bathroom' },
+    { id: 'break', symbol: '🛋️', label: 'break', sentence: 'a break' },
+    { id: 'more', symbol: '➕', label: 'more', sentence: 'more' },
+    { id: 'stop', symbol: '🛑', label: 'stop', sentence: 'to stop' },
+    { id: 'help', symbol: '🆘', label: 'help', sentence: 'help' },
+    { id: 'pain', symbol: '🤕', label: 'pain', sentence: 'to talk about pain' },
+    { id: 'happy', symbol: '🙂', label: 'happy', sentence: 'happy' },
+    { id: 'sad', symbol: '🙁', label: 'sad', sentence: 'sad' }
+  ];
+
+  const expandedOnly = [
+    { id: 'hot', symbol: '🥵', label: 'hot', sentence: 'hot' },
+    { id: 'cold', symbol: '🥶', label: 'cold', sentence: 'cold' },
+    { id: 'yes', symbol: '✅', label: 'yes', sentence: 'yes' },
+    { id: 'no', symbol: '❌', label: 'no', sentence: 'no' },
+    { id: 'finished', symbol: '🏁', label: 'finished', sentence: 'finished' },
+    { id: 'music', symbol: '🎵', label: 'music', sentence: 'music' }
+  ];
+
+  const starterOptions = [
+    { id: 'want', label: 'I want' },
+    { id: 'need', label: 'I need' },
+    { id: 'feel', label: 'I feel' }
+  ];
+
+  global.CommunicationTilesData = {
+    vocabSets: {
+      basic: baseItems,
+      expanded: baseItems.concat(expandedOnly)
+    },
+    starterOptions
+  };
+})(window);

--- a/tactile/communication-tiles/index.html
+++ b/tactile/communication-tiles/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Communication Tiles (Touch)</title>
+  <link rel="stylesheet" href="../../css/communication-tiles.css">
+</head>
+<body class="communication-tiles-page">
+  <main id="communication-app" class="communication-app">
+    <header class="communication-header">
+      <h1>Communication Tiles (Touch)</h1>
+      <p>Large symbol tiles for common requests with optional click or dwell confirmation.</p>
+      <p class="mode-note"><strong>Touch mode:</strong> Click confirmation is default, and dwell can be done by press-and-hold.</p>
+    </header>
+
+    <section class="communication-controls">
+      <label>Vocabulary set
+        <select data-role="vocab">
+          <option value="basic">Basic (10 requests)</option>
+          <option value="expanded">Expanded</option>
+        </select>
+      </label>
+
+      <label>Feedback
+        <select data-role="feedback">
+          <option value="tts">Spoken feedback (TTS)</option>
+          <option value="audio">Pre-recorded audio</option>
+          <option value="none">No feedback</option>
+        </select>
+      </label>
+
+      <label>Confirmation mode
+        <select data-role="confirm">
+          <option value="click">Click confirmation</option>
+          <option value="dwell">Dwell confirmation</option>
+        </select>
+      </label>
+
+      <label>Dwell duration: <span data-role="dwell-value">1200 ms</span>
+        <input data-role="dwell" type="range" min="400" max="3000" step="100" value="1200">
+      </label>
+
+      <label>Sentence starter
+        <select data-role="starter"></select>
+      </label>
+    </section>
+
+    <section class="sentence-strip">
+      <div data-role="sentence-text" aria-live="polite"></div>
+      <div class="sentence-actions">
+        <button type="button" data-role="undo-sentence">Undo</button>
+        <button type="button" data-role="clear-sentence">Clear</button>
+      </div>
+    </section>
+
+    <section class="tile-grid" data-role="grid"></section>
+  </main>
+
+  <script src="../../js/communication-tiles-data.js"></script>
+  <script src="../../js/communication-tiles-app.js"></script>
+  <script>
+    window.CommunicationTilesApp.mount({ mode: 'tactile' });
+  </script>
+</body>
+</html>

--- a/tactile/index.html
+++ b/tactile/index.html
@@ -111,6 +111,15 @@
             </a>
         </div>
 
+        <div class="tile">
+            <a href="communication-tiles/index.html">
+                <img src="../images/choixeyegaze.png" alt="communication tiles">
+                <div class="tile-title">
+                    <h3 data-fr="Tuiles de communication" data-en="Communication tiles" data-ja="コミュニケーションタイル">Tuiles de communication</h3>
+                </div>
+            </a>
+        </div>
+
     </div>
     <button id="langToggle" class="floating-button lang-toggle" title="Changer la langue / Switch language">EN</button>
 


### PR DESCRIPTION
### Motivation
- Provide a simple large-symbol communication activity for common requests (eat, drink, bathroom, break, more, stop, help, pain, happy, sad) usable with both touch and eye-gaze input. 
- Share one content model and UI behavior across modes so vocabulary, sentence strip, and audio options stay consistent. 
- Support accessibility needs by offering dwell activation, click confirmation, and optional spoken feedback. 

### Description
- Added a shared data model in `js/communication-tiles-data.js` with `basic` and `expanded` vocabulary sets plus sentence starter options. 
- Implemented shared app logic in `js/communication-tiles-app.js` that renders large symbol tiles, supports `tts` or pre-recorded `audio`, provides `click` and `dwell` confirmation modes, and builds a sentence strip like `I want + drink`. 
- Added styling in `css/communication-tiles.css` and new activity pages `tactile/communication-tiles/index.html` and `eyegaze/communication-tiles/index.html`, with defaults adapted per mode (`click` default for tactile, `dwell` default for eyegaze). 
- Added entry tiles to `tactile/index.html` and `eyegaze/index.html` and a setup guide at `documentation/communication-tiles/index.html`, with a link added to `documentation/index.html`. 

### Testing
- Ran `node --check js/communication-tiles-data.js` which completed successfully. 
- Ran `node --check js/communication-tiles-app.js` which completed successfully. 
- Manual smoke rendering was prepared by wiring pages to the shared JS/CSS and documentation was added; no automated browser tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee18a489083259001f564d3934c83)