### PR TITLE
Add mode selection, narration, hotspots, and improved game lifecycle to Samurai story

### DIFF
--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -67,6 +67,14 @@
       box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
     }
 
+    .story-vignette {
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at center, transparent 30%, rgba(0, 0, 0, 0.5) 100%);
+      pointer-events: none;
+      z-index: 1;
+    }
+
     .story-image {
       display: block;
       max-width: 100%;
@@ -89,6 +97,51 @@
       display: none;
       transition: opacity 1.2s ease-in-out;
       z-index: 2;
+    }
+
+    .story-overlay {
+      position: absolute;
+      inset: auto 5% 5% 5%;
+      padding: 14px 18px;
+      border-radius: 14px;
+      background: linear-gradient(145deg, rgba(18, 12, 9, 0.84), rgba(46, 22, 10, 0.66));
+      border: 1px solid rgba(255, 211, 152, 0.35);
+      color: #ffe8c5;
+      font-size: clamp(18px, 2.2vw, 30px);
+      letter-spacing: 0.02em;
+      line-height: 1.4;
+      text-align: center;
+      font-family: "Georgia", "Times New Roman", serif;
+      z-index: 3;
+      opacity: 0;
+      transform: translateY(8px);
+      transition: opacity 0.35s ease, transform 0.35s ease;
+      text-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+      pointer-events: none;
+    }
+
+    .story-overlay.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .hotspot {
+      position: absolute;
+      width: clamp(58px, 8vw, 96px);
+      height: clamp(58px, 8vw, 96px);
+      border-radius: 50%;
+      border: 2px solid rgba(255, 255, 255, 0.8);
+      box-shadow: 0 0 0 6px rgba(250, 204, 21, 0.2), 0 0 18px rgba(250, 204, 21, 0.7);
+      background: rgba(250, 204, 21, 0.18);
+      z-index: 4;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+    }
+
+    .hotspot.visible {
+      opacity: 1;
+      pointer-events: auto;
     }
 
     .story-media.video-playing .story-video {
@@ -143,6 +196,7 @@
       z-index: 20;
       box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
       transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      display: none;
     }
 
     .next-button:hover,
@@ -199,6 +253,120 @@
       100% { opacity: 0; }
     }
 
+    .mode-screen {
+      position: fixed;
+      inset: 0;
+      z-index: 60;
+      display: grid;
+      place-items: center;
+      background:
+        radial-gradient(circle at 20% 20%, rgba(190, 24, 93, 0.28), transparent 45%),
+        radial-gradient(circle at 80% 25%, rgba(30, 64, 175, 0.25), transparent 52%),
+        radial-gradient(circle at 50% 95%, rgba(217, 119, 6, 0.24), transparent 56%),
+        #040507;
+    }
+
+    .mode-panel {
+      width: min(1000px, 92vw);
+      padding: clamp(18px, 3vw, 36px);
+      border-radius: 20px;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      background: linear-gradient(140deg, rgba(11, 15, 25, 0.94), rgba(23, 12, 6, 0.85));
+      box-shadow: 0 24px 70px rgba(0, 0, 0, 0.6);
+    }
+
+    .mode-title {
+      margin: 0 0 8px;
+      text-align: center;
+      font-size: clamp(30px, 4vw, 52px);
+      letter-spacing: 0.06em;
+      color: #fdf4da;
+      text-transform: uppercase;
+      font-family: "Georgia", serif;
+    }
+
+    .mode-subtitle {
+      margin: 0 0 22px;
+      text-align: center;
+      color: #d4d4d8;
+      font-size: clamp(15px, 1.8vw, 20px);
+    }
+
+    .mode-preview {
+      display: grid;
+      grid-template-columns: minmax(200px, 320px) 1fr;
+      gap: 18px;
+      align-items: center;
+    }
+
+    .mode-preview img {
+      width: 100%;
+      border-radius: 14px;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+      aspect-ratio: 1 / 1;
+      object-fit: cover;
+    }
+
+    .mode-buttons {
+      display: grid;
+      gap: 12px;
+    }
+
+    .mode-button {
+      text-align: left;
+      border-radius: 14px;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      padding: 14px 16px;
+      color: #f8fafc;
+      cursor: pointer;
+      background: linear-gradient(130deg, rgba(17, 24, 39, 0.95), rgba(42, 20, 13, 0.7));
+      font: inherit;
+    }
+
+    .mode-button strong {
+      display: block;
+      font-size: 18px;
+      margin-bottom: 4px;
+      color: #fef3c7;
+    }
+
+    .mode-button:hover,
+    .mode-button:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(250, 204, 21, 0.75);
+      outline: none;
+    }
+
+    .mode-button.active {
+      border-color: rgba(250, 204, 21, 0.95);
+      box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.34);
+    }
+
+    .game-status {
+      position: absolute;
+      top: 18px;
+      left: 18px;
+      z-index: 10;
+      border-radius: 12px;
+      padding: 10px 12px;
+      background: rgba(0, 0, 0, 0.58);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      font-size: 14px;
+      max-width: min(520px, 72vw);
+    }
+
+    .game-status button {
+      margin-top: 8px;
+      border-radius: 8px;
+      border: 1px solid rgba(250, 204, 21, 0.65);
+      background: rgba(250, 204, 21, 0.2);
+      color: #fff9db;
+      padding: 6px 10px;
+      cursor: pointer;
+      font: inherit;
+    }
+
     :fullscreen .story-page {
       padding: 0;
     }
