### PR TITLE
Add Eyegaze landing UI, modes, hotspots and samurai challenge flow

### DIFF
--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -3,27 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Samurai Story Journey</title>
+  <title>Eyegaze Samurai Story</title>
   <style>
     :root {
       color-scheme: dark;
-      font-family: "Helvetica Neue", Arial, system-ui, sans-serif;
+      font-family: "Trebuchet MS", "Segoe UI", system-ui, sans-serif;
     }
 
-    * {
-      box-sizing: border-box;
-    }
+    * { box-sizing: border-box; }
 
-    html,
-    body {
+    html, body {
       margin: 0;
       height: 100%;
-    }
-
-    body {
-      background: #08090c;
-      color: #f9fafb;
+      background: #050508;
       overflow: hidden;
+      color: #f5f5f5;
     }
 
     #app {
@@ -31,6 +25,7 @@
       width: 100vw;
       height: 100vh;
       overflow: hidden;
+      background: radial-gradient(circle at 50% 12%, #242837 0%, #11141f 36%, #07090e 68%, #030304 100%);
     }
 
     .page {
@@ -39,351 +34,594 @@
       display: none;
     }
 
-    .page.active {
+    .page.active { display: flex; }
+
+    .landing-page {
+      align-items: center;
+      justify-content: center;
+      padding: clamp(12px, 2.5vw, 36px);
+    }
+
+    .landing-shell {
+      width: min(1200px, 94vw);
+      height: min(760px, 92vh);
+      border-radius: 20px;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      background:
+        linear-gradient(150deg, rgba(40, 51, 77, 0.38), rgba(8, 9, 15, 0.95)),
+        url('../../images/samurai/lampbg.png') center / cover no-repeat;
+      display: grid;
+      grid-template-columns: 1.05fr 1fr;
+      gap: clamp(12px, 2vw, 28px);
+      box-shadow: 0 20px 80px rgba(0, 0, 0, 0.65);
+      overflow: hidden;
+      backdrop-filter: blur(1px);
+    }
+
+    .menu-panel {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 14px;
+      padding: clamp(20px, 3.6vw, 42px);
+      background: linear-gradient(100deg, rgba(6, 7, 12, 0.88), rgba(10, 14, 24, 0.58));
+    }
+
+    .landing-title {
+      margin: 0;
+      line-height: 1.04;
+      font-size: clamp(30px, 5.8vw, 58px);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      text-shadow: 0 2px 18px rgba(0, 0, 0, 0.55);
+    }
+
+    .landing-subtitle {
+      margin: 6px 0 12px;
+      color: rgba(238, 241, 255, 0.84);
+      max-width: 44ch;
+      font-size: clamp(13px, 1.5vw, 17px);
+      line-height: 1.45;
+    }
+
+    .mode-button {
+      border: 1px solid rgba(240, 245, 255, 0.33);
+      background: linear-gradient(120deg, rgba(26, 32, 44, 0.92), rgba(8, 12, 20, 0.92));
+      color: #f6f6ff;
+      border-radius: 12px;
+      text-align: left;
+      padding: 16px 18px;
+      cursor: pointer;
+      transition: transform .16s ease, box-shadow .18s ease, border-color .18s ease;
+    }
+
+    .mode-button:hover,
+    .mode-button:focus-visible,
+    .mode-button.selected {
+      transform: translateY(-1px) scale(1.01);
+      box-shadow: 0 10px 26px rgba(34, 138, 255, 0.22);
+      border-color: rgba(111, 180, 255, 0.9);
+      outline: none;
+    }
+
+    .mode-button strong {
+      display: block;
+      font-size: clamp(16px, 2vw, 20px);
+      letter-spacing: .03em;
+      text-transform: uppercase;
+      margin-bottom: 4px;
+    }
+
+    .mode-button span {
+      color: rgba(229, 234, 252, 0.9);
+      font-size: clamp(12px, 1.25vw, 14px);
+      line-height: 1.35;
+    }
+
+    .hero-panel {
+      position: relative;
       display: flex;
       align-items: center;
       justify-content: center;
+      padding: clamp(14px, 2.2vw, 28px);
+      background: linear-gradient(180deg, rgba(8, 10, 16, 0.18), rgba(8, 10, 16, 0.8));
+    }
+
+    .hero-preview {
+      width: min(100%, 480px);
+      max-height: 85%;
+      border-radius: 14px;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      object-fit: cover;
+      box-shadow: 0 22px 58px rgba(0,0,0,0.55);
+      transition: opacity .34s ease;
+      background: #06080d;
+    }
+
+    .hero-label {
+      position: absolute;
+      left: 18px;
+      right: 18px;
+      bottom: 18px;
+      padding: 10px 14px;
+      border-radius: 10px;
+      background: rgba(6, 10, 20, 0.74);
+      border: 1px solid rgba(255,255,255,0.2);
+      font-size: clamp(13px, 1.4vw, 16px);
+      letter-spacing: .02em;
+      text-align: center;
     }
 
     .story-page {
-      background: radial-gradient(circle at top, rgba(59, 130, 246, 0.25), transparent 60%),
-                  radial-gradient(circle at bottom, rgba(249, 115, 22, 0.15), transparent 70%),
-                  #07080b;
-      padding: clamp(16px, 4vw, 48px);
+      align-items: center;
+      justify-content: center;
+      padding: clamp(10px, 2vw, 24px);
+      background: radial-gradient(circle at top, rgba(89, 140, 255, 0.18), transparent 50%), #05060a;
     }
 
     .story-media {
       position: relative;
-      max-width: min(92vw, 1200px);
-      max-height: min(86vh, 760px);
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: #000;
-      border-radius: 12px;
+      width: min(94vw, 1240px);
+      height: min(92vh, 760px);
+      border-radius: 14px;
       overflow: hidden;
-      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+      background: #000;
+      box-shadow: 0 16px 48px rgba(0,0,0,0.56);
+    }
+
+    .story-image, .story-video {
+      width: 100%; height: 100%; object-fit: contain; background: #000;
     }
 
     .story-image {
-      display: block;
-      max-width: 100%;
-      max-height: 100%;
-      width: auto;
-      height: auto;
-      filter: grayscale(100%) contrast(1.2) brightness(0.95);
+      filter: grayscale(100%) contrast(1.18) brightness(.92);
       animation: colorFadeIn 4s ease-in-out forwards;
-      transition: filter 0.3s ease, opacity 0.8s ease-in-out;
-      opacity: 1;
+      transition: opacity .9s ease;
+      display: block;
     }
 
+    .story-media.video-playing .story-image { opacity: 0; }
+
     .story-video {
-      position: absolute;
-      inset: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
-      opacity: 0;
+      position: absolute; inset: 0;
       display: none;
-      transition: opacity 1.2s ease-in-out;
-      z-index: 2;
+      opacity: 0;
+      transition: opacity .6s ease;
     }
 
     .story-media.video-playing .story-video {
-      opacity: 1;
       display: block;
+      opacity: 1;
     }
 
-    .story-media.video-playing .story-image {
+    .story-caption {
+      position: absolute;
+      left: 50%;
+      bottom: 18px;
+      transform: translateX(-50%);
+      width: min(92%, 960px);
+      background: linear-gradient(170deg, rgba(8,10,16,.88), rgba(8,14,26,.82));
+      border: 1px solid rgba(255,255,255,.28);
+      border-radius: 12px;
+      padding: 12px 16px;
+      font-size: clamp(20px, 2.7vw, 34px);
+      font-family: Georgia, "Times New Roman", serif;
+      text-align: center;
+      letter-spacing: .02em;
+      line-height: 1.24;
       opacity: 0;
+      transition: opacity .4s ease;
+      z-index: 6;
     }
 
-    @keyframes colorFadeIn {
-      0% {
-        filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      }
-      20% {
-        filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      }
-      100% {
-        filter: grayscale(0%) contrast(1) brightness(1);
-      }
+    .story-caption.show { opacity: 1; }
+
+    .gaze-hotspot {
+      position: absolute;
+      width: clamp(78px, 11vw, 132px);
+      height: clamp(78px, 11vw, 132px);
+      border-radius: 50%;
+      border: 2px solid rgba(130, 203, 255, 0.75);
+      background: radial-gradient(circle, rgba(66, 153, 225, 0.28), rgba(66, 153, 225, 0));
+      z-index: 7;
+      opacity: 0;
+      pointer-events: none;
+      transform: translate(-50%, -50%);
+      transition: opacity .2s ease, transform .2s ease;
     }
 
-    .page.game-page {
+    .gaze-hotspot.show {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .gaze-hotspot.focused {
+      transform: translate(-50%, -50%) scale(1.08);
+      border-color: rgba(177, 232, 255, 0.95);
+    }
+
+    .hotspot-progress {
+      position: absolute;
+      left: 50%; top: 50%;
+      width: 68%; height: 68%;
+      transform: translate(-50%, -50%);
+      border-radius: 50%;
+      background: conic-gradient(rgba(125, 214, 255, .92) calc(var(--progress, 0) * 1%), rgba(255,255,255,.08) 0);
+      mask: radial-gradient(circle, transparent 58%, #000 61%);
+    }
+
+    .game-page {
       background: #000;
       padding: 0;
+      align-items: stretch;
+      justify-content: stretch;
     }
 
-    .game-frame {
-      width: 100%;
-      height: 100%;
-      display: block;
-      background: #000;
-      position: relative;
-      overflow: hidden;
-    }
+    .game-frame { width: 100%; height: 100%; overflow: hidden; }
 
-    .next-button {
+    .game-challenge {
       position: fixed;
-      bottom: 24px;
-      right: 24px;
-      padding: 14px 26px;
-      border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      background: rgba(15, 23, 42, 0.85);
-      color: #f8fafc;
-      font-size: 16px;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      cursor: pointer;
-      z-index: 20;
-      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      left: 50%; top: 18px;
+      transform: translateX(-50%);
+      z-index: 40;
+      min-width: min(660px, 90vw);
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 1px solid rgba(255,255,255,.24);
+      background: rgba(5, 8, 16, .84);
+      text-align: center;
+      font-size: clamp(13px, 1.5vw, 17px);
+      line-height: 1.38;
+      display: none;
     }
 
-    .next-button:hover,
-    .next-button:focus-visible {
-      transform: translateY(-2px);
-      background: rgba(30, 41, 59, 0.95);
-      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
-      outline: none;
-    }
+    .game-challenge.show { display: block; }
 
-    .fullscreen-button {
+    .control-button {
       position: fixed;
-      top: 24px;
-      right: 24px;
-      padding: 12px 20px;
+      right: 20px;
       border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      background: rgba(15, 23, 42, 0.75);
+      border: 1px solid rgba(255,255,255,.35);
+      background: rgba(11, 19, 36, .84);
       color: #f8fafc;
-      font-size: 14px;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
+      padding: 10px 18px;
       cursor: pointer;
-      z-index: 20;
-      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      z-index: 45;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      font-size: 13px;
+      font-weight: 700;
     }
 
-    .fullscreen-button:hover,
-    .fullscreen-button:focus-visible {
-      transform: translateY(-2px);
-      background: rgba(30, 41, 59, 0.95);
-      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
-      outline: none;
-    }
+    .control-button:hover, .control-button:focus-visible { outline: none; background: rgba(20,33,60,.95); }
+
+    #nextButton { bottom: 20px; }
+    #fullscreenButton { top: 20px; }
 
     .transition-overlay {
       position: fixed;
       inset: 0;
-      background: #050505;
       opacity: 0;
       pointer-events: none;
-      z-index: 30;
+      background: radial-gradient(circle at center, rgba(13,20,40,.7), rgba(0,0,0,.94));
+      z-index: 50;
     }
 
-    .transition-overlay.active {
-      animation: sceneFade 900ms ease-in-out forwards;
+    .transition-overlay.active { animation: sceneFade .8s ease-in-out forwards; }
+
+    @keyframes colorFadeIn {
+      from { filter: grayscale(100%) contrast(1.18) brightness(.92); }
+      to { filter: grayscale(0%) contrast(1) brightness(1); }
     }
 
     @keyframes sceneFade {
       0% { opacity: 0; }
-      40% { opacity: 0.85; }
+      45% { opacity: .95; }
       100% { opacity: 0; }
     }
 
-    :fullscreen .story-page {
-      padding: 0;
-    }
-
-    :fullscreen .story-media {
-      max-width: 100vw;
-      max-height: 100vh;
-      border-radius: 0;
+    @media (max-width: 900px) {
+      .landing-shell { grid-template-columns: 1fr; }
+      .hero-panel { min-height: 32vh; }
     }
   </style>
 </head>
 <body>
   <div id="app">
-    <section class="page story-page active" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn.">
-      <div class="story-media" data-story-media>
-        <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+    <section id="landingPage" class="page landing-page active" data-type="landing">
+      <div class="landing-shell">
+        <div class="menu-panel">
+          <h1 class="landing-title">Eyegaze Samurai</h1>
+          <p class="landing-subtitle">Choose your path. Each mode changes progression rules just like changing character style in a game menu.</p>
+          <button class="mode-button" data-mode="story" data-label="Story Mode" data-hero="../../images/samuraikata/paysagejapon.jpg">
+            <strong>Story Mode</strong>
+            <span>Automatic pacing. Narration and scenes progress by themselves. Mini games are non-blocking.</span>
+          </button>
+          <button class="mode-button" data-mode="autonomous" data-label="Autonomous Advancer" data-hero="../../images/samuraikata/maitrechi.jpg">
+            <strong>Autonomous Advancer</strong>
+            <span>User advances pages manually. Mini games stay free-play with no fail state.</span>
+          </button>
+          <button class="mode-button" data-mode="samurai" data-label="Samurai" data-hero="../../images/samuraikata/katanafleurs.jpg">
+            <strong>Samurai</strong>
+            <span>User advances pages and must complete game challenge checks. If failed, the journey resets.</span>
+          </button>
+        </div>
+        <div class="hero-panel">
+          <img id="heroPreview" class="hero-preview" src="../../images/samuraikata/paysagejapon.jpg" alt="Eyegaze Samurai preview" />
+          <div id="heroLabel" class="hero-label">Preview: Story Mode</div>
+        </div>
       </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere.">
+    <section class="page story-page" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn." data-text="At dawn, the young samurai opens his eyes and listens to the wind." data-audio="../../songs/samurai/samuraisong1.mp3" data-hotspot="82,78">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" muted playsinline></video>
+        <div class="story-caption" data-caption></div>
+        <div class="gaze-hotspot" data-hotspot-node><div class="hotspot-progress"></div></div>
       </div>
     </section>
 
-    <section class="page game-page" data-type="game" data-game="cherry">
-      <div class="game-frame" data-game-host></div>
-    </section>
-
-    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy.">
+    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere." data-text="Chi gathers like water in his palms, bright and alive." data-audio="../../songs/samurai/samuraisong2.mp3" data-hotspot="18,64">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" muted playsinline></video>
+        <div class="story-caption" data-caption></div>
+        <div class="gaze-hotspot" data-hotspot-node><div class="hotspot-progress"></div></div>
       </div>
     </section>
 
-    <section class="page game-page" data-type="game" data-game="meditation">
-      <div class="game-frame" data-game-host></div>
-    </section>
+    <section class="page game-page" data-type="game" data-game="cherry"><div class="game-frame" data-game-host></div></section>
 
-    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky.">
+    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy." data-text="The old master says: patience cuts deeper than steel." data-audio="../../songs/samurai/samuraisong3.mp3" data-hotspot="82,22">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" muted playsinline></video>
+        <div class="story-caption" data-caption></div>
+        <div class="gaze-hotspot" data-hotspot-node><div class="hotspot-progress"></div></div>
       </div>
     </section>
 
-    <section class="page game-page" data-type="game" data-game="lamp">
-      <div class="game-frame" data-game-host></div>
-    </section>
+    <section class="page game-page" data-type="game" data-game="meditation"><div class="game-frame" data-game-host></div></section>
 
-    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms.">
+    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky." data-text="Lanterns rise above the village, carrying promises into the night." data-audio="../../songs/samurai/samuraisong4.mp3" data-hotspot="22,20">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" muted playsinline></video>
+        <div class="story-caption" data-caption></div>
+        <div class="gaze-hotspot" data-hotspot-node><div class="hotspot-progress"></div></div>
+      </div>
+    </section>
+
+    <section class="page game-page" data-type="game" data-game="lamp"><div class="game-frame" data-game-host></div></section>
+
+    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms." data-text="Blade and spirit become one. The journey can begin again." data-audio="../../songs/samurai/cherryblossomsong2.mp3" data-hotspot="50,54">
+      <div class="story-media" data-story-media>
+        <img class="story-image" alt="" />
+        <video class="story-video" muted playsinline></video>
+        <div class="story-caption" data-caption></div>
+        <div class="gaze-hotspot" data-hotspot-node><div class="hotspot-progress"></div></div>
       </div>
     </section>
   </div>
 
-  <button id="nextButton" class="next-button" type="button">Next</button>
-  <button id="fullscreenButton" class="fullscreen-button" type="button">Fullscreen</button>
+  <button id="nextButton" class="control-button" type="button" hidden>Next</button>
+  <button id="fullscreenButton" class="control-button" type="button">Fullscreen</button>
+  <div id="gameChallenge" class="game-challenge" aria-live="polite"></div>
   <div id="transitionOverlay" class="transition-overlay" aria-hidden="true"></div>
 
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const pages = Array.from(document.querySelectorAll('.page'));
+      const landingPage = document.getElementById('landingPage');
+      const modeButtons = Array.from(document.querySelectorAll('.mode-button'));
+      const heroPreview = document.getElementById('heroPreview');
+      const heroLabel = document.getElementById('heroLabel');
       const nextButton = document.getElementById('nextButton');
       const fullscreenButton = document.getElementById('fullscreenButton');
       const transitionOverlay = document.getElementById('transitionOverlay');
+      const gameChallenge = document.getElementById('gameChallenge');
+
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
-      const fadeDurationMs = 4000;
+
+      const MODE_CONFIG = {
+        story: { autoStoryAdvance: true, manualStoryAdvance: false, manualGameAdvance: false, enforceGameChallenge: false },
+        autonomous: { autoStoryAdvance: false, manualStoryAdvance: true, manualGameAdvance: true, enforceGameChallenge: false },
+        samurai: { autoStoryAdvance: false, manualStoryAdvance: true, manualGameAdvance: true, enforceGameChallenge: true }
+      };
+
+      const SETTINGS = {
+        colorFadeMs: 4000,
+        captionDelayMs: 3600,
+        autoAfterCaptionMs: 3500,
+        hotspotDwellMs: 1200,
+        fallbackVideoWaitMs: 5200,
+        freeplayGameAutoMs: 12000,
+        samuraiChallengeMaxMs: 14000,
+        samuraiChallengeDwellMs: 1800
+      };
+
+      let selectedMode = 'story';
       let currentIndex = 0;
+      let currentAudio = null;
 
       const storyTimers = new WeakMap();
       const gameSessions = new Map();
+      const gameState = { challengeTimer: null, failTimer: null, dwellTimer: null, running: false, complete: false };
 
       const triggerTransition = () => {
-        if (!transitionOverlay) return;
         transitionOverlay.classList.remove('active');
         void transitionOverlay.offsetHeight;
         transitionOverlay.classList.add('active');
       };
 
+      const clearAudio = () => {
+        if (!currentAudio) return;
+        currentAudio.pause();
+        currentAudio.currentTime = 0;
+        currentAudio = null;
+      };
+
       const clearStoryTimers = (page) => {
         const timers = storyTimers.get(page);
         if (!timers) return;
-        if (timers.videoTimeout) {
-          clearTimeout(timers.videoTimeout);
-        }
-        if (timers.checkTimeout) {
-          clearTimeout(timers.checkTimeout);
+        Object.values(timers).forEach((id) => id && clearTimeout(id));
+        if (timers.hotspotNode) {
+          timers.hotspotNode.removeEventListener('mouseenter', timers.onEnter || (() => {}));
+          timers.hotspotNode.removeEventListener('mouseleave', timers.onLeave || (() => {}));
         }
         storyTimers.delete(page);
       };
 
-      const resetStoryMedia = (page) => {
+      const checkVideoExists = (path) => new Promise((resolve) => {
+        const tester = document.createElement('video');
+        let done = false;
+        const finish = (ok) => {
+          if (done) return;
+          done = true;
+          tester.removeAttribute('src');
+          tester.load();
+          resolve(ok);
+        };
+        tester.addEventListener('loadeddata', () => finish(true), { once: true });
+        tester.addEventListener('error', () => finish(false), { once: true });
+        tester.preload = 'metadata';
+        tester.src = path;
+        tester.load();
+        setTimeout(() => finish(false), 1200);
+      });
+
+      const hideChallenge = () => {
+        gameChallenge.classList.remove('show');
+        gameChallenge.textContent = '';
+      };
+
+      const clearGameChallengeTimers = () => {
+        ['challengeTimer', 'failTimer', 'dwellTimer'].forEach((k) => {
+          if (gameState[k]) clearTimeout(gameState[k]);
+          gameState[k] = null;
+        });
+      };
+
+      const resetStory = () => {
+        showPage(1);
+      };
+
+      const setupStoryPage = async (page) => {
+        clearStoryTimers(page);
+        clearAudio();
+
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
         const video = page.querySelector('.story-video');
-        if (!media || !image || !video) return;
-        media.classList.remove('video-playing');
-        video.pause();
-        video.removeAttribute('src');
-        video.load();
+        const caption = page.querySelector('[data-caption]');
+        const hotspot = page.querySelector('[data-hotspot-node]');
+        if (!media || !image || !video || !caption || !hotspot) return;
+
+        const imageName = page.dataset.image;
+        image.src = `${imageBasePath}${imageName}`;
+        image.alt = page.dataset.alt || '';
         image.style.animation = 'none';
         void image.offsetHeight;
-        image.style.animation = 'colorFadeIn 4s ease-in-out forwards';
-      };
+        image.style.animation = `colorFadeIn ${SETTINGS.colorFadeMs}ms ease-in-out forwards`;
 
-      const checkVideoExists = (path, callback) => {
-        const tester = document.createElement('video');
-        let settled = false;
-        const clean = () => {
-          tester.removeEventListener('loadeddata', onLoad);
-          tester.removeEventListener('error', onError);
-        };
-        const onLoad = () => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(true);
-        };
-        const onError = () => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(false);
-        };
-        tester.addEventListener('loadeddata', onLoad);
-        tester.addEventListener('error', onError);
-        tester.src = path;
-        tester.preload = 'metadata';
-        tester.load();
-        const timeoutId = setTimeout(() => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(false);
-        }, 1200);
-        return timeoutId;
-      };
+        caption.textContent = '';
+        caption.classList.remove('show');
+        hotspot.classList.remove('show', 'focused');
+        hotspot.style.setProperty('--progress', 0);
 
-      const setupStoryPage = (page) => {
-        clearStoryTimers(page);
-        const imageName = page.dataset.image;
-        const altText = page.dataset.alt || '';
-        const media = page.querySelector('[data-story-media]');
-        const image = page.querySelector('.story-image');
-        const video = page.querySelector('.story-video');
-        if (!imageName || !media || !image || !video) return;
-
-        resetStoryMedia(page);
-        image.src = `${imageBasePath}${imageName}`;
-        image.alt = altText;
         media.classList.remove('video-playing');
+        video.pause();
+        video.onended = null;
+        video.removeAttribute('src');
+        video.load();
+
+        const timers = {};
+        storyTimers.set(page, timers);
+
+        const text = page.dataset.text || '';
+        const audioSrc = page.dataset.audio;
+        const spot = (page.dataset.hotspot || '85,80').split(',').map((v) => Number(v.trim()));
+        hotspot.style.left = `${Math.max(5, Math.min(95, spot[0] || 85))}%`;
+        hotspot.style.top = `${Math.max(5, Math.min(95, spot[1] || 80))}%`;
+
+        timers.captionDelay = setTimeout(() => {
+          if (pages[currentIndex] !== page) return;
+          caption.textContent = text;
+          caption.classList.add('show');
+          if (audioSrc) {
+            currentAudio = new Audio(audioSrc);
+            currentAudio.play().catch(() => {});
+          }
+        }, SETTINGS.captionDelayMs);
 
         const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
         const videoPath = `${videoBasePath}${videoName}`;
+        const hasVideo = await checkVideoExists(videoPath);
+        if (pages[currentIndex] !== page) return;
 
-        const timers = { videoTimeout: null, checkTimeout: null };
-        timers.checkTimeout = checkVideoExists(videoPath, (exists) => {
-          if (!exists) return;
+        const startVideo = () => {
+          if (pages[currentIndex] !== page) return;
+          clearAudio();
+          caption.classList.remove('show');
+          hotspot.classList.remove('show', 'focused');
+          hotspot.style.setProperty('--progress', 0);
+          if (!hasVideo) {
+            triggerTransition();
+            setTimeout(nextPage, 360);
+            return;
+          }
           video.src = videoPath;
           video.load();
-          timers.videoTimeout = setTimeout(() => {
+          media.classList.add('video-playing');
+          video.play().catch(() => {});
+          video.onended = () => {
+            triggerTransition();
+            setTimeout(nextPage, 420);
+          };
+          timers.videoFallback = setTimeout(() => {
             if (pages[currentIndex] !== page) return;
-            media.classList.add('video-playing');
-            const playPromise = video.play();
-            if (playPromise && typeof playPromise.catch === 'function') {
-              playPromise.catch(() => {});
-            }
-          }, fadeDurationMs + 300);
-        });
-        storyTimers.set(page, timers);
+            triggerTransition();
+            setTimeout(nextPage, 420);
+          }, SETTINGS.fallbackVideoWaitMs);
+        };
+
+        if (MODE_CONFIG[selectedMode].autoStoryAdvance) {
+          timers.autoAdvance = setTimeout(startVideo, SETTINGS.captionDelayMs + SETTINGS.autoAfterCaptionMs);
+        } else {
+          hotspot.classList.add('show');
+          const holdStart = () => {
+            if (pages[currentIndex] !== page) return;
+            hotspot.classList.add('focused');
+            const begin = performance.now();
+            const tick = () => {
+              if (!hotspot.classList.contains('focused')) return;
+              const elapsed = performance.now() - begin;
+              const pct = Math.min(100, (elapsed / SETTINGS.hotspotDwellMs) * 100);
+              hotspot.style.setProperty('--progress', pct.toFixed(2));
+              if (elapsed >= SETTINGS.hotspotDwellMs) {
+                startVideo();
+                return;
+              }
+              timers.progressRaf = requestAnimationFrame(tick);
+            };
+            timers.progressRaf = requestAnimationFrame(tick);
+          };
+          const holdCancel = () => {
+            hotspot.classList.remove('focused');
+            hotspot.style.setProperty('--progress', 0);
+            if (timers.progressRaf) cancelAnimationFrame(timers.progressRaf);
+          };
+          timers.onEnter = holdStart;
+          timers.onLeave = holdCancel;
+          timers.hotspotNode = hotspot;
+          hotspot.addEventListener('mouseenter', holdStart);
+          hotspot.addEventListener('mouseleave', holdCancel);
+        }
       };
 
-      const gameTemplates = {
-        cherry: 'tpl-cherryblossom',
-        meditation: 'tpl-meditation',
-        lamp: 'tpl-lamp'
-      };
-
+      const gameTemplates = { cherry: 'tpl-cherryblossom', meditation: 'tpl-meditation', lamp: 'tpl-lamp' };
       const templateCache = {};
       const loadTemplate = (id) => {
         if (!templateCache[id]) {
@@ -393,217 +631,235 @@
         return templateCache[id];
       };
 
+      const mountGameTemplate = async (host, templateId) => {
+        const html = loadTemplate(templateId);
+        if (!html) return null;
+        host.innerHTML = '';
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const fragment = document.createDocumentFragment();
+        const appendChildren = (parent) => parent && parent.childNodes.forEach((node) => {
+          if (node.nodeName !== 'TITLE') fragment.appendChild(node.cloneNode(true));
+        });
+        appendChildren(doc.head);
+        appendChildren(doc.body);
+        window.storyGameApi = null;
+        host.appendChild(fragment);
+        const scriptPromises = [];
+        host.querySelectorAll('script').forEach((oldScript) => {
+          const newScript = document.createElement('script');
+          newScript.async = false;
+          Array.from(oldScript.attributes).forEach((attr) => newScript.setAttribute(attr.name, attr.value));
+          newScript.textContent = oldScript.textContent;
+          if (newScript.src) {
+            scriptPromises.push(new Promise((resolve) => {
+              newScript.addEventListener('load', resolve, { once: true });
+              newScript.addEventListener('error', resolve, { once: true });
+            }));
+          }
+          oldScript.replaceWith(newScript);
+        });
+        await Promise.allSettled(scriptPromises);
+        return window.storyGameApi || null;
+      };
+
       const stopGame = (page) => {
         const key = page?.dataset.game;
         if (!key) return;
         const session = gameSessions.get(key);
         if (!session) return;
-        const attemptStop = (api) => {
-          if (!api || typeof api.stop !== 'function') return;
-          try {
-            const maybePromise = api.stop();
-            if (maybePromise && typeof maybePromise.then === 'function') {
-              maybePromise.catch(() => {});
-            }
-          } catch (error) {
-            /* ignore stop errors */
-          }
-        };
-        if (session.api) {
-          attemptStop(session.api);
-        } else if (session.apiPromise) {
-          session.apiPromise.then(attemptStop).catch(() => {});
-        }
+        try { session.api?.stop?.(); } catch (_) {}
         if (session.host) {
           session.mountedNodes = Array.from(session.host.childNodes);
-          if (session.mountedNodes.length) {
-            session.mountedNodes.forEach((node) => {
-              if (node.parentNode === session.host) {
-                session.host.removeChild(node);
-              }
-            });
-            session.detached = true;
-          }
+          session.host.innerHTML = '';
+          session.detached = true;
         }
       };
 
-      const mountGameTemplate = async (host, templateId) => {
-        const html = loadTemplate(templateId);
-        if (!html) return null;
-        let scriptPromises = [];
-        try {
-          host.innerHTML = '';
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(html, 'text/html');
-          const fragment = document.createDocumentFragment();
-          const appendChildren = (parent) => {
-            if (!parent) return;
-            parent.childNodes.forEach((node) => {
-              if (node.nodeName === 'TITLE') return;
-              fragment.appendChild(node.cloneNode(true));
-            });
+      const runSamuraiChallenge = (onSuccess) => {
+        clearGameChallengeTimers();
+        gameState.running = true;
+        gameState.complete = false;
+        gameChallenge.innerHTML = 'Samurai Trial: hold your gaze on <strong>NEXT</strong> for 1.8 seconds within 14 seconds to continue.';
+        gameChallenge.classList.add('show');
+
+        const pointerEnter = () => {
+          const start = performance.now();
+          const animate = () => {
+            if (!gameState.running || gameState.complete) return;
+            const elapsed = performance.now() - start;
+            nextButton.style.setProperty('--ring', Math.min(100, (elapsed / SETTINGS.samuraiChallengeDwellMs) * 100));
+            if (elapsed >= SETTINGS.samuraiChallengeDwellMs) {
+              gameState.complete = true;
+              clearGameChallengeTimers();
+              gameChallenge.textContent = 'Challenge complete. Advance when ready.';
+              onSuccess();
+              return;
+            }
+            gameState.dwellTimer = requestAnimationFrame(animate);
           };
-          appendChildren(doc.head);
-          appendChildren(doc.body);
-          window.storyGameApi = null;
-          host.appendChild(fragment);
-          host.querySelectorAll('script').forEach((oldScript) => {
-            const newScript = document.createElement('script');
-            newScript.async = false;
-            Array.from(oldScript.attributes).forEach((attr) => {
-              newScript.setAttribute(attr.name, attr.value);
-            });
-            newScript.textContent = oldScript.textContent;
-            const promise = newScript.src
-              ? new Promise((resolve) => {
-                  newScript.addEventListener('load', resolve, { once: true });
-                  newScript.addEventListener('error', resolve, { once: true });
-                })
-              : Promise.resolve();
-            scriptPromises.push(promise);
-            oldScript.replaceWith(newScript);
-          });
-        } catch (error) {
-          return null;
-        }
-        try {
-          await Promise.all(scriptPromises);
-        } catch (error) {
-          /* ignore script load failures */
-        }
-        return window.storyGameApi || null;
-      };
-
-      const loadGame = (key, page) => {
-        const host = page.querySelector('[data-game-host]');
-        if (!host) return;
-
-        let session = gameSessions.get(key);
-        if (!session) {
-          const templateId = gameTemplates[key];
-          if (!templateId) return;
-          const apiPromise = mountGameTemplate(host, templateId);
-          const mountedNodes = Array.from(host.childNodes);
-          session = { host, api: null, apiPromise, mountedNodes, detached: false };
-          gameSessions.set(key, session);
-        } else {
-          session.host = host;
-          if (!session.mountedNodes || !session.mountedNodes.length) {
-            session.mountedNodes = Array.from(host.childNodes);
-          }
-          if (session.detached && session.mountedNodes && session.mountedNodes.length) {
-            host.innerHTML = '';
-            session.mountedNodes.forEach((node) => {
-              host.appendChild(node);
-            });
-            session.detached = false;
-          }
-        }
-
-        const startGame = async () => {
-          try {
-            if (!session.api) {
-              session.api = await session.apiPromise;
-            }
-          } catch (error) {
-            return;
-          }
-          if (pages[currentIndex] !== page) return;
-          const api = session.api;
-          if (!api || typeof api.start !== 'function') return;
-          window.requestAnimationFrame(() => {
-            try {
-              const maybePromise = api.start();
-              if (maybePromise && typeof maybePromise.then === 'function') {
-                maybePromise.catch(() => {});
-              }
-            } catch (error) {
-              /* ignore start errors */
-            }
-          });
+          gameState.dwellTimer = requestAnimationFrame(animate);
         };
 
-        startGame();
+        const pointerLeave = () => {
+          if (gameState.dwellTimer) cancelAnimationFrame(gameState.dwellTimer);
+          gameState.dwellTimer = null;
+          nextButton.style.removeProperty('--ring');
+        };
+
+        nextButton.addEventListener('mouseenter', pointerEnter);
+        nextButton.addEventListener('mouseleave', pointerLeave);
+
+        gameState.failTimer = setTimeout(() => {
+          nextButton.removeEventListener('mouseenter', pointerEnter);
+          nextButton.removeEventListener('mouseleave', pointerLeave);
+          if (gameState.complete) return;
+          gameChallenge.textContent = 'Challenge failed. The journey resets.';
+          setTimeout(() => {
+            hideChallenge();
+            showPage(1);
+          }, 1200);
+        }, SETTINGS.samuraiChallengeMaxMs);
+
+        gameState.challengeTimer = setInterval(() => {
+          if (!gameState.running || gameState.complete) return;
+          const remaining = Math.max(0, Math.ceil((SETTINGS.samuraiChallengeMaxMs - (Date.now() - (gameState.startAt || Date.now()))) / 1000));
+          gameChallenge.innerHTML = `Samurai Trial: hold your gaze on <strong>NEXT</strong> for 1.8 seconds. Time left: <strong>${remaining}s</strong>.`;
+        }, 250);
+        gameState.startAt = Date.now();
+      };
+
+      const loadGame = async (key, page) => {
+        const host = page.querySelector('[data-game-host]');
+        if (!host) return;
+        let session = gameSessions.get(key);
+        if (!session) {
+          const apiPromise = mountGameTemplate(host, gameTemplates[key]);
+          session = { host, api: null, apiPromise, mountedNodes: [], detached: false };
+          gameSessions.set(key, session);
+        } else if (session.detached && session.mountedNodes?.length) {
+          session.host = host;
+          host.innerHTML = '';
+          session.mountedNodes.forEach((node) => host.appendChild(node));
+          session.detached = false;
+        } else {
+          session.host = host;
+        }
+
+        try {
+          if (!session.api) session.api = await session.apiPromise;
+          session.api?.start?.();
+        } catch (_) {}
+
+        if (MODE_CONFIG[selectedMode].manualGameAdvance) {
+          nextButton.hidden = false;
+          if (MODE_CONFIG[selectedMode].enforceGameChallenge) {
+            nextButton.disabled = true;
+            runSamuraiChallenge(() => { nextButton.disabled = false; });
+          } else {
+            hideChallenge();
+            nextButton.disabled = false;
+          }
+        } else {
+          nextButton.hidden = true;
+          hideChallenge();
+          setTimeout(() => {
+            if (pages[currentIndex] === page) {
+              triggerTransition();
+              setTimeout(nextPage, 420);
+            }
+          }, SETTINGS.freeplayGameAutoMs);
+        }
       };
 
       const showPage = (index) => {
         if (index < 0 || index >= pages.length) return;
-        if (index === currentIndex) return;
-
-        const previousPage = pages[currentIndex];
-        if (previousPage) {
-          previousPage.classList.remove('active');
-          if (previousPage.dataset.type === 'story') {
-            clearStoryTimers(previousPage);
-            resetStoryMedia(previousPage);
-          }
-          if (previousPage.dataset.type === 'game') {
-            stopGame(previousPage);
-            triggerTransition();
-          }
+        const previous = pages[currentIndex];
+        if (previous) {
+          previous.classList.remove('active');
+          if (previous.dataset.type === 'story') clearStoryTimers(previous);
+          if (previous.dataset.type === 'game') stopGame(previous);
         }
+
+        clearAudio();
+        hideChallenge();
+        clearGameChallengeTimers();
 
         currentIndex = index;
         const page = pages[currentIndex];
         if (!page) return;
         page.classList.add('active');
 
+        nextButton.hidden = true;
+        nextButton.disabled = false;
+
         if (page.dataset.type === 'story') {
+          if (MODE_CONFIG[selectedMode].manualStoryAdvance) nextButton.hidden = true;
           setupStoryPage(page);
-        }
-        if (page.dataset.type === 'game') {
+        } else if (page.dataset.type === 'game') {
           loadGame(page.dataset.game, page);
         }
       };
 
       const nextPage = () => {
-        const nextIndex = (currentIndex + 1) % pages.length;
-        showPage(nextIndex);
+        const next = (currentIndex + 1) % pages.length;
+        triggerTransition();
+        setTimeout(() => showPage(next), 360);
       };
 
-      if (nextButton) {
-        nextButton.addEventListener('click', () => {
-          nextPage();
+      const startJourney = (mode) => {
+        selectedMode = mode;
+        currentIndex = 0;
+        pages.forEach((p) => p.classList.remove('active'));
+        landingPage.classList.remove('active');
+        showPage(1);
+      };
+
+      modeButtons.forEach((button) => {
+        const setPreview = () => {
+          heroPreview.style.opacity = '0.25';
+          const src = button.dataset.hero;
+          setTimeout(() => {
+            heroPreview.src = src;
+            heroLabel.textContent = `Preview: ${button.dataset.label}`;
+            heroPreview.style.opacity = '1';
+          }, 120);
+        };
+        button.addEventListener('mouseenter', setPreview);
+        button.addEventListener('focus', setPreview);
+        button.addEventListener('click', () => {
+          modeButtons.forEach((b) => b.classList.remove('selected'));
+          button.classList.add('selected');
+          setPreview();
+          startJourney(button.dataset.mode);
         });
-      }
+      });
+
+      nextButton.addEventListener('click', nextPage);
 
       const requestFullscreen = async () => {
-        if (document.fullscreenElement) {
-          await document.exitFullscreen();
-          return;
-        }
-        const root = document.documentElement;
-        const method = root.requestFullscreen || root.webkitRequestFullscreen || root.msRequestFullscreen;
-        if (method) {
-          try {
-            await method.call(root);
-          } catch (error) {
-            /* ignore fullscreen failures */
-          }
-        }
+        if (document.fullscreenElement) return document.exitFullscreen();
+        try { await document.documentElement.requestFullscreen(); } catch (_) {}
       };
 
-      if (fullscreenButton) {
-        fullscreenButton.addEventListener('click', () => {
-          requestFullscreen();
-        });
-      }
-
-      const updateFullscreenLabel = () => {
-        if (!fullscreenButton) return;
+      fullscreenButton.addEventListener('click', requestFullscreen);
+      document.addEventListener('fullscreenchange', () => {
         fullscreenButton.textContent = document.fullscreenElement ? 'Exit Fullscreen' : 'Fullscreen';
-      };
-
-      document.addEventListener('fullscreenchange', updateFullscreenLabel);
+      });
 
       document.addEventListener('keydown', (event) => {
-        if (event.key === 'ArrowRight' || event.key === ' ') {
+        if (event.key === 'Enter' && landingPage.classList.contains('active')) {
+          const selected = document.querySelector('.mode-button.selected') || modeButtons[0];
+          selected.click();
+          return;
+        }
+        if ((event.key === 'ArrowRight' || event.key === ' ') && !nextButton.hidden && !nextButton.disabled) {
+          event.preventDefault();
           nextPage();
         }
       });
 
-      setupStoryPage(pages[currentIndex]);
-      updateFullscreenLabel();
+      modeButtons[0].classList.add('selected');
     });
   </script>
 


### PR DESCRIPTION
### Motivation
- Provide an entry landing experience with selectable modes and preview to guide user progression choices.  
- Enrich story pages with captions, ambient audio, gaze hotspots and optional video playback for a more cinematic narrative.  
- Add game mounting lifecycle improvements and a gaze-based "Samurai" challenge to enforce interactive progression in certain modes.

### Description
- Rework styling and layout: update page title, fonts, color palette, add a `landing-shell` layout, hero preview, polished controls and responsive tweaks in CSS.  
- Introduce a landing page with mode buttons wired to a `MODE_CONFIG` table and `startJourney(mode)` to switch behavior between `story`, `autonomous`, and `samurai` modes.  
- Enhance story pages to support `data-text`, `data-audio`, `data-hotspot` and video fallbacks; add caption rendering, audio lifecycle with `clearAudio()`, and hotspot dwell-to-advance logic.  
- Improve media handling: async `checkVideoExists()` promise, color fade animation control, robust video fallback timers, and centralized `storyTimers` management.  
- Revamp game mounting and lifecycle: `mountGameTemplate()` parses and injects templates and scripts, `loadGame()` starts games and toggles `nextButton` visibility based on mode, and `stopGame()` now cleans host content.  
- Add a gaze-based samurai challenge (`runSamuraiChallenge`) that enforces a dwell-on-`Next` requirement with timers and failure reset behavior for the `samurai` mode.  
- Misc: transition overlay animation, keyboard interactions for starting mode selection and advancing, `nextButton` / `fullscreenButton` behavior updates and general timer/cleanup improvements.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e387c429ec8325bf7df0ef72d9a7a0)