@@ -211,18 +379,48 @@
   </style>
 </head>
 <body>
+  <section id="modeScreen" class="mode-screen">
+    <div class="mode-panel">
+      <h1 class="mode-title">Eyegaze Samurai</h1>
+      <p class="mode-subtitle">Choose your path. The portrait changes with each style, like selecting a character.</p>
+      <div class="mode-preview">
+        <img id="modePreviewImage" src="../../images/samuraikata/boulebleuchi.jpg" alt="Mode preview" />
+        <div class="mode-buttons">
+          <button class="mode-button" type="button" data-mode="story" data-preview="../../images/samuraikata/maitrechi.jpg">
+            <strong>Story Mode</strong>
+            Auto-advances pages after narration and keeps mini-games non-blocking.
+          </button>
+          <button class="mode-button" type="button" data-mode="autonomous" data-preview="../../images/samuraikata/lanternesallu.jpg">
+            <strong>Autonomous Advancer</strong>
+            The player advances each page with gaze/hover hotspots; mini-games are still non-blocking.
+          </button>
+          <button class="mode-button" type="button" data-mode="samurai" data-preview="../../images/samuraikata/katanafleurs.jpg">
+            <strong>Samurai</strong>
+            Player advances pages and must complete each mini-game challenge, otherwise the journey resets.
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <div id="app">
-    <section class="page story-page active" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn.">
+    <section class="page story-page active" data-type="story" data-image="paysagejapon.jpg" data-audio="../../songs/samurai/samuraisong1.mp3" data-text="At dawn, the valley breathes and your journey begins." data-hotspot-x="85" data-hotspot-y="82" data-alt="A peaceful Japanese landscape at dawn.">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" muted playsinline></video>
+        <div class="story-vignette"></div>
+        <div class="story-overlay" data-story-overlay></div>
+        <button class="hotspot" type="button" data-hotspot aria-label="Advance story"></button>
       </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere.">
+    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-audio="../../songs/samurai/samuraisong2.mp3" data-text="You gather chi energy in silence, waiting for the right moment." data-hotspot-x="14" data-hotspot-y="78" data-alt="A samurai focuses on a glowing chi sphere.">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" muted playsinline></video>
+        <div class="story-vignette"></div>
+        <div class="story-overlay" data-story-overlay></div>
+        <button class="hotspot" type="button" data-hotspot aria-label="Advance story"></button>
       </div>
     </section>
 
@@ -230,10 +428,13 @@
       <div class="game-frame" data-game-host></div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy.">
+    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-audio="../../songs/samurai/samuraisong3.mp3" data-text="Your master whispers: breathe first, strike later." data-hotspot-x="50" data-hotspot-y="20" data-alt="A master guides the samurai with calm energy.">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" muted playsinline></video>
+        <div class="story-vignette"></div>
+        <div class="story-overlay" data-story-overlay></div>
+        <button class="hotspot" type="button" data-hotspot aria-label="Advance story"></button>
       </div>
     </section>
 
@@ -241,10 +442,13 @@
       <div class="game-frame" data-game-host></div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky.">
+    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-audio="../../songs/samurai/cherryblossomsong.mp3" data-text="Lantern lights rise like prayers into the night sky." data-hotspot-x="78" data-hotspot-y="18" data-alt="Lanterns glow softly in the night sky.">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" muted playsinline></video>
+        <div class="story-vignette"></div>
+        <div class="story-overlay" data-story-overlay></div>
+        <button class="hotspot" type="button" data-hotspot aria-label="Advance story"></button>
       </div>
     </section>
 
@@ -252,10 +456,13 @@
       <div class="game-frame" data-game-host></div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms.">
+    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-audio="../../songs/samurai/cherryblossomsong2.mp3" data-text="Your blade rests under petals, waiting for the final test." data-hotspot-x="82" data-hotspot-y="74" data-alt="A katana rests among drifting cherry blossoms.">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" muted playsinline></video>
+        <div class="story-vignette"></div>
+        <div class="story-overlay" data-story-overlay></div>
+        <button class="hotspot" type="button" data-hotspot aria-label="Advance story"></button>
       </div>
     </section>
   </div>
@@ -270,10 +477,26 @@
       const nextButton = document.getElementById('nextButton');
       const fullscreenButton = document.getElementById('fullscreenButton');
       const transitionOverlay = document.getElementById('transitionOverlay');
+      const modeScreen = document.getElementById('modeScreen');
+      const modeButtons = Array.from(document.querySelectorAll('.mode-button'));
+      const modePreviewImage = document.getElementById('modePreviewImage');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
       const fadeDurationMs = 4000;
+      const autoAdvanceDelayMs = 2200;
+      const gameSoftDurationMs = 18000;
+      const gameHardDurationMs = 35000;
+      const dwellMs = 900;
+
+      const MODES = {
+        story: { id: 'story', autoStoryAdvance: true, requiresGameSuccess: false },
+        autonomous: { id: 'autonomous', autoStoryAdvance: false, requiresGameSuccess: false },
+        samurai: { id: 'samurai', autoStoryAdvance: false, requiresGameSuccess: true }
+      };
+
+      let mode = MODES.story;
       let currentIndex = 0;
+      let storyAudio = null;
 
       const storyTimers = new WeakMap();
       const gameSessions = new Map();
@@ -288,12 +511,9 @@
       const clearStoryTimers = (page) => {
         const timers = storyTimers.get(page);
         if (!timers) return;
-        if (timers.videoTimeout) {
-          clearTimeout(timers.videoTimeout);
-        }
-        if (timers.checkTimeout) {
-          clearTimeout(timers.checkTimeout);
-        }
+        Object.values(timers).forEach((id) => {
+          if (id) clearTimeout(id);
+        });
         storyTimers.delete(page);
       };
 
@@ -301,22 +521,36 @@
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
         const video = page.querySelector('.story-video');
-        if (!media || !image || !video) return;
+        const overlay = page.querySelector('[data-story-overlay]');
+        const hotspot = page.querySelector('[data-hotspot]');
+        if (!media || !image || !video || !overlay || !hotspot) return;
         media.classList.remove('video-playing');
         video.pause();
         video.removeAttribute('src');
         video.load();
+        overlay.textContent = '';
+        overlay.classList.remove('visible');
+        hotspot.classList.remove('visible');
         image.style.animation = 'none';
         void image.offsetHeight;
         image.style.animation = 'colorFadeIn 4s ease-in-out forwards';
       };
 
+      const stopNarration = () => {
+        if (!storyAudio) return;
+        storyAudio.pause();
+        storyAudio.src = '';
+        storyAudio = null;
+      };
+
       const checkVideoExists = (path, callback) => {
         const tester = document.createElement('video');
         let settled = false;
+        let timeoutId = null;
         const clean = () => {
           tester.removeEventListener('loadeddata', onLoad);
           tester.removeEventListener('error', onError);
+          if (timeoutId) clearTimeout(timeoutId);
         };
         const onLoad = () => {
           if (settled) return;
@@ -335,47 +569,15 @@
         tester.src = path;
         tester.preload = 'metadata';
         tester.load();
-        const timeoutId = setTimeout(() => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(false);
-        }, 1200);
-        return timeoutId;
+        timeoutId = setTimeout(onError, 1600);
       };
 
-      const setupStoryPage = (page) => {
-        clearStoryTimers(page);
-        const imageName = page.dataset.image;
-        const altText = page.dataset.alt || '';
-        const media = page.querySelector('[data-story-media]');
-        const image = page.querySelector('.story-image');
-        const video = page.querySelector('.story-video');
-        if (!imageName || !media || !image || !video) return;
-
-        resetStoryMedia(page);
-        image.src = `${imageBasePath}${imageName}`;
-        image.alt = altText;
-        media.classList.remove('video-playing');
-
-        const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
-        const videoPath = `${videoBasePath}${videoName}`;
-
-        const timers = { videoTimeout: null, checkTimeout: null };
-        timers.checkTimeout = checkVideoExists(videoPath, (exists) => {
-          if (!exists) return;
-          video.src = videoPath;
-          video.load();
-          timers.videoTimeout = setTimeout(() => {
-            if (pages[currentIndex] !== page) return;
-            media.classList.add('video-playing');
-            const playPromise = video.play();
-            if (playPromise && typeof playPromise.catch === 'function') {
-              playPromise.catch(() => {});
-            }
-          }, fadeDurationMs + 300);
-        });
-        storyTimers.set(page, timers);
+      const positionHotspot = (page, hotspot) => {
+        const x = Number(page.dataset.hotspotX || 82);
+        const y = Number(page.dataset.hotspotY || 78);
+        hotspot.style.left = `${x}%`;
+        hotspot.style.top = `${y}%`;
+        hotspot.style.transform = 'translate(-50%, -50%)';
       };
 
       const gameTemplates = {
@@ -383,7 +585,6 @@
         meditation: 'tpl-meditation',
         lamp: 'tpl-lamp'
       };
-
       const templateCache = {};
       const loadTemplate = (id) => {
         if (!templateCache[id]) {
@@ -393,167 +594,238 @@
         return templateCache[id];
       };
 
+      const resetJourney = () => {
+        const previous = pages[currentIndex];
+        if (previous?.dataset.type === 'story') {
+          clearStoryTimers(previous);
+          resetStoryMedia(previous);
+          stopNarration();
+        }
+        if (previous?.dataset.type === 'game') {
+          stopGame(previous);
+        }
+        currentIndex = 0;
+        pages.forEach((p, i) => p.classList.toggle('active', i === 0));
+        setupStoryPage(pages[0]);
+      };
+
+      const setupStoryPage = (page) => {
+        clearStoryTimers(page);
+        stopNarration();
+
+        const imageName = page.dataset.image;
+        const altText = page.dataset.alt || '';
+        const narrativeText = page.dataset.text || '';
+        const audioSrc = page.dataset.audio || '';
+        const media = page.querySelector('[data-story-media]');
+        const image = page.querySelector('.story-image');
+        const video = page.querySelector('.story-video');
+        const overlay = page.querySelector('[data-story-overlay]');
+        const hotspot = page.querySelector('[data-hotspot]');
+        if (!imageName || !media || !image || !video || !overlay || !hotspot) return;
+
+        resetStoryMedia(page);
+        image.src = `${imageBasePath}${imageName}`;
+        image.alt = altText;
+        overlay.textContent = narrativeText;
+        positionHotspot(page, hotspot);
+
+        const timers = { textTimeout: null, autoAdvanceTimeout: null };
+        const advanceByHotspot = () => {
+          if (!hotspot.classList.contains('visible')) return;
+          hotspot.classList.remove('visible');
+          playStoryVideo(page);
+        };
+
+        let dwellTimeout = null;
+        const dwellStart = () => {
+          clearTimeout(dwellTimeout);
+          dwellTimeout = setTimeout(advanceByHotspot, dwellMs);
+        };
+        const dwellCancel = () => {
+          clearTimeout(dwellTimeout);
+        };
+        hotspot.onmouseenter = dwellStart;
+        hotspot.onmouseleave = dwellCancel;
+        hotspot.onfocus = dwellStart;
+        hotspot.onblur = dwellCancel;
+        hotspot.onclick = advanceByHotspot;
+
+        timers.textTimeout = setTimeout(() => {
+          if (pages[currentIndex] !== page) return;
+          overlay.classList.add('visible');
+          if (audioSrc) {
+            storyAudio = new Audio(audioSrc);
+            storyAudio.play().catch(() => {});
+            storyAudio.onended = () => {
+              if (pages[currentIndex] !== page) return;
+              if (mode.autoStoryAdvance) {
+                timers.autoAdvanceTimeout = setTimeout(() => playStoryVideo(page), autoAdvanceDelayMs);
+              } else {
+                hotspot.classList.add('visible');
+              }
+            };
+          } else if (mode.autoStoryAdvance) {
+            timers.autoAdvanceTimeout = setTimeout(() => playStoryVideo(page), autoAdvanceDelayMs);
+          } else {
+            hotspot.classList.add('visible');
+          }
+        }, fadeDurationMs + 120);
+
+        storyTimers.set(page, timers);
+      };
+
+      const playStoryVideo = (page) => {
+        if (pages[currentIndex] !== page) return;
+        const media = page.querySelector('[data-story-media]');
+        const imageName = page.dataset.image;
+        const video = page.querySelector('.story-video');
+        if (!media || !imageName || !video) {
+          nextPage();
+          return;
+        }
+        stopNarration();
+
+        const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
+        const videoPath = `${videoBasePath}${videoName}`;
+        checkVideoExists(videoPath, (exists) => {
+          if (pages[currentIndex] !== page) return;
+          if (!exists) {
+            nextPage();
+            return;
+          }
+          video.src = videoPath;
+          video.onended = () => {
+            triggerTransition();
+            nextPage();
+          };
+          media.classList.add('video-playing');
+          video.currentTime = 0;
+          video.play().catch(() => {
+            nextPage();
+          });
+        });
+      };
+
       const stopGame = (page) => {
         const key = page?.dataset.game;
         if (!key) return;
         const session = gameSessions.get(key);
         if (!session) return;
-        const attemptStop = (api) => {
-          if (!api || typeof api.stop !== 'function') return;
-          try {
-            const maybePromise = api.stop();
-            if (maybePromise && typeof maybePromise.then === 'function') {
-              maybePromise.catch(() => {});
-            }
-          } catch (error) {
-            /* ignore stop errors */
-          }
-        };
-        if (session.api) {
-          attemptStop(session.api);
-        } else if (session.apiPromise) {
-          session.apiPromise.then(attemptStop).catch(() => {});
-        }
-        if (session.host) {
-          session.mountedNodes = Array.from(session.host.childNodes);
-          if (session.mountedNodes.length) {
-            session.mountedNodes.forEach((node) => {
-              if (node.parentNode === session.host) {
-                session.host.removeChild(node);
-              }
-            });
-            session.detached = true;
-          }
+        if (session.timeoutId) clearTimeout(session.timeoutId);
+        if (session.statusEl?.parentNode) session.statusEl.parentNode.removeChild(session.statusEl);
+        if (session.api && typeof session.api.stop === 'function') {
+          try { session.api.stop(); } catch (error) { }
         }
       };
 
       const mountGameTemplate = async (host, templateId) => {
         const html = loadTemplate(templateId);
         if (!html) return null;
-        let scriptPromises = [];
-        try {
-          host.innerHTML = '';
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(html, 'text/html');
-          const fragment = document.createDocumentFragment();
-          const appendChildren = (parent) => {
-            if (!parent) return;
-            parent.childNodes.forEach((node) => {
-              if (node.nodeName === 'TITLE') return;
-              fragment.appendChild(node.cloneNode(true));
-            });
-          };
-          appendChildren(doc.head);
-          appendChildren(doc.body);
-          window.storyGameApi = null;
-          host.appendChild(fragment);
-          host.querySelectorAll('script').forEach((oldScript) => {
-            const newScript = document.createElement('script');
-            newScript.async = false;
-            Array.from(oldScript.attributes).forEach((attr) => {
-              newScript.setAttribute(attr.name, attr.value);
-            });
-            newScript.textContent = oldScript.textContent;
-            const promise = newScript.src
-              ? new Promise((resolve) => {
-                  newScript.addEventListener('load', resolve, { once: true });
-                  newScript.addEventListener('error', resolve, { once: true });
-                })
-              : Promise.resolve();
-            scriptPromises.push(promise);
-            oldScript.replaceWith(newScript);
+        host.innerHTML = '';
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const fragment = document.createDocumentFragment();
+        const appendChildren = (parent) => {
+          if (!parent) return;
+          parent.childNodes.forEach((node) => {
+            if (node.nodeName === 'TITLE') return;
+            fragment.appendChild(node.cloneNode(true));
           });
-        } catch (error) {
-          return null;
-        }
-        try {
-          await Promise.all(scriptPromises);
-        } catch (error) {
-          /* ignore script load failures */
-        }
+        };
+        appendChildren(doc.head);
+        appendChildren(doc.body);
+        window.storyGameApi = null;
+        host.appendChild(fragment);
+        const promises = [];
+        host.querySelectorAll('script').forEach((oldScript) => {
+          const newScript = document.createElement('script');
+          newScript.async = false;
+          Array.from(oldScript.attributes).forEach((attr) => newScript.setAttribute(attr.name, attr.value));
+          newScript.textContent = oldScript.textContent;
+          if (newScript.src) {
+            promises.push(new Promise((resolve) => {
+              newScript.addEventListener('load', resolve, { once: true });
+              newScript.addEventListener('error', resolve, { once: true });
+            }));
+          }
+          oldScript.replaceWith(newScript);
+        });
+        await Promise.all(promises);
         return window.storyGameApi || null;
       };
 
-      const loadGame = (key, page) => {
+      const loadGame = async (key, page) => {
         const host = page.querySelector('[data-game-host]');
         if (!host) return;
-
+        const templateId = gameTemplates[key];
+        if (!templateId) return;
         let session = gameSessions.get(key);
         if (!session) {
-          const templateId = gameTemplates[key];
-          if (!templateId) return;
-          const apiPromise = mountGameTemplate(host, templateId);
-          const mountedNodes = Array.from(host.childNodes);
-          session = { host, api: null, apiPromise, mountedNodes, detached: false };
+          session = { host, api: null, timeoutId: null, statusEl: null };
           gameSessions.set(key, session);
-        } else {
-          session.host = host;
-          if (!session.mountedNodes || !session.mountedNodes.length) {
-            session.mountedNodes = Array.from(host.childNodes);
-          }
-          if (session.detached && session.mountedNodes && session.mountedNodes.length) {
-            host.innerHTML = '';
-            session.mountedNodes.forEach((node) => {
-              host.appendChild(node);
-            });
-            session.detached = false;
-          }
+        }
+        session.host = host;
+        session.api = await mountGameTemplate(host, templateId);
+        if (pages[currentIndex] !== page) return;
+
+        if (session.api && typeof session.api.start === 'function') {
+          try { session.api.start(); } catch (error) { }
         }
 
-        const startGame = async () => {
-          try {
-            if (!session.api) {
-              session.api = await session.apiPromise;
-            }
-          } catch (error) {
-            return;
-          }
+        const status = document.createElement('div');
+        status.className = 'game-status';
+        session.statusEl = status;
+
+        const goNext = () => {
           if (pages[currentIndex] !== page) return;
-          const api = session.api;
-          if (!api || typeof api.start !== 'function') return;
-          window.requestAnimationFrame(() => {
-            try {
-              const maybePromise = api.start();
-              if (maybePromise && typeof maybePromise.then === 'function') {
-                maybePromise.catch(() => {});
-              }
-            } catch (error) {
-              /* ignore start errors */
-            }
-          });
+          triggerTransition();
+          nextPage();
         };
 
-        startGame();
+        if (!mode.requiresGameSuccess) {
+          status.textContent = 'Mini-game mode: free play. The story will continue shortly.';
+          host.appendChild(status);
+          session.timeoutId = setTimeout(goNext, gameSoftDurationMs);
+          return;
+        }
+
+        status.innerHTML = 'Samurai challenge: complete this mini-game. Click success only when the player truly performed the task.';
+        const successBtn = document.createElement('button');
+        successBtn.type = 'button';
+        successBtn.textContent = 'Mark challenge as complete';
+        successBtn.addEventListener('click', goNext);
+        status.appendChild(successBtn);
+        host.appendChild(status);
+
+        session.timeoutId = setTimeout(() => {
+          if (pages[currentIndex] !== page) return;
+          triggerTransition();
+          resetJourney();
+        }, gameHardDurationMs);
       };
 
       const showPage = (index) => {
         if (index < 0 || index >= pages.length) return;
         if (index === currentIndex) return;
-
         const previousPage = pages[currentIndex];
         if (previousPage) {
           previousPage.classList.remove('active');
           if (previousPage.dataset.type === 'story') {
             clearStoryTimers(previousPage);
             resetStoryMedia(previousPage);
+            stopNarration();
           }
           if (previousPage.dataset.type === 'game') {
             stopGame(previousPage);
-            triggerTransition();
           }
         }
 
         currentIndex = index;
         const page = pages[currentIndex];
-        if (!page) return;
         page.classList.add('active');
-
-        if (page.dataset.type === 'story') {
-          setupStoryPage(page);
-        }
-        if (page.dataset.type === 'game') {
-          loadGame(page.dataset.game, page);
-        }
+        if (page.dataset.type === 'story') setupStoryPage(page);
+        if (page.dataset.type === 'game') loadGame(page.dataset.game, page);
       };
 
       const nextPage = () => {
@@ -561,33 +833,33 @@
         showPage(nextIndex);
       };
 
-      if (nextButton) {
-        nextButton.addEventListener('click', () => {
-          nextPage();
+      modeButtons.forEach((button) => {
+        const preview = button.dataset.preview;
+        button.addEventListener('mouseenter', () => {
+          if (preview && modePreviewImage) modePreviewImage.src = preview;
         });
+        button.addEventListener('focus', () => {
+          if (preview && modePreviewImage) modePreviewImage.src = preview;
+        });
+        button.addEventListener('click', () => {
+          const chosen = button.dataset.mode;
+          mode = MODES[chosen] || MODES.story;
+          modeButtons.forEach((b) => b.classList.toggle('active', b === button));
+          modeScreen.style.display = 'none';
+          resetJourney();
+        });
+      });
+
+      if (nextButton) {
+        nextButton.addEventListener('click', nextPage);
       }
 
       const requestFullscreen = async () => {
-        if (document.fullscreenElement) {
-          await document.exitFullscreen();
-          return;
-        }
-        const root = document.documentElement;
-        const method = root.requestFullscreen || root.webkitRequestFullscreen || root.msRequestFullscreen;
-        if (method) {
-          try {
-            await method.call(root);
-          } catch (error) {
-            /* ignore fullscreen failures */
-          }
-        }
+        if (document.fullscreenElement) return document.exitFullscreen();
+        return document.documentElement.requestFullscreen?.();
       };
 
-      if (fullscreenButton) {
-        fullscreenButton.addEventListener('click', () => {
-          requestFullscreen();
-        });
-      }
+      if (fullscreenButton) fullscreenButton.addEventListener('click', () => requestFullscreen().catch(() => {}));
 
       const updateFullscreenLabel = () => {
         if (!fullscreenButton) return;
@@ -595,14 +867,12 @@
       };
 
       document.addEventListener('fullscreenchange', updateFullscreenLabel);
-
       document.addEventListener('keydown', (event) => {
-        if (event.key === 'ArrowRight' || event.key === ' ') {
+        if ((event.key === 'ArrowRight' || event.key === ' ') && !mode.autoStoryAdvance) {
           nextPage();
         }
       });
 
-      setupStoryPage(pages[currentIndex]);
       updateFullscreenLabel();
     });
   </script>


### PR DESCRIPTION
### Motivation
- Introduce selectable play modes (Story / Autonomous / Samurai) and richer story presentation with narration and interactive hotspots to make the Samuraistory experience more immersive and configurable. 
- Improve game lifecycle handling and media transitions so mini-games, narration, and scene transitions behave predictably across modes.

### Description
- Add UI and styles for a mode chooser (`#modeScreen`, `.mode-panel`, `.mode-button`) and visual polish including vignette, overlays, and hotspot styles (`.story-vignette`, `.story-overlay`, `.hotspot`).
- Extend story page markup with new data attributes (`data-audio`, `data-text`, `data-hotspot-x`, `data-hotspot-y`) and insert overlay, vignette and hotspot elements into each story page in the HTML.
- Implement mode state and behavior in script via `MODES`, mode buttons and `resetJourney`, and change navigation to respect `mode.autoStoryAdvance` and `mode.requiresGameSuccess` logic.
- Add narration and overlay flow in `setupStoryPage` using `Audio`, show/hide hotspot after narration, implement hotspot dwell/click advancement, implement `playStoryVideo` with `checkVideoExists`, and add `stopNarration`/`resetStoryMedia` cleanup.
- Rework game mounting and management to `mountGameTemplate` (async script injection), `loadGame` (async) and `stopGame`, introduce per-game `gameSessions` with status UI and timers, and add soft/hard durations with a manual success button for `samurai` mode.
- Misc fixes and polish including removing `loop` from video tags, adjusting video load/play timeouts, centralizing timer cleanup, hiding the `nextButton` by default, and tuning fullscreen and keyboard handling to respect modes.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e387c429ec8325bf7df0ef72d9a7a0)