### PR TITLE
Add landing menu, mode system, gaze interactions and game lifecycle refactor for Eyegaze Samurai

### DIFF
--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -31,15 +31,42 @@
       width: 100%;
       height: 100%;
       display: grid;
-      grid-template-rows: auto 1fr auto;
-      gap: 1.2vw;
+      grid-template-columns: minmax(280px, 32vw) 1fr;
+      gap: clamp(10px, 1.2vw, 18px);
       padding: clamp(10px, 1.6vw, 24px);
+    }
+
+    .menu-sidebar {
+      display: grid;
+      grid-template-rows: auto auto 1fr auto;
+      gap: 14px;
+      background: linear-gradient(180deg, rgba(8,10,18,.85), rgba(5,7,12,.96));
+      border: 1px solid rgba(255,255,255,.16);
+      border-radius: 18px;
+      padding: clamp(12px, 1.4vw, 20px);
+      box-shadow: 0 14px 40px rgba(0,0,0,.35);
+    }
+
+    .menu-title {
+      font-family: Georgia, serif;
+      color: var(--gold);
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      font-size: clamp(1.15rem, 1.7vw, 1.8rem);
+      margin: 0;
+    }
+
+    .menu-intro {
+      margin: 0;
+      line-height: 1.5;
+      color: rgba(245,248,255,.9);
+      font-size: clamp(.9rem, 1.05vw, 1rem);
     }
 
     .menu-row {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: clamp(10px, 1.2vw, 18px);
+      grid-template-columns: 1fr;
+      gap: 12px;
       align-items: stretch;
     }
 
@@ -51,7 +78,7 @@
       padding: clamp(14px, 2.1vw, 24px);
       text-align: left;
       cursor: pointer;
-      min-height: 110px;
+      min-height: 120px;
       transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
     }
 
@@ -85,6 +112,7 @@
       border-radius: 18px;
       border: 1px solid rgba(255,255,255,.16);
       background: #000;
+      min-height: 100%;
     }
 
     .menu-preview img {
@@ -121,9 +149,10 @@
     .menu-footer {
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: flex-end;
       gap: 14px;
-      padding: 10px 4px;
+      padding: 4px 0;
+      flex-wrap: wrap;
     }
 
     .loading-track {
@@ -143,8 +172,8 @@
     }
 
     .loading-label {
-      min-width: 200px;
-      text-align: right;
+      min-width: 140px;
+      text-align: left;
       font-size: .9rem;
       opacity: .9;
     }
@@ -173,6 +202,24 @@
         #06070b;
     }
 
+    body.playing {
+      cursor: none;
+    }
+
+    #chiCursor {
+      position: fixed;
+      width: 30px;
+      height: 30px;
+      border-radius: 50%;
+      pointer-events: none;
+      z-index: 120;
+      opacity: 0;
+      transform: translate(-50%, -50%);
+      background: radial-gradient(circle at 35% 30%, rgba(255,255,255,.7), rgba(72,183,255,.65) 42%, rgba(26,92,245,.5) 68%, rgba(12,30,120,.2) 100%);
+      box-shadow: 0 0 0 4px rgba(56,189,248,.2), 0 0 18px rgba(56,189,248,.9);
+      transition: opacity .2s ease;
+    }
+
     .story-media {
       position: relative;
       width: 100%;
@@ -194,7 +241,7 @@
       height: 100%;
       object-fit: cover;
       filter: grayscale(100%) contrast(1.2) brightness(.95);
-      transition: filter 2s ease, opacity .6s ease;
+      transition: filter 6s ease, opacity .6s ease;
       opacity: 1;
     }
 
@@ -324,9 +371,8 @@
     @keyframes sceneFade { 0% { opacity: 0; } 40% { opacity: .85; } 100% { opacity: 0; } }
 
     @media (max-width: 980px) {
-      .menu-row { grid-template-columns: 1fr; }
-      .menu-shell { grid-template-rows: auto 1fr auto auto; }
-      .menu-footer { flex-wrap: wrap; }
+      .menu-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
+      .menu-sidebar { grid-template-rows: auto auto auto auto; }
       .loading-label { min-width: 100%; text-align: left; }
     }
   </style>
@@ -335,11 +381,20 @@
   <div id="app">
     <section id="landingPage" class="page landing-page active" data-type="landing">
       <div class="menu-shell">
-        <div class="menu-row">
-          <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong>A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.</button>
-          <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong>You decide when to advance scenes, but mini-games remain relaxed and never block your journey.</button>
-          <button class="mode-button" data-mode="samurai" type="button"><strong>Samurai</strong>A demanding path: you control progression and must complete mini-game challenges to keep moving.</button>
-        </div>
+        <aside class="menu-sidebar">
+          <h2 class="menu-title">Eyegaze Samurai</h2>
+          <p class="menu-intro">Choose your path and enter the journey. The story pages, songs and videos are prepared before launch for smoother play.</p>
+          <div class="menu-row">
+            <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong>A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.</button>
+            <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong>You decide when to advance scenes, but mini-games remain relaxed and never block your journey.</button>
+            <button class="mode-button" data-mode="samurai" type="button"><strong>Samurai</strong>A demanding path: you control progression and must complete mini-game challenges to keep moving.</button>
+          </div>
+          <div class="menu-footer">
+            <div class="loading-track"><div id="loadingFill" class="loading-fill"></div></div>
+            <div id="loadingLabel" class="loading-label">Preparing assets… 0%</div>
+            <button id="startJourneyButton" class="start-button" type="button" disabled>Loading…</button>
+          </div>
+        </aside>
 
         <div class="menu-preview">
           <img id="menuPreviewImage" src="../../images/samuraikata/paysagejapon.jpg" alt="Mode preview" />
@@ -347,12 +402,6 @@
             <h1 id="menuPreviewTitle">Story Mode</h1>
             <p id="menuPreviewDescription">Witness a long-form tale of discipline and spirit as each illustrated page, narration, and animation flows continuously.</p>
           </div>
-        </div>
-
-        <div class="menu-footer">
-          <div class="loading-track"><div id="loadingFill" class="loading-fill"></div></div>
-          <div id="loadingLabel" class="loading-label">Preparing assets… 0%</div>
-          <button id="startJourneyButton" class="start-button" type="button" disabled>Loading…</button>
         </div>
       </div>
     </section>
@@ -420,6 +469,7 @@
 
   <button id="nextButton" class="next-button" type="button" hidden>Next</button>
   <button id="fullscreenButton" class="fullscreen-button" type="button">Fullscreen</button>
+  <div id="chiCursor" aria-hidden="true"></div>
   <div id="transitionOverlay" class="transition-overlay" aria-hidden="true"></div>
 
   <script>
@@ -436,6 +486,7 @@
       const menuPreviewDescription = document.getElementById('menuPreviewDescription');
       const loadingFill = document.getElementById('loadingFill');
       const loadingLabel = document.getElementById('loadingLabel');
+      const chiCursor = document.getElementById('chiCursor');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
 
@@ -445,6 +496,7 @@
       const gameSessions = new Map();
 
       const dwellMs = 1000;
+      const colorFadeWaitMs = 3300;
       const samuraiTimeoutMs = 25000;
       let currentMode = 'story';
       let currentIndex = 0;
@@ -642,15 +694,18 @@
           if (pages[currentIndex] !== page) return;
           image.classList.add('colored');
           if (!manual) {
-            timers.ids.push(setTimeout(step4, 1100));
+            timers.ids.push(setTimeout(step4, colorFadeWaitMs));
             return;
           }
-          gazeTarget.classList.add('visible');
-          if (timers.cleanup) timers.cleanup();
-          timers.cleanup = createDwellGate(gazeTarget, () => {
-            gazeTarget.classList.remove('visible');
-            step4();
-          });
+          timers.ids.push(setTimeout(() => {
+            if (pages[currentIndex] !== page) return;
+            gazeTarget.classList.add('visible');
+            if (timers.cleanup) timers.cleanup();
+            timers.cleanup = createDwellGate(gazeTarget, () => {
+              gazeTarget.classList.remove('visible');
+              step4();
+            });
+          }, colorFadeWaitMs));
         };
         const step2 = () => {
           if (pages[currentIndex] !== page) return;
@@ -947,6 +1002,8 @@
       startJourneyButton.addEventListener('click', async () => {
         if (startJourneyButton.disabled) return;
         isJourneyStarted = true;
+        document.body.classList.add('playing');
+        if (chiCursor) chiCursor.style.opacity = '1';
         await requestFullscreen();
         fullscreenButton.hidden = true;
         triggerTransition();
@@ -959,6 +1016,12 @@
       document.addEventListener('keydown', (event) => {
         if (!isJourneyStarted) return;
         if (event.key === 'ArrowRight' || event.key === ' ') nextPage();
+      });
+
+      document.addEventListener('mousemove', (event) => {
+        if (!isJourneyStarted || !chiCursor) return;
+        chiCursor.style.left = `${event.clientX}px`;
+        chiCursor.style.top = `${event.clientY}px`;
       });
 
       updateModeUI();

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -47,58 +47,42 @@
       width: 100%;
       height: 100%;
       display: grid;
-      grid-template-columns: minmax(290px, 34vw) 1fr;
+      grid-template-columns: minmax(240px, 28vw) 1fr;
       gap: clamp(10px, 1.2vw, 18px);
       padding: clamp(14px, 2.2vw, 34px);
     }
 
-    .menu-sidebar {
+    .menu-controls {
+      position: relative;
       display: grid;
-      grid-template-rows: auto auto 1fr auto;
-      gap: 14px;
+      grid-template-rows: 1fr auto;
+      align-items: end;
+      padding: 16px;
+      border-radius: 30px;
+      overflow: hidden;
       background:
-        linear-gradient(180deg, rgba(42, 18, 24, .56), rgba(10, 10, 15, .74)),
-        repeating-linear-gradient(0deg, rgba(255,255,255,.015) 0 3px, rgba(0,0,0,.015) 3px 6px);
-      border: 1px solid rgba(247, 205, 131, .22);
-      border-radius: 28px;
-      padding: clamp(16px, 1.6vw, 24px);
-      box-shadow: 0 24px 52px rgba(0,0,0,.36), inset 0 0 0 1px rgba(255,255,255,.05);
-      backdrop-filter: blur(4px);
-    }
-
-    .menu-title {
-      font-family: Georgia, serif;
-      color: var(--gold);
-      letter-spacing: .06em;
-      text-transform: uppercase;
-      font-size: clamp(1.15rem, 1.7vw, 1.8rem);
-      margin: 0;
-      text-shadow: 0 4px 14px rgba(0,0,0,.45);
-    }
-
-    .menu-intro {
-      margin: 0;
-      line-height: 1.5;
-      color: rgba(255, 236, 228, .84);
-      font-size: clamp(.9rem, 1.05vw, 1rem);
+        linear-gradient(145deg, rgba(7, 8, 12, .62), rgba(7, 8, 12, .35)),
+        url('../../images/samurai/cherryblossom.png') center left / 120% auto no-repeat;
+      border: 1px solid rgba(255, 230, 195, .16);
     }
 
     .menu-row {
       display: grid;
       grid-template-columns: 1fr;
-      gap: 12px;
-      align-items: stretch;
+      gap: 10px;
+      align-items: end;
+      margin-bottom: 16px;
     }
 
     .mode-button {
-      border: 1px solid rgba(248, 213, 150, .2);
-      border-radius: 20px;
-      background: linear-gradient(130deg, rgba(70, 26, 26, .58), rgba(26, 12, 14, .66));
-      color: #fff;
-      padding: clamp(14px, 2.1vw, 24px);
+      border: 1px solid rgba(248, 213, 150, .18);
+      border-radius: 999px;
+      background: rgba(17, 12, 18, .42);
+      color: #f9efe1;
+      padding: 10px 14px;
       text-align: left;
       cursor: pointer;
-      min-height: 106px;
+      min-height: 0;
       transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
       backdrop-filter: blur(2px);
     }
@@ -107,31 +91,31 @@
       display: block;
       font-family: Georgia, serif;
       color: var(--gold);
-      letter-spacing: .08em;
+      letter-spacing: .05em;
       text-transform: uppercase;
-      font-size: clamp(1rem, 1.6vw, 1.4rem);
-      margin-bottom: 8px;
+      font-size: clamp(.84rem, 1.08vw, 1rem);
+      margin-bottom: 2px;
     }
 
     .mode-button:hover,
     .mode-button:focus-visible {
       transform: translateY(-2px);
-      border-color: rgba(252, 216, 147, .7);
-      box-shadow: 0 12px 24px rgba(0,0,0,.32), 0 0 0 1px rgba(252,216,147,.16);
+      border-color: rgba(252, 216, 147, .52);
+      box-shadow: 0 6px 16px rgba(0,0,0,.22), 0 0 0 1px rgba(252,216,147,.12);
       outline: none;
     }
 
     .mode-button.active {
-      border-color: rgba(252, 216, 147, .65);
-      background: linear-gradient(130deg, rgba(120, 74, 34, .56), rgba(38, 24, 15, .76));
-      box-shadow: inset 0 0 0 1px rgba(252,216,147,.26), 0 12px 26px rgba(0,0,0,.34);
+      border-color: rgba(252, 216, 147, .58);
+      background: rgba(84, 51, 28, .5);
+      box-shadow: inset 0 0 0 1px rgba(252,216,147,.2), 0 8px 18px rgba(0,0,0,.26);
     }
 
     .menu-preview {
       position: relative;
       overflow: hidden;
-      border-radius: 34px;
-      border: 1px solid rgba(255,255,255,.16);
+      border-radius: 40px;
+      border: 1px solid rgba(255,255,255,.12);
       background: #000;
       min-height: 100%;
       box-shadow: 0 24px 50px rgba(0,0,0,.38);
@@ -150,12 +134,12 @@
       left: 2.2vw;
       right: 2.2vw;
       bottom: 2.2vw;
-      padding: 16px 18px;
-      border-radius: 22px;
-      border: 1px solid rgba(249, 213, 140, .26);
-      background: linear-gradient(180deg, rgba(20, 13, 14, .5), rgba(9, 11, 18, .58));
+      padding: 12px 14px;
+      border-radius: 16px;
+      border: 1px solid rgba(249, 213, 140, .18);
+      background: linear-gradient(180deg, rgba(20, 13, 14, .36), rgba(9, 11, 18, .44));
       backdrop-filter: blur(3px);
-      box-shadow: 0 8px 20px rgba(0,0,0,.24);
+      box-shadow: 0 6px 14px rgba(0,0,0,.18);
     }
 
     .menu-overlay h1 {
@@ -172,7 +156,7 @@
     .menu-footer {
       display: flex;
       align-items: center;
-      justify-content: flex-end;
+      justify-content: flex-start;
       gap: 14px;
       padding: 4px 0;
       flex-wrap: wrap;
@@ -396,7 +380,7 @@
 
     @media (max-width: 980px) {
       .menu-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
-      .menu-sidebar { grid-template-rows: auto auto auto auto; }
+      .menu-controls { min-height: 260px; }
       .loading-label { min-width: 100%; text-align: left; }
     }
   </style>
@@ -405,9 +389,7 @@
   <div id="app">
     <section id="landingPage" class="page landing-page active" data-type="landing">
       <div class="menu-shell">
-        <aside class="menu-sidebar">
-          <h2 class="menu-title">Eyegaze Samurai</h2>
-          <p class="menu-intro">Choose your path and enter the journey. The story pages, songs and videos are prepared before launch for smoother play.</p>
+        <div class="menu-controls">
           <div class="menu-row">
             <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong>A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.</button>
             <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong>You decide when to advance scenes, but mini-games remain relaxed and never block your journey.</button>
@@ -418,7 +400,7 @@
             <div id="loadingLabel" class="loading-label">Preparing assets… 0%</div>
             <button id="startJourneyButton" class="start-button" type="button" disabled>Loading…</button>
           </div>
-        </aside>
+        </div>
 
         <div class="menu-preview">
           <img id="menuPreviewImage" src="../../images/samuraikata/paysagejapon.jpg" alt="Mode preview" />

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -19,23 +19,37 @@
     .page.active { display: flex; }
 
     .landing-page {
+      position: relative;
       padding: 0;
       background:
-        radial-gradient(circle at 20% 14%, rgba(167, 57, 57, .28), transparent 34%),
-        radial-gradient(circle at 84% 80%, rgba(214, 160, 84, .2), transparent 36%),
-        linear-gradient(160deg, rgba(33, 15, 15, .72), rgba(7, 8, 12, .92)),
+        radial-gradient(circle at 20% 14%, rgba(167, 57, 57, .22), transparent 40%),
+        radial-gradient(circle at 84% 80%, rgba(214, 160, 84, .16), transparent 42%),
+        linear-gradient(160deg, rgba(22, 13, 16, .58), rgba(7, 8, 12, .82)),
         url('../../images/samurai/cherryblossombg.png') center/cover no-repeat;
       align-items: stretch;
       justify-content: stretch;
     }
 
+    .landing-page::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background:
+        radial-gradient(circle at 10% 12%, rgba(255, 220, 228, .26) 0 2px, transparent 2px) 0 0/120px 120px,
+        radial-gradient(circle at 74% 46%, rgba(255, 220, 228, .16) 0 2px, transparent 2px) 0 0/140px 140px;
+      pointer-events: none;
+      opacity: .7;
+    }
+
     .menu-shell {
+      position: relative;
+      z-index: 1;
       width: 100%;
       height: 100%;
       display: grid;
-      grid-template-columns: minmax(280px, 32vw) 1fr;
+      grid-template-columns: minmax(290px, 34vw) 1fr;
       gap: clamp(10px, 1.2vw, 18px);
-      padding: clamp(10px, 1.6vw, 24px);
+      padding: clamp(14px, 2.2vw, 34px);
     }
 
     .menu-sidebar {
@@ -43,12 +57,13 @@
       grid-template-rows: auto auto 1fr auto;
       gap: 14px;
       background:
-        linear-gradient(180deg, rgba(62, 19, 19, .86), rgba(16, 10, 11, .96)),
-        repeating-linear-gradient(0deg, rgba(255,255,255,.02) 0 2px, rgba(0,0,0,.02) 2px 4px);
-      border: 1px solid rgba(247, 205, 131, .3);
-      border-radius: 18px;
-      padding: clamp(12px, 1.4vw, 20px);
-      box-shadow: 0 18px 44px rgba(0,0,0,.46), inset 0 0 0 1px rgba(255,255,255,.06);
+        linear-gradient(180deg, rgba(42, 18, 24, .56), rgba(10, 10, 15, .74)),
+        repeating-linear-gradient(0deg, rgba(255,255,255,.015) 0 3px, rgba(0,0,0,.015) 3px 6px);
+      border: 1px solid rgba(247, 205, 131, .22);
+      border-radius: 28px;
+      padding: clamp(16px, 1.6vw, 24px);
+      box-shadow: 0 24px 52px rgba(0,0,0,.36), inset 0 0 0 1px rgba(255,255,255,.05);
+      backdrop-filter: blur(4px);
     }
 
     .menu-title {
@@ -64,7 +79,7 @@
     .menu-intro {
       margin: 0;
       line-height: 1.5;
-      color: rgba(255, 234, 218, .9);
+      color: rgba(255, 236, 228, .84);
       font-size: clamp(.9rem, 1.05vw, 1rem);
     }
 
@@ -76,15 +91,16 @@
     }
 
     .mode-button {
-      border: 1px solid rgba(248, 213, 150, .32);
-      border-radius: 16px;
-      background: linear-gradient(130deg, rgba(70, 26, 26, .88), rgba(26, 12, 14, .95));
+      border: 1px solid rgba(248, 213, 150, .2);
+      border-radius: 20px;
+      background: linear-gradient(130deg, rgba(70, 26, 26, .58), rgba(26, 12, 14, .66));
       color: #fff;
       padding: clamp(14px, 2.1vw, 24px);
       text-align: left;
       cursor: pointer;
-      min-height: 120px;
+      min-height: 106px;
       transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+      backdrop-filter: blur(2px);
     }
 
     .mode-button strong {
@@ -100,25 +116,25 @@
     .mode-button:hover,
     .mode-button:focus-visible {
       transform: translateY(-2px);
-      border-color: rgba(252, 216, 147, .95);
-      box-shadow: 0 16px 30px rgba(0,0,0,.4), 0 0 0 1px rgba(252,216,147,.2);
+      border-color: rgba(252, 216, 147, .7);
+      box-shadow: 0 12px 24px rgba(0,0,0,.32), 0 0 0 1px rgba(252,216,147,.16);
       outline: none;
     }
 
     .mode-button.active {
-      border-color: rgba(252, 216, 147, .95);
-      background: linear-gradient(130deg, rgba(120, 74, 34, .85), rgba(38, 24, 15, .96));
-      box-shadow: inset 0 0 0 1px rgba(252,216,147,.42), 0 16px 34px rgba(0,0,0,.4);
+      border-color: rgba(252, 216, 147, .65);
+      background: linear-gradient(130deg, rgba(120, 74, 34, .56), rgba(38, 24, 15, .76));
+      box-shadow: inset 0 0 0 1px rgba(252,216,147,.26), 0 12px 26px rgba(0,0,0,.34);
     }
 
     .menu-preview {
       position: relative;
       overflow: hidden;
-      border-radius: 18px;
-      border: 1px solid rgba(255,255,255,.24);
+      border-radius: 34px;
+      border: 1px solid rgba(255,255,255,.16);
       background: #000;
       min-height: 100%;
-      box-shadow: 0 18px 44px rgba(0,0,0,.42);
+      box-shadow: 0 24px 50px rgba(0,0,0,.38);
     }
 
     .menu-preview img {
@@ -134,12 +150,12 @@
       left: 2.2vw;
       right: 2.2vw;
       bottom: 2.2vw;
-      padding: 14px 16px;
-      border-radius: 12px;
-      border: 1px solid rgba(249, 213, 140, .34);
-      background: linear-gradient(180deg, rgba(18, 12, 13, .64), rgba(9, 11, 18, .72));
+      padding: 16px 18px;
+      border-radius: 22px;
+      border: 1px solid rgba(249, 213, 140, .26);
+      background: linear-gradient(180deg, rgba(20, 13, 14, .5), rgba(9, 11, 18, .58));
       backdrop-filter: blur(3px);
-      box-shadow: 0 10px 24px rgba(0,0,0,.32);
+      box-shadow: 0 8px 20px rgba(0,0,0,.24);
     }
 
     .menu-overlay h1 {
@@ -187,15 +203,15 @@
 
     .start-button {
       border-radius: 999px;
-      border: 1px solid rgba(252,216,147,.95);
-      background: linear-gradient(150deg, rgba(170,98,44,.92), rgba(95,42,20,.96));
+      border: 1px solid rgba(252,216,147,.75);
+      background: linear-gradient(150deg, rgba(170,98,44,.74), rgba(95,42,20,.82));
       color: #fff8e8;
       padding: 14px 26px;
       text-transform: uppercase;
       letter-spacing: .08em;
       font-weight: 700;
       cursor: pointer;
-      box-shadow: 0 10px 22px rgba(0,0,0,.35);
+      box-shadow: 0 8px 18px rgba(0,0,0,.3);
     }
 
     .start-button:disabled { opacity: .55; cursor: not-allowed; }

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -21,7 +21,9 @@
     .landing-page {
       padding: 0;
       background:
-        linear-gradient(160deg, rgba(25,18,42,.5), rgba(4,5,8,.9)),
+        radial-gradient(circle at 20% 14%, rgba(167, 57, 57, .28), transparent 34%),
+        radial-gradient(circle at 84% 80%, rgba(214, 160, 84, .2), transparent 36%),
+        linear-gradient(160deg, rgba(33, 15, 15, .72), rgba(7, 8, 12, .92)),
         url('../../images/samurai/cherryblossombg.png') center/cover no-repeat;
       align-items: stretch;
       justify-content: stretch;
@@ -40,11 +42,13 @@
       display: grid;
       grid-template-rows: auto auto 1fr auto;
       gap: 14px;
-      background: linear-gradient(180deg, rgba(8,10,18,.85), rgba(5,7,12,.96));
-      border: 1px solid rgba(255,255,255,.16);
+      background:
+        linear-gradient(180deg, rgba(62, 19, 19, .86), rgba(16, 10, 11, .96)),
+        repeating-linear-gradient(0deg, rgba(255,255,255,.02) 0 2px, rgba(0,0,0,.02) 2px 4px);
+      border: 1px solid rgba(247, 205, 131, .3);
       border-radius: 18px;
       padding: clamp(12px, 1.4vw, 20px);
-      box-shadow: 0 14px 40px rgba(0,0,0,.35);
+      box-shadow: 0 18px 44px rgba(0,0,0,.46), inset 0 0 0 1px rgba(255,255,255,.06);
     }
 
     .menu-title {
@@ -54,12 +58,13 @@
       text-transform: uppercase;
       font-size: clamp(1.15rem, 1.7vw, 1.8rem);
       margin: 0;
+      text-shadow: 0 4px 14px rgba(0,0,0,.45);
     }
 
     .menu-intro {
       margin: 0;
       line-height: 1.5;
-      color: rgba(245,248,255,.9);
+      color: rgba(255, 234, 218, .9);
       font-size: clamp(.9rem, 1.05vw, 1rem);
     }
 
@@ -71,9 +76,9 @@
     }
 
     .mode-button {
-      border: 1px solid rgba(255,255,255,.22);
+      border: 1px solid rgba(248, 213, 150, .32);
       border-radius: 16px;
-      background: linear-gradient(130deg, rgba(20,26,48,.9), rgba(10,12,21,.95));
+      background: linear-gradient(130deg, rgba(70, 26, 26, .88), rgba(26, 12, 14, .95));
       color: #fff;
       padding: clamp(14px, 2.1vw, 24px);
       text-align: left;
@@ -95,24 +100,25 @@
     .mode-button:hover,
     .mode-button:focus-visible {
       transform: translateY(-2px);
-      border-color: rgba(242,207,134,.9);
-      box-shadow: 0 16px 30px rgba(0,0,0,.35);
+      border-color: rgba(252, 216, 147, .95);
+      box-shadow: 0 16px 30px rgba(0,0,0,.4), 0 0 0 1px rgba(252,216,147,.2);
       outline: none;
     }
 
     .mode-button.active {
-      border-color: rgba(242,207,134,.95);
-      background: linear-gradient(130deg, rgba(84,52,24,.8), rgba(23,15,11,.95));
-      box-shadow: inset 0 0 0 1px rgba(242,207,134,.35), 0 16px 34px rgba(0,0,0,.35);
+      border-color: rgba(252, 216, 147, .95);
+      background: linear-gradient(130deg, rgba(120, 74, 34, .85), rgba(38, 24, 15, .96));
+      box-shadow: inset 0 0 0 1px rgba(252,216,147,.42), 0 16px 34px rgba(0,0,0,.4);
     }
 
     .menu-preview {
       position: relative;
       overflow: hidden;
       border-radius: 18px;
-      border: 1px solid rgba(255,255,255,.16);
+      border: 1px solid rgba(255,255,255,.24);
       background: #000;
       min-height: 100%;
+      box-shadow: 0 18px 44px rgba(0,0,0,.42);
     }
 
     .menu-preview img {
@@ -130,9 +136,10 @@
       bottom: 2.2vw;
       padding: 14px 16px;
       border-radius: 12px;
-      border: 1px solid rgba(255,255,255,.2);
-      background: rgba(4,8,16,.64);
-      backdrop-filter: blur(2px);
+      border: 1px solid rgba(249, 213, 140, .34);
+      background: linear-gradient(180deg, rgba(18, 12, 13, .64), rgba(9, 11, 18, .72));
+      backdrop-filter: blur(3px);
+      box-shadow: 0 10px 24px rgba(0,0,0,.32);
     }
 
     .menu-overlay h1 {
@@ -159,15 +166,15 @@
       flex: 1;
       height: 12px;
       border-radius: 999px;
-      border: 1px solid rgba(255,255,255,.24);
-      background: rgba(8,10,16,.65);
+      border: 1px solid rgba(250, 218, 154, .3);
+      background: rgba(23,12,13,.7);
       overflow: hidden;
     }
 
     .loading-fill {
       width: 0%;
       height: 100%;
-      background: linear-gradient(90deg, rgba(165,66,66,.9), rgba(247,200,125,.85));
+      background: linear-gradient(90deg, rgba(155,42,42,.92), rgba(209,128,72,.92), rgba(250,210,130,.92));
       transition: width .2s linear;
     }
 
@@ -180,14 +187,15 @@
 
     .start-button {
       border-radius: 999px;
-      border: 1px solid rgba(242,207,134,.9);
-      background: linear-gradient(150deg, rgba(134,93,48,.9), rgba(62,34,13,.95));
-      color: #fff7e6;
+      border: 1px solid rgba(252,216,147,.95);
+      background: linear-gradient(150deg, rgba(170,98,44,.92), rgba(95,42,20,.96));
+      color: #fff8e8;
       padding: 14px 26px;
       text-transform: uppercase;
       letter-spacing: .08em;
       font-weight: 700;
       cursor: pointer;
+      box-shadow: 0 10px 22px rgba(0,0,0,.35);
     }
 
     .start-button:disabled { opacity: .55; cursor: not-allowed; }

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -92,7 +92,7 @@
       height: 100%;
       object-fit: cover;
       transition: transform .45s ease;
-      transform: scale(1.015);
+      transform: scale(1.035);
     }
 
     .menu-overlay {
@@ -190,10 +190,9 @@
 
     .story-image {
       display: block;
-      max-width: 100%;
-      max-height: 100%;
-      width: auto;
-      height: auto;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
       filter: grayscale(100%) contrast(1.2) brightness(.95);
       transition: filter 2s ease, opacity .6s ease;
       opacity: 1;
@@ -450,7 +449,10 @@
       let currentMode = 'story';
       let currentIndex = 0;
       let isJourneyStarted = false;
-      let narrationAudio = null;
+      const storyMusic = new Audio();
+      storyMusic.loop = true;
+      storyMusic.preload = 'auto';
+      let storyMusicSrc = '';
       let activeSamuraiChallenge = null;
 
       const modeConfig = {
@@ -497,11 +499,18 @@
         return [words.slice(0, mid).join(' '), words.slice(mid).join(' ')];
       };
 
-      const stopNarration = () => {
-        if (!narrationAudio) return;
-        narrationAudio.pause();
-        narrationAudio.currentTime = 0;
-        narrationAudio = null;
+      const playStoryMusic = (src) => {
+        if (!src) return;
+        if (storyMusicSrc !== src) {
+          storyMusicSrc = src;
+          storyMusic.src = src;
+          storyMusic.load();
+        }
+        storyMusic.play().catch(() => {});
+      };
+
+      const pauseStoryMusic = () => {
+        storyMusic.pause();
       };
 
       const clearStoryTimers = (page) => {
@@ -582,7 +591,6 @@
 
       const setupStoryPage = (page) => {
         clearStoryTimers(page);
-        stopNarration();
 
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
@@ -596,6 +604,7 @@
         const fullText = page.dataset.text || '';
         const audioPath = page.dataset.audio || '';
         const [textA, textB] = splitText(fullText);
+        playStoryMusic(audioPath);
 
         image.src = `${imageBasePath}${imageName}`;
         image.alt = page.dataset.alt || '';
@@ -618,10 +627,16 @@
           if (pages[currentIndex] !== page) return;
           caption.textContent = `${textA} ${textB}`.trim();
           caption.classList.add('visible');
-          const narr = new Audio(audioPath);
-          narrationAudio = narr;
-          narr.play().catch(() => {});
-          timers.ids.push(setTimeout(step5, 900));
+          if (!manual) {
+            timers.ids.push(setTimeout(step5, 900));
+            return;
+          }
+          gazeTarget.classList.add('visible');
+          if (timers.cleanup) timers.cleanup();
+          timers.cleanup = createDwellGate(gazeTarget, () => {
+            gazeTarget.classList.remove('visible');
+            step5();
+          });
         };
         const step3 = () => {
           if (pages[currentIndex] !== page) return;
@@ -766,6 +781,7 @@
       const loadGame = (key, page) => {
         const host = page.querySelector('[data-game-host]');
         if (!host) return;
+        pauseStoryMusic();
 
         let session = gameSessions.get(key);
         if (!session) {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -7,191 +7,185 @@
   <style>
     :root {
       color-scheme: dark;
-      font-family: "Segoe UI", "Trebuchet MS", system-ui, sans-serif;
+      font-family: "Segoe UI", system-ui, sans-serif;
       --gold: #f2cf86;
-      --ink: #06070b;
-      --panel: rgba(8, 10, 18, 0.78);
     }
 
     * { box-sizing: border-box; }
     html, body { margin: 0; height: 100%; }
-
-    body {
-      background: radial-gradient(circle at top, #1a203a 0%, #0a0b14 44%, #040406 100%);
-      color: #f8fafc;
-      overflow: hidden;
-    }
-
-    #app {
-      position: relative;
-      width: 100vw;
-      height: 100vh;
-      overflow: hidden;
-    }
-
+    body { background: #030409; color: #f8fafc; overflow: hidden; }
+    #app { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
     .page { position: absolute; inset: 0; display: none; }
     .page.active { display: flex; }
 
     .landing-page {
-      align-items: center;
-      justify-content: center;
-      padding: clamp(20px, 3vw, 44px);
+      padding: 0;
       background:
-        linear-gradient(145deg, rgba(29, 18, 43, 0.55), rgba(5, 6, 10, 0.92)),
+        linear-gradient(160deg, rgba(25,18,42,.5), rgba(4,5,8,.9)),
         url('../../images/samurai/cherryblossombg.png') center/cover no-repeat;
+      align-items: stretch;
+      justify-content: stretch;
     }
 
     .menu-shell {
-      width: min(92vw, 1180px);
-      height: min(88vh, 760px);
-      border-radius: 24px;
-      border: 1px solid rgba(255, 255, 255, 0.22);
+      width: 100%;
+      height: 100%;
       display: grid;
-      grid-template-columns: 1.2fr 0.8fr;
-      overflow: hidden;
-      box-shadow: 0 28px 74px rgba(0, 0, 0, 0.55);
-      backdrop-filter: blur(4px);
-      background: rgba(7, 9, 16, 0.52);
+      grid-template-rows: auto 1fr auto;
+      gap: 1.2vw;
+      padding: clamp(10px, 1.6vw, 24px);
+    }
+
+    .menu-row {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: clamp(10px, 1.2vw, 18px);
+      align-items: stretch;
+    }
+
+    .mode-button {
+      border: 1px solid rgba(255,255,255,.22);
+      border-radius: 16px;
+      background: linear-gradient(130deg, rgba(20,26,48,.9), rgba(10,12,21,.95));
+      color: #fff;
+      padding: clamp(14px, 2.1vw, 24px);
+      text-align: left;
+      cursor: pointer;
+      min-height: 110px;
+      transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+    }
+
+    .mode-button strong {
+      display: block;
+      font-family: Georgia, serif;
+      color: var(--gold);
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      font-size: clamp(1rem, 1.6vw, 1.4rem);
+      margin-bottom: 8px;
+    }
+
+    .mode-button:hover,
+    .mode-button:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(242,207,134,.9);
+      box-shadow: 0 16px 30px rgba(0,0,0,.35);
+      outline: none;
+    }
+
+    .mode-button.active {
+      border-color: rgba(242,207,134,.95);
+      background: linear-gradient(130deg, rgba(84,52,24,.8), rgba(23,15,11,.95));
+      box-shadow: inset 0 0 0 1px rgba(242,207,134,.35), 0 16px 34px rgba(0,0,0,.35);
     }
 
     .menu-preview {
       position: relative;
       overflow: hidden;
+      border-radius: 18px;
+      border: 1px solid rgba(255,255,255,.16);
       background: #000;
-      min-height: 420px;
     }
 
     .menu-preview img {
       width: 100%;
       height: 100%;
       object-fit: cover;
-      filter: saturate(1.04) brightness(1.05);
+      transition: transform .45s ease;
       transform: scale(1.015);
-      transition: transform 0.55s ease, opacity 0.45s ease;
-    }
-
-    .menu-preview::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(120deg, rgba(5, 6, 8, 0) 15%, rgba(5, 6, 8, 0.3) 80%, rgba(5, 6, 8, 0.7) 100%);
-      pointer-events: none;
     }
 
     .menu-overlay {
       position: absolute;
-      left: clamp(16px, 3vw, 36px);
-      right: clamp(16px, 3vw, 36px);
-      bottom: clamp(16px, 2.6vw, 36px);
-      padding: 14px 18px;
-      border: 1px solid rgba(255, 255, 255, 0.24);
-      border-radius: 14px;
-      background: rgba(6, 8, 14, 0.72);
-      z-index: 2;
+      left: 2.2vw;
+      right: 2.2vw;
+      bottom: 2.2vw;
+      padding: 14px 16px;
+      border-radius: 12px;
+      border: 1px solid rgba(255,255,255,.2);
+      background: rgba(4,8,16,.64);
+      backdrop-filter: blur(2px);
     }
 
     .menu-overlay h1 {
       margin: 0 0 6px;
-      font-family: "Georgia", "Times New Roman", serif;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      font-weight: 700;
-      font-size: clamp(1.05rem, 2.6vw, 1.9rem);
+      font-family: Georgia, serif;
       color: var(--gold);
-      text-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      font-size: clamp(1.2rem, 2.2vw, 2.1rem);
     }
 
-    .menu-overlay p {
-      margin: 0;
-      opacity: 0.92;
-      line-height: 1.45;
-      font-size: clamp(0.9rem, 1.45vw, 1rem);
-    }
+    .menu-overlay p { margin: 0; font-size: clamp(.95rem, 1.25vw, 1.1rem); line-height: 1.45; }
 
-    .menu-panel {
-      background: linear-gradient(180deg, rgba(8, 10, 18, 0.92), rgba(6, 7, 13, 0.98));
-      padding: clamp(20px, 3vw, 34px);
+    .menu-footer {
       display: flex;
-      flex-direction: column;
-      gap: 16px;
-      justify-content: center;
-      border-left: 1px solid rgba(255, 255, 255, 0.12);
+      align-items: center;
+      justify-content: space-between;
+      gap: 14px;
+      padding: 10px 4px;
     }
 
-    .menu-title {
-      font-family: "Georgia", "Times New Roman", serif;
-      margin: 0;
-      color: var(--gold);
-      font-size: clamp(1.2rem, 2.5vw, 2rem);
-      letter-spacing: 0.07em;
-      text-transform: uppercase;
+    .loading-track {
+      flex: 1;
+      height: 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.24);
+      background: rgba(8,10,16,.65);
+      overflow: hidden;
     }
 
-    .menu-subtitle { margin: 0 0 8px; opacity: 0.84; }
-
-    .mode-button {
-      width: 100%;
-      border: 1px solid rgba(255, 255, 255, 0.2);
-      background: linear-gradient(125deg, rgba(28, 33, 60, 0.84), rgba(20, 24, 43, 0.95));
-      color: #fff;
-      border-radius: 14px;
-      cursor: pointer;
-      text-align: left;
-      padding: 14px 16px;
-      line-height: 1.4;
-      transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    .loading-fill {
+      width: 0%;
+      height: 100%;
+      background: linear-gradient(90deg, rgba(165,66,66,.9), rgba(247,200,125,.85));
+      transition: width .2s linear;
     }
 
-    .mode-button strong { display: block; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 4px; }
-    .mode-button:hover, .mode-button:focus-visible {
-      transform: translateY(-2px);
-      border-color: rgba(242, 207, 134, 0.86);
-      box-shadow: 0 10px 26px rgba(0, 0, 0, 0.4);
-      outline: none;
-    }
-
-    .mode-button.active {
-      border-color: rgba(242, 207, 134, 0.95);
-      box-shadow: inset 0 0 0 1px rgba(242, 207, 134, 0.4), 0 10px 30px rgba(242, 207, 134, 0.18);
-      background: linear-gradient(125deg, rgba(88, 52, 24, 0.78), rgba(30, 21, 15, 0.96));
+    .loading-label {
+      min-width: 200px;
+      text-align: right;
+      font-size: .9rem;
+      opacity: .9;
     }
 
     .start-button {
-      margin-top: 6px;
       border-radius: 999px;
-      border: 1px solid rgba(242, 207, 134, 0.82);
-      background: linear-gradient(150deg, rgba(134, 93, 48, 0.84), rgba(70, 43, 18, 0.95));
-      color: #fff8e8;
-      padding: 14px 22px;
-      font-weight: 700;
-      letter-spacing: 0.08em;
+      border: 1px solid rgba(242,207,134,.9);
+      background: linear-gradient(150deg, rgba(134,93,48,.9), rgba(62,34,13,.95));
+      color: #fff7e6;
+      padding: 14px 26px;
       text-transform: uppercase;
+      letter-spacing: .08em;
+      font-weight: 700;
       cursor: pointer;
     }
+
+    .start-button:disabled { opacity: .55; cursor: not-allowed; }
 
     .story-page {
       align-items: center;
       justify-content: center;
-      padding: clamp(16px, 4vw, 48px);
+      padding: clamp(14px, 2vw, 28px);
       background:
-        radial-gradient(circle at top, rgba(59, 130, 246, 0.2), transparent 58%),
-        radial-gradient(circle at bottom, rgba(249, 115, 22, 0.15), transparent 70%),
-        #07080b;
+        radial-gradient(circle at top, rgba(59,130,246,.18), transparent 58%),
+        radial-gradient(circle at bottom, rgba(249,115,22,.13), transparent 72%),
+        #06070b;
     }
 
     .story-media {
       position: relative;
-      max-width: min(92vw, 1240px);
-      max-height: min(86vh, 760px);
       width: 100%;
       height: 100%;
+      max-width: min(96vw, 1380px);
+      max-height: min(94vh, 860px);
       display: flex;
       align-items: center;
       justify-content: center;
       background: #000;
-      border-radius: 16px;
+      border-radius: 14px;
       overflow: hidden;
-      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+      box-shadow: 0 24px 60px rgba(0,0,0,.55);
     }
 
     .story-image {
@@ -200,10 +194,13 @@
       max-height: 100%;
       width: auto;
       height: auto;
-      filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      animation: colorFadeIn 4s ease-in-out forwards;
-      transition: filter 0.3s ease, opacity 0.8s ease-in-out;
+      filter: grayscale(100%) contrast(1.2) brightness(.95);
+      transition: filter 2s ease, opacity .6s ease;
       opacity: 1;
+    }
+
+    .story-image.colored {
+      filter: grayscale(0%) contrast(1) brightness(1);
     }
 
     .story-video {
@@ -214,131 +211,107 @@
       object-fit: contain;
       opacity: 0;
       display: none;
-      transition: opacity 0.8s ease-in-out;
+      transition: opacity .75s ease;
       z-index: 2;
       background: #000;
     }
 
-    .story-media.video-playing .story-video { opacity: 1; display: block; }
-    .story-media.video-playing .story-image { opacity: 0; }
+    .story-media.video-playing .story-video { display: block; opacity: 1; }
+    .story-media.video-playing .story-image,
+    .story-media.video-playing .story-caption { opacity: 0; }
 
     .story-caption {
       position: absolute;
-      left: clamp(18px, 3vw, 36px);
-      right: clamp(18px, 3vw, 36px);
-      bottom: clamp(18px, 3vw, 34px);
+      left: 2.2vw;
+      right: 2.2vw;
+      bottom: 2vw;
       z-index: 4;
-      padding: 14px 18px;
+      padding: 18px 20px;
       border-radius: 12px;
-      background: rgba(2, 6, 14, 0.72);
-      border: 1px solid rgba(255, 255, 255, 0.2);
-      font-family: "Georgia", "Times New Roman", serif;
-      font-size: clamp(1.1rem, 2.1vw, 1.65rem);
-      line-height: 1.35;
-      letter-spacing: 0.02em;
-      text-shadow: 0 6px 20px rgba(0, 0, 0, 0.72);
-      opacity: 0;
-      transform: translateY(8px);
-      transition: opacity 0.35s ease, transform 0.35s ease;
+      border: 1px solid rgba(255,255,255,.22);
+      background: rgba(5,10,18,.7);
+      font-family: "Palatino Linotype", "Book Antiqua", Palatino, serif;
+      font-size: clamp(1.15rem, 2.1vw, 1.9rem);
+      font-style: italic;
+      line-height: 1.45;
+      letter-spacing: .02em;
+      text-shadow: 0 7px 24px rgba(0,0,0,.75);
       pointer-events: none;
+      opacity: 0;
+      transform: translateY(12px);
+      transition: opacity .35s ease, transform .35s ease;
     }
 
     .story-caption.visible { opacity: 1; transform: translateY(0); }
 
     .gaze-target {
       position: absolute;
-      width: clamp(90px, 9vw, 140px);
-      height: clamp(90px, 9vw, 140px);
+      width: clamp(92px, 8.6vw, 132px);
+      height: clamp(92px, 8.6vw, 132px);
       border-radius: 50%;
-      border: 2px solid rgba(255, 255, 255, 0.5);
-      box-shadow: 0 0 0 4px rgba(76, 186, 255, 0.2), 0 0 22px rgba(52, 199, 255, 0.5);
-      background: radial-gradient(circle, rgba(80, 189, 255, 0.3), rgba(80, 189, 255, 0.07));
-      z-index: 5;
-      cursor: pointer;
+      border: 2px solid rgba(255,255,255,.5);
+      background:
+        radial-gradient(circle at 35% 30%, rgba(255,255,255,.4) 0 16%, rgba(255,84,84,.35) 34%, rgba(128,26,26,.26) 64%, rgba(68,0,0,.2) 100%);
+      box-shadow: 0 0 0 5px rgba(255,80,80,.13), 0 0 24px rgba(255,72,72,.45);
+      z-index: 6;
       opacity: 0;
-      transition: opacity 0.2s ease, transform 0.2s ease;
       pointer-events: none;
+      overflow: hidden;
+      transition: opacity .2s ease, transform .2s ease;
     }
 
-    .gaze-target.visible { opacity: 1; pointer-events: auto; animation: pulse 1.4s infinite ease-in-out; }
-    .gaze-target.active { transform: scale(1.08); }
-
-    .hud {
-      position: fixed;
-      top: 16px;
-      left: 16px;
-      z-index: 40;
-      display: flex;
-      gap: 10px;
-      align-items: center;
-      flex-wrap: wrap;
+    .gaze-target::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 0;
+      height: 0;
+      background: rgba(255,40,40,.33);
+      transform: translate(-50%, -50%);
+      transition: width .95s linear, height .95s linear;
     }
 
-    .hud-pill {
-      padding: 8px 12px;
-      border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.28);
-      background: rgba(6, 8, 14, 0.7);
-      font-size: 13px;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-    }
+    .gaze-target.visible { opacity: 1; pointer-events: auto; }
+    .gaze-target.dwell { transform: scale(1.06); }
+    .gaze-target.dwell::after { width: 100%; height: 100%; }
 
     .next-button, .fullscreen-button {
       position: fixed;
       padding: 12px 20px;
       border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.32);
-      background: rgba(15, 23, 42, 0.82);
+      border: 1px solid rgba(255,255,255,.32);
+      background: rgba(15,23,42,.82);
       color: #f8fafc;
       font-size: 14px;
       font-weight: 600;
-      letter-spacing: 0.08em;
+      letter-spacing: .08em;
       text-transform: uppercase;
       cursor: pointer;
       z-index: 20;
-      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+      box-shadow: 0 12px 32px rgba(0,0,0,.4);
     }
-
-    .next-button { bottom: 24px; right: 24px; }
-    .fullscreen-button { top: 24px; right: 24px; }
-
-    .next-button[hidden] { display: none; }
+    .next-button { bottom: 20px; right: 20px; }
+    .fullscreen-button { top: 20px; right: 20px; }
+    .next-button[hidden], .fullscreen-button[hidden] { display: none; }
 
     .page.game-page { background: #000; padding: 0; align-items: stretch; justify-content: stretch; }
     .game-frame { width: 100%; height: 100%; display: block; background: #000; position: relative; overflow: hidden; }
 
     .samurai-challenge {
       position: absolute;
-      top: 16px;
-      right: 16px;
-      z-index: 6;
-      width: min(280px, 40vw);
-      border: 1px solid rgba(255, 255, 255, 0.25);
-      background: rgba(6, 8, 14, 0.7);
-      border-radius: 12px;
-      padding: 10px;
-      display: none;
-    }
-
-    .samurai-challenge.visible { display: block; }
-
-    .challenge-target {
-      margin-top: 10px;
-      width: 92px;
-      height: 92px;
+      top: 14px;
+      right: 14px;
+      width: 94px;
+      height: 94px;
       border-radius: 50%;
-      background: radial-gradient(circle, rgba(250, 208, 124, 0.5), rgba(250, 208, 124, 0.18));
-      border: 2px dashed rgba(250, 208, 124, 0.95);
-      display: grid;
-      place-items: center;
-      font-size: 12px;
-      text-align: center;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
+      border: 2px dashed rgba(248,211,132,.95);
+      background: radial-gradient(circle, rgba(248,211,132,.42), rgba(248,211,132,.16));
+      display: none;
+      z-index: 8;
       cursor: pointer;
-      user-select: none;
     }
+    .samurai-challenge.visible { display: block; }
 
     .transition-overlay {
       position: fixed;
@@ -348,19 +321,14 @@
       pointer-events: none;
       z-index: 30;
     }
-
     .transition-overlay.active { animation: sceneFade 900ms ease-in-out forwards; }
-
-    @keyframes colorFadeIn {
-      0%, 20% { filter: grayscale(100%) contrast(1.2) brightness(0.95); }
-      100% { filter: grayscale(0%) contrast(1) brightness(1); }
-    }
-    @keyframes sceneFade { 0% { opacity: 0; } 40% { opacity: 0.85; } 100% { opacity: 0; } }
-    @keyframes pulse { 0%,100% { transform: scale(1);} 50% { transform: scale(1.06);} }
+    @keyframes sceneFade { 0% { opacity: 0; } 40% { opacity: .85; } 100% { opacity: 0; } }
 
     @media (max-width: 980px) {
-      .menu-shell { grid-template-columns: 1fr; height: min(92vh, 980px); }
-      .menu-preview { min-height: 280px; }
+      .menu-row { grid-template-columns: 1fr; }
+      .menu-shell { grid-template-rows: auto 1fr auto auto; }
+      .menu-footer { flex-wrap: wrap; }
+      .loading-label { min-width: 100%; text-align: left; }
     }
   </style>
 </head>
@@ -368,100 +336,87 @@
   <div id="app">
     <section id="landingPage" class="page landing-page active" data-type="landing">
       <div class="menu-shell">
+        <div class="menu-row">
+          <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong>A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.</button>
+          <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong>You decide when to advance scenes, but mini-games remain relaxed and never block your journey.</button>
+          <button class="mode-button" data-mode="samurai" type="button"><strong>Samurai</strong>A demanding path: you control progression and must complete mini-game challenges to keep moving.</button>
+        </div>
+
         <div class="menu-preview">
           <img id="menuPreviewImage" src="../../images/samuraikata/paysagejapon.jpg" alt="Mode preview" />
           <div class="menu-overlay">
             <h1 id="menuPreviewTitle">Story Mode</h1>
-            <p id="menuPreviewDescription">Automatic progression through story scenes after narration.</p>
+            <p id="menuPreviewDescription">Witness a long-form tale of discipline and spirit as each illustrated page, narration, and animation flows continuously.</p>
           </div>
         </div>
-        <div class="menu-panel">
-          <h2 class="menu-title">Eyegaze Samurai</h2>
-          <p class="menu-subtitle">Choose a path before beginning the journey.</p>
-          <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong>Auto advance after each narration and transition. No mini-game win condition.</button>
-          <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong>User advances pages manually. Mini-games remain free-play (no fail).</button>
-          <button class="mode-button" data-mode="samurai" type="button"><strong>Samurai</strong>User advances manually and must complete mini-game challenge or reset.</button>
-          <button id="startJourneyButton" class="start-button" type="button">Start Journey</button>
+
+        <div class="menu-footer">
+          <div class="loading-track"><div id="loadingFill" class="loading-fill"></div></div>
+          <div id="loadingLabel" class="loading-label">Preparing assets… 0%</div>
+          <button id="startJourneyButton" class="start-button" type="button" disabled>Loading…</button>
         </div>
       </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn." data-text="At dawn, the valley waits in silence as your journey begins." data-audio="../../songs/samurai/cherryblossomsong.mp3" data-target="82,72">
+    <section class="page story-page" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn." data-text="At first light, mist drifts above the valley while distant bells echo across silent fields. You stand still, breathing in the cold dawn, and feel the first promise of your long path." data-audio="../../songs/samurai/cherryblossomsong.mp3" data-target="82,72">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
         <video class="story-video" playsinline></video>
         <div class="story-caption" data-story-caption></div>
-        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
       </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere." data-text="You gather chi and shape it with calm breath and intent." data-audio="../../songs/samurai/samuraisong1.mp3" data-target="16,74">
+    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere." data-text="You gather swirling chi between your palms, shaping its pulse with patience instead of force. The trembling light steadies, and your heartbeat learns to follow its rhythm." data-audio="../../songs/samurai/samuraisong1.mp3" data-target="16,74">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
         <video class="story-video" playsinline></video>
         <div class="story-caption" data-story-caption></div>
-        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="cherry">
       <div class="game-frame" data-game-host></div>
-      <div class="samurai-challenge" data-samurai-challenge>
-        <strong>Samurai challenge</strong>
-        <div>Hold gaze on the circle for 2 seconds to clear this game.</div>
-        <div class="challenge-target" data-challenge-target>Focus<br/>Here</div>
-      </div>
+      <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy." data-text="Your master teaches that precision begins with patience." data-audio="../../songs/samurai/samuraisong2.mp3" data-target="84,30">
+    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy." data-text="Your master watches in silence, then speaks slowly about balance, restraint, and exactness. Every motion, he says, must begin in stillness before it can become a strike." data-audio="../../songs/samurai/samuraisong2.mp3" data-target="84,30">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
         <video class="story-video" playsinline></video>
         <div class="story-caption" data-story-caption></div>
-        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="meditation">
       <div class="game-frame" data-game-host></div>
-      <div class="samurai-challenge" data-samurai-challenge>
-        <strong>Samurai challenge</strong>
-        <div>Hold gaze on the circle for 2 seconds to clear this game.</div>
-        <div class="challenge-target" data-challenge-target>Focus<br/>Here</div>
-      </div>
+      <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky." data-text="Lanterns rise like stars and carry your vows forward." data-audio="../../songs/samurai/samuraisong3.mp3" data-target="18,34">
+    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky." data-text="Night arrives and hundreds of lanterns rise, carrying whispered hopes into the wind. Their warm glow paints the darkness, and you swear to honor each promise you have made." data-audio="../../songs/samurai/samuraisong3.mp3" data-target="18,34">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
         <video class="story-video" playsinline></video>
         <div class="story-caption" data-story-caption></div>
-        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="lamp">
       <div class="game-frame" data-game-host></div>
-      <div class="samurai-challenge" data-samurai-challenge>
-        <strong>Samurai challenge</strong>
-        <div>Hold gaze on the circle for 2 seconds to clear this game.</div>
-        <div class="challenge-target" data-challenge-target>Focus<br/>Here</div>
-      </div>
+      <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms." data-text="The blade rests; your spirit does not. You are ready." data-audio="../../songs/samurai/samuraisong4.mp3" data-target="50,20">
+    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms." data-text="Cherry petals circle your resting blade as the final lesson settles in your chest. Strength, discipline, and mercy now move together, and your journey enters its next chapter." data-audio="../../songs/samurai/samuraisong4.mp3" data-target="50,20">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
         <video class="story-video" playsinline></video>
         <div class="story-caption" data-story-caption></div>
-        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
       </div>
     </section>
-  </div>
-
-  <div class="hud">
-    <div id="modeBadge" class="hud-pill">Mode: Story</div>
-    <div id="statusBadge" class="hud-pill">Select a mode and start.</div>
   </div>
 
   <button id="nextButton" class="next-button" type="button" hidden>Next</button>
@@ -471,76 +426,75 @@
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const pages = Array.from(document.querySelectorAll('.page'));
+      const storyPages = pages.filter((p) => p.dataset.type === 'story');
       const nextButton = document.getElementById('nextButton');
       const fullscreenButton = document.getElementById('fullscreenButton');
       const transitionOverlay = document.getElementById('transitionOverlay');
-      const modeBadge = document.getElementById('modeBadge');
-      const statusBadge = document.getElementById('statusBadge');
-      const landingPage = document.getElementById('landingPage');
       const modeButtons = Array.from(document.querySelectorAll('.mode-button'));
       const startJourneyButton = document.getElementById('startJourneyButton');
       const menuPreviewImage = document.getElementById('menuPreviewImage');
       const menuPreviewTitle = document.getElementById('menuPreviewTitle');
       const menuPreviewDescription = document.getElementById('menuPreviewDescription');
+      const loadingFill = document.getElementById('loadingFill');
+      const loadingLabel = document.getElementById('loadingLabel');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
-      const fadeDurationMs = 4000;
-      const dwellForAdvanceMs = 1000;
-      const storyAutoDelayMs = 1300;
-      const gameAutoDelayMs = 5500;
-      const samuraiTimeoutMs = 25000;
 
-      let currentMode = 'story';
-      let currentIndex = 0;
-      let narrationAudio = null;
-      let isJourneyStarted = false;
-
+      const gameTemplates = { cherry: 'tpl-cherryblossom', meditation: 'tpl-meditation', lamp: 'tpl-lamp' };
+      const templateCache = {};
       const storyTimers = new WeakMap();
       const gameSessions = new Map();
+
+      const dwellMs = 1000;
+      const samuraiTimeoutMs = 25000;
+      let currentMode = 'story';
+      let currentIndex = 0;
+      let isJourneyStarted = false;
+      let narrationAudio = null;
       let activeSamuraiChallenge = null;
 
       const modeConfig = {
         story: {
-          label: 'Story',
+          label: 'Story Mode',
           previewImage: '../../images/samuraikata/paysagejapon.jpg',
           previewTitle: 'Story Mode',
-          previewDescription: 'Automatic progression through story scenes after narration.',
-          autoAdvanceStory: true,
+          previewDescription: 'A cinematic tale that progresses without requiring input and preserves uninterrupted narrative flow.',
           manualAdvance: false,
           enforceGameWin: false,
-          autoAdvanceGame: true,
+          autoGameAdvance: true,
         },
         autonomous: {
           label: 'Autonomous Advancer',
           previewImage: '../../images/samuraikata/maitrechi.jpg',
           previewTitle: 'Autonomous Advancer',
-          previewDescription: 'User advances pages manually with no mini-game fail condition.',
-          autoAdvanceStory: false,
+          previewDescription: 'A user-paced journey where you control progression, while mini-games remain open and non-blocking.',
           manualAdvance: true,
           enforceGameWin: false,
-          autoAdvanceGame: false,
+          autoGameAdvance: false,
         },
         samurai: {
           label: 'Samurai',
           previewImage: '../../images/samuraikata/katanafleurs.jpg',
-          previewTitle: 'Samurai Mode',
-          previewDescription: 'Manual story advance + mini-game challenge required to continue.',
-          autoAdvanceStory: false,
+          previewTitle: 'Samurai',
+          previewDescription: 'The strict path: you manually progress and must succeed in mini-game challenges to continue.',
           manualAdvance: true,
           enforceGameWin: true,
-          autoAdvanceGame: false,
+          autoGameAdvance: false,
         }
       };
 
       const triggerTransition = () => {
-        if (!transitionOverlay) return;
         transitionOverlay.classList.remove('active');
         void transitionOverlay.offsetHeight;
         transitionOverlay.classList.add('active');
       };
 
-      const setStatus = (text) => {
-        if (statusBadge) statusBadge.textContent = text;
+      const splitText = (text) => {
+        const normalized = (text || '').trim();
+        if (!normalized) return ['', ''];
+        const words = normalized.split(/\s+/);
+        const mid = Math.ceil(words.length / 2);
+        return [words.slice(0, mid).join(' '), words.slice(mid).join(' ')];
       };
 
       const stopNarration = () => {
@@ -550,32 +504,11 @@
         narrationAudio = null;
       };
 
-      const updateModeUI = () => {
-        const config = modeConfig[currentMode];
-        modeButtons.forEach((button) => {
-          button.classList.toggle('active', button.dataset.mode === currentMode);
-        });
-        if (menuPreviewImage) menuPreviewImage.src = config.previewImage;
-        if (menuPreviewTitle) menuPreviewTitle.textContent = config.previewTitle;
-        if (menuPreviewDescription) menuPreviewDescription.textContent = config.previewDescription;
-        if (modeBadge) modeBadge.textContent = `Mode: ${config.label}`;
-        if (!isJourneyStarted) setStatus('Select a mode and start.');
-      };
-
       const clearStoryTimers = (page) => {
         const timers = storyTimers.get(page);
         if (!timers) return;
-        ['fadeTimeout', 'hoverTimeout', 'autoTimeout', 'checkTimeout', 'samuraiTimeout'].forEach((key) => {
-          if (timers[key]) clearTimeout(timers[key]);
-        });
-        if (timers.dwellHandler && timers.gazeTarget) {
-          timers.gazeTarget.removeEventListener('mouseenter', timers.dwellHandler.enter);
-          timers.gazeTarget.removeEventListener('mouseleave', timers.dwellHandler.leave);
-          timers.gazeTarget.removeEventListener('focus', timers.dwellHandler.enter);
-          timers.gazeTarget.removeEventListener('blur', timers.dwellHandler.leave);
-          timers.gazeTarget.removeEventListener('touchstart', timers.dwellHandler.enter);
-          timers.gazeTarget.removeEventListener('touchend', timers.dwellHandler.leave);
-        }
+        if (timers.ids) timers.ids.forEach((id) => clearTimeout(id));
+        if (timers.cleanup) timers.cleanup();
         storyTimers.delete(page);
       };
 
@@ -585,93 +518,65 @@
         const video = page.querySelector('.story-video');
         const caption = page.querySelector('[data-story-caption]');
         const gazeTarget = page.querySelector('[data-gaze-target]');
-        if (!media || !image || !video) return;
-
+        if (!media || !image || !video || !caption || !gazeTarget) return;
         media.classList.remove('video-playing');
+        image.classList.remove('colored');
         video.pause();
         video.currentTime = 0;
         video.removeAttribute('src');
         video.load();
         video.onended = null;
-        image.style.animation = 'none';
-        void image.offsetHeight;
-        image.style.animation = `colorFadeIn ${fadeDurationMs / 1000}s ease-in-out forwards`;
-
-        if (caption) {
-          caption.classList.remove('visible');
-          caption.textContent = '';
-        }
-        if (gazeTarget) {
-          gazeTarget.classList.remove('visible', 'active');
-        }
+        caption.classList.remove('visible');
+        caption.textContent = '';
+        gazeTarget.classList.remove('visible', 'dwell');
       };
 
-      const checkVideoExists = (path, callback) => {
-        const tester = document.createElement('video');
-        let settled = false;
-        let timeoutId = null;
-        const clean = () => {
-          tester.removeEventListener('loadeddata', onLoad);
-          tester.removeEventListener('error', onError);
-          if (timeoutId) clearTimeout(timeoutId);
-        };
-        const onLoad = () => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(true);
-        };
-        const onError = () => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(false);
-        };
-        tester.addEventListener('loadeddata', onLoad);
-        tester.addEventListener('error', onError);
-        tester.src = path;
-        tester.preload = 'metadata';
-        tester.load();
-        timeoutId = setTimeout(() => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(false);
-        }, 1500);
-      };
-
-      const parseTargetPos = (raw) => {
-        if (!raw) return { x: 85, y: 72 };
-        const [xStr, yStr] = raw.split(',');
-        const x = Number.parseFloat(xStr);
-        const y = Number.parseFloat(yStr);
-        if (Number.isNaN(x) || Number.isNaN(y)) return { x: 85, y: 72 };
-        return { x: Math.min(94, Math.max(6, x)), y: Math.min(92, Math.max(8, y)) };
-      };
-
-      const queueAdvance = (delayMs = 0) => {
-        const pendingPage = pages[currentIndex];
-        setTimeout(() => {
-          if (pages[currentIndex] !== pendingPage) return;
-          nextPage();
-        }, delayMs);
-      };
-
-      const playPageVideo = (page, video, media, autoAfterVideo = false) => {
-        if (!video || !media) {
-          queueAdvance();
+      const playVideoThenAdvance = (page, video, media) => {
+        if (!video || !media || !video.src) {
+          triggerTransition();
+          setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 260);
           return;
         }
         media.classList.add('video-playing');
         video.currentTime = 0;
-        const playPromise = video.play();
-        if (playPromise && typeof playPromise.catch === 'function') {
-          playPromise.catch(() => {});
-        }
+        const p = video.play();
+        if (p && typeof p.catch === 'function') p.catch(() => {});
         video.onended = () => {
           if (pages[currentIndex] !== page) return;
           triggerTransition();
-          queueAdvance(autoAfterVideo ? storyAutoDelayMs : 240);
+          setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 300);
+        };
+      };
+
+      const createDwellGate = (target, onDone) => {
+        let hold = null;
+        const start = () => {
+          target.classList.add('dwell');
+          hold = setTimeout(() => {
+            hold = null;
+            target.classList.remove('dwell');
+            onDone();
+          }, dwellMs);
+        };
+        const cancel = () => {
+          if (hold) clearTimeout(hold);
+          hold = null;
+          target.classList.remove('dwell');
+        };
+        target.addEventListener('mouseenter', start);
+        target.addEventListener('mouseleave', cancel);
+        target.addEventListener('focus', start);
+        target.addEventListener('blur', cancel);
+        target.addEventListener('touchstart', start, { passive: true });
+        target.addEventListener('touchend', cancel);
+        return () => {
+          cancel();
+          target.removeEventListener('mouseenter', start);
+          target.removeEventListener('mouseleave', cancel);
+          target.removeEventListener('focus', start);
+          target.removeEventListener('blur', cancel);
+          target.removeEventListener('touchstart', start);
+          target.removeEventListener('touchend', cancel);
         };
       };
 
@@ -679,98 +584,84 @@
         clearStoryTimers(page);
         stopNarration();
 
-        const imageName = page.dataset.image;
-        const altText = page.dataset.alt || '';
-        const text = page.dataset.text || '';
-        const audioPath = page.dataset.audio || '';
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
         const video = page.querySelector('.story-video');
         const caption = page.querySelector('[data-story-caption]');
         const gazeTarget = page.querySelector('[data-gaze-target]');
-        if (!imageName || !media || !image || !video || !caption || !gazeTarget) return;
+        if (!media || !image || !video || !caption || !gazeTarget) return;
 
         resetStoryMedia(page);
-        image.src = `${imageBasePath}${imageName}`;
-        image.alt = altText;
+        const imageName = page.dataset.image;
+        const fullText = page.dataset.text || '';
+        const audioPath = page.dataset.audio || '';
+        const [textA, textB] = splitText(fullText);
 
-        const pos = parseTargetPos(page.dataset.target);
-        gazeTarget.style.left = `${pos.x}%`;
-        gazeTarget.style.top = `${pos.y}%`;
+        image.src = `${imageBasePath}${imageName}`;
+        image.alt = page.dataset.alt || '';
+
+        const [xRaw, yRaw] = (page.dataset.target || '82,72').split(',');
+        gazeTarget.style.left = `${Math.min(94, Math.max(6, Number.parseFloat(xRaw) || 82))}%`;
+        gazeTarget.style.top = `${Math.min(92, Math.max(8, Number.parseFloat(yRaw) || 72))}%`;
 
         const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
         const videoPath = `${videoBasePath}${videoName}`;
+        video.src = videoPath;
+        video.preload = 'auto';
+        video.load();
 
-        const timers = { gazeTarget, dwellHandler: null, videoAvailable: false };
+        const timers = { ids: [], cleanup: null };
+        const manual = modeConfig[currentMode].manualAdvance;
 
-        const revealNarrationAndUI = () => {
+        const step5 = () => playVideoThenAdvance(page, video, media);
+        const step4 = () => {
           if (pages[currentIndex] !== page) return;
-          caption.textContent = text;
+          caption.textContent = `${textA} ${textB}`.trim();
           caption.classList.add('visible');
+          const narr = new Audio(audioPath);
+          narrationAudio = narr;
+          narr.play().catch(() => {});
+          timers.ids.push(setTimeout(step5, 900));
+        };
+        const step3 = () => {
+          if (pages[currentIndex] !== page) return;
+          image.classList.add('colored');
+          if (!manual) {
+            timers.ids.push(setTimeout(step4, 1100));
+            return;
+          }
           gazeTarget.classList.add('visible');
-          setStatus('Look at the glowing circle to play the scene video.');
-          if (audioPath) {
-            narrationAudio = new Audio(audioPath);
-            narrationAudio.play().catch(() => {});
+          if (timers.cleanup) timers.cleanup();
+          timers.cleanup = createDwellGate(gazeTarget, () => {
+            gazeTarget.classList.remove('visible');
+            step4();
+          });
+        };
+        const step2 = () => {
+          if (pages[currentIndex] !== page) return;
+          caption.textContent = textA;
+          caption.classList.add('visible');
+          timers.ids.push(setTimeout(step3, 1100));
+        };
+        const step1 = () => {
+          if (pages[currentIndex] !== page) return;
+          image.classList.remove('colored');
+          caption.classList.remove('visible');
+          caption.textContent = '';
+          if (!manual) {
+            timers.ids.push(setTimeout(step2, 900));
+            return;
           }
-
-          if (modeConfig[currentMode].autoAdvanceStory) {
-            timers.autoTimeout = setTimeout(() => {
-              if (pages[currentIndex] !== page) return;
-              if (!timers.videoAvailable) {
-                triggerTransition();
-                queueAdvance(storyAutoDelayMs);
-                return;
-              }
-              playPageVideo(page, video, media, true);
-            }, 2200);
-          }
+          gazeTarget.classList.add('visible');
+          timers.cleanup = createDwellGate(gazeTarget, () => {
+            gazeTarget.classList.remove('visible');
+            step2();
+          });
         };
 
-        const handleTargetEnter = () => {
-          gazeTarget.classList.add('active');
-          timers.hoverTimeout = setTimeout(() => {
-            if (pages[currentIndex] !== page) return;
-            if (modeConfig[currentMode].autoAdvanceStory) return;
-            if (!timers.videoAvailable) {
-              triggerTransition();
-              queueAdvance(240);
-              return;
-            }
-            playPageVideo(page, video, media);
-          }, dwellForAdvanceMs);
-        };
-
-        const handleTargetLeave = () => {
-          gazeTarget.classList.remove('active');
-          if (timers.hoverTimeout) {
-            clearTimeout(timers.hoverTimeout);
-            timers.hoverTimeout = null;
-          }
-        };
-
-        timers.dwellHandler = { enter: handleTargetEnter, leave: handleTargetLeave };
-        gazeTarget.addEventListener('mouseenter', handleTargetEnter);
-        gazeTarget.addEventListener('mouseleave', handleTargetLeave);
-        gazeTarget.addEventListener('focus', handleTargetEnter);
-        gazeTarget.addEventListener('blur', handleTargetLeave);
-        gazeTarget.addEventListener('touchstart', handleTargetEnter, { passive: true });
-        gazeTarget.addEventListener('touchend', handleTargetLeave);
-
-        timers.fadeTimeout = setTimeout(revealNarrationAndUI, fadeDurationMs + 80);
-
-        checkVideoExists(videoPath, (exists) => {
-          timers.videoAvailable = exists;
-          if (!exists) return;
-          video.src = videoPath;
-          video.load();
-        });
-
+        timers.ids.push(setTimeout(step1, 150));
         storyTimers.set(page, timers);
       };
-
-      const gameTemplates = { cherry: 'tpl-cherryblossom', meditation: 'tpl-meditation', lamp: 'tpl-lamp' };
-      const templateCache = {};
 
       const loadTemplate = (id) => {
         if (!templateCache[id]) {
@@ -789,21 +680,17 @@
           clearTimeout(activeSamuraiChallenge.timeoutId);
           activeSamuraiChallenge = null;
         }
-        const attemptStop = (api) => {
-          if (!api || typeof api.stop !== 'function') return;
+        if (session.api && typeof session.api.stop === 'function') {
           try {
-            const maybePromise = api.stop();
-            if (maybePromise && typeof maybePromise.then === 'function') maybePromise.catch(() => {});
+            const maybe = session.api.stop();
+            if (maybe && typeof maybe.then === 'function') maybe.catch(() => {});
           } catch (_) {}
-        };
-        if (session.api) attemptStop(session.api);
-        else if (session.apiPromise) session.apiPromise.then(attemptStop).catch(() => {});
+        }
       };
 
       const mountGameTemplate = async (host, templateId) => {
         const html = loadTemplate(templateId);
         if (!html) return null;
-        let scriptPromises = [];
         host.innerHTML = '';
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, 'text/html');
@@ -812,8 +699,7 @@
         const appendChildren = (parent) => {
           if (!parent) return;
           parent.childNodes.forEach((node) => {
-            if (node.nodeName === 'TITLE') return;
-            fragment.appendChild(node.cloneNode(true));
+            if (node.nodeName !== 'TITLE') fragment.appendChild(node.cloneNode(true));
           });
         };
 
@@ -822,6 +708,7 @@
         window.storyGameApi = null;
         host.appendChild(fragment);
 
+        const scriptPromises = [];
         host.querySelectorAll('script').forEach((oldScript) => {
           const newScript = document.createElement('script');
           newScript.async = false;
@@ -842,52 +729,34 @@
       };
 
       const installSamuraiChallenge = (page) => {
-        const box = page.querySelector('[data-samurai-challenge]');
-        const target = page.querySelector('[data-challenge-target]');
-        if (!box || !target) return;
-
-        box.classList.toggle('visible', modeConfig[currentMode].enforceGameWin);
+        const target = page.querySelector('[data-samurai-challenge]');
+        if (!target) return;
+        target.classList.toggle('visible', modeConfig[currentMode].enforceGameWin);
         target.onmouseenter = null;
         target.onmouseleave = null;
         target.onfocus = null;
         target.onblur = null;
 
-        if (!modeConfig[currentMode].enforceGameWin) {
-          return;
-        }
+        if (!modeConfig[currentMode].enforceGameWin) return;
 
-        let holdTimeout = null;
+        let hold = null;
         const complete = () => {
-          setStatus('Challenge complete. Transitioning to next page.');
           if (activeSamuraiChallenge) {
             clearTimeout(activeSamuraiChallenge.timeoutId);
             activeSamuraiChallenge = null;
           }
           triggerTransition();
-          queueAdvance(350);
+          setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 300);
         };
-
-        const startHold = () => {
-          holdTimeout = setTimeout(complete, 2000);
-          target.style.transform = 'scale(1.08)';
-        };
-
-        const clearHold = () => {
-          if (holdTimeout) {
-            clearTimeout(holdTimeout);
-            holdTimeout = null;
-          }
-          target.style.transform = '';
-        };
-
-        target.onmouseenter = startHold;
-        target.onmouseleave = clearHold;
-        target.onfocus = startHold;
-        target.onblur = clearHold;
+        const start = () => { hold = setTimeout(complete, 2000); };
+        const cancel = () => { if (hold) clearTimeout(hold); hold = null; };
+        target.onmouseenter = start;
+        target.onmouseleave = cancel;
+        target.onfocus = start;
+        target.onblur = cancel;
 
         const timeoutId = setTimeout(() => {
           if (pages[currentIndex] !== page || currentMode !== 'samurai') return;
-          setStatus('Challenge failed. Restarting mini-game.');
           showPage(currentIndex);
         }, samuraiTimeoutMs);
 
@@ -902,129 +771,175 @@
         if (!session) {
           const templateId = gameTemplates[key];
           if (!templateId) return;
-          const apiPromise = mountGameTemplate(host, templateId);
-          session = { host, api: null, apiPromise };
+          session = { host, api: null, apiPromise: mountGameTemplate(host, templateId) };
           gameSessions.set(key, session);
         }
 
-        const startGame = async () => {
+        (async () => {
           try {
             if (!session.api) session.api = await session.apiPromise;
           } catch (_) { return; }
           if (pages[currentIndex] !== page) return;
-          const api = session.api;
-          if (api && typeof api.start === 'function') {
+
+          if (session.api && typeof session.api.start === 'function') {
             try {
-              const maybePromise = api.start();
-              if (maybePromise && typeof maybePromise.then === 'function') maybePromise.catch(() => {});
+              const maybe = session.api.start();
+              if (maybe && typeof maybe.then === 'function') maybe.catch(() => {});
             } catch (_) {}
           }
 
           installSamuraiChallenge(page);
 
-          if (!modeConfig[currentMode].enforceGameWin && modeConfig[currentMode].autoAdvanceGame) {
-            setStatus('Mini-game free play. Advancing automatically.');
+          if (!modeConfig[currentMode].enforceGameWin && modeConfig[currentMode].autoGameAdvance) {
             setTimeout(() => {
               if (pages[currentIndex] !== page) return;
               triggerTransition();
-              queueAdvance(250);
-            }, gameAutoDelayMs);
-          } else if (!modeConfig[currentMode].enforceGameWin) {
-            setStatus('Mini-game free play. Use Next when ready.');
-          } else {
-            setStatus('Samurai challenge active: complete it before timeout.');
+              setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 260);
+            }, 5200);
           }
-        };
-
-        startGame();
+        })();
       };
 
-      const updateNextButtonVisibility = () => {
+      const updateNextButton = () => {
         const page = pages[currentIndex];
-        const manualMode = modeConfig[currentMode].manualAdvance;
-        const shouldShow = isJourneyStarted && manualMode && page && page.dataset.type !== 'landing';
-        if (nextButton) nextButton.hidden = !shouldShow;
+        const show = isJourneyStarted && modeConfig[currentMode].manualAdvance && page && page.dataset.type !== 'landing';
+        nextButton.hidden = !show;
       };
 
       const showPage = (index) => {
         if (index < 0 || index >= pages.length) return;
-
-        const previousPage = pages[currentIndex];
-        if (previousPage) {
-          previousPage.classList.remove('active');
-          clearStoryTimers(previousPage);
-          if (previousPage.dataset.type === 'story') resetStoryMedia(previousPage);
-          if (previousPage.dataset.type === 'game') stopGame(previousPage);
+        const prev = pages[currentIndex];
+        if (prev) {
+          prev.classList.remove('active');
+          clearStoryTimers(prev);
+          if (prev.dataset.type === 'story') resetStoryMedia(prev);
+          if (prev.dataset.type === 'game') stopGame(prev);
         }
 
         currentIndex = index;
         const page = pages[currentIndex];
         if (!page) return;
         page.classList.add('active');
-        updateNextButtonVisibility();
+        updateNextButton();
 
-        if (page.dataset.type === 'landing') {
-          setStatus('Select a mode and start.');
-          return;
-        }
-
-        if (page.dataset.type === 'story') {
-          setStatus('Story scene loading...');
-          setupStoryPage(page);
-        }
-
-        if (page.dataset.type === 'game') {
-          loadGame(page.dataset.game, page);
-        }
+        if (page.dataset.type === 'story') setupStoryPage(page);
+        if (page.dataset.type === 'game') loadGame(page.dataset.game, page);
       };
 
       const nextPage = () => {
         if (!isJourneyStarted) return;
-        const nextIndex = (currentIndex + 1) % pages.length;
-        showPage(nextIndex === 0 ? 1 : nextIndex);
+        const n = (currentIndex + 1) % pages.length;
+        showPage(n === 0 ? 1 : n);
+      };
+
+      const requestFullscreen = async () => {
+        const root = document.documentElement;
+        if (document.fullscreenElement) return;
+        const fn = root.requestFullscreen || root.webkitRequestFullscreen || root.msRequestFullscreen;
+        if (!fn) return;
+        try { await fn.call(root); } catch (_) {}
+      };
+
+      document.addEventListener('fullscreenchange', () => {
+        if (isJourneyStarted && !document.fullscreenElement) {
+          requestFullscreen();
+        }
+        fullscreenButton.textContent = document.fullscreenElement ? 'Exit Fullscreen' : 'Fullscreen';
+      });
+
+      const preloadAsset = (src) => new Promise((resolve) => {
+        if (!src) return resolve();
+        const ext = src.split('?')[0].toLowerCase();
+        if (/\.(jpg|jpeg|png|gif|webp|svg)$/.test(ext)) {
+          const img = new Image();
+          img.onload = img.onerror = () => resolve();
+          img.src = src;
+          return;
+        }
+        if (/\.(mp3|wav|ogg|m4a)$/.test(ext)) {
+          const a = new Audio();
+          const done = () => { a.removeEventListener('canplaythrough', done); a.removeEventListener('error', done); resolve(); };
+          a.addEventListener('canplaythrough', done, { once: true });
+          a.addEventListener('error', done, { once: true });
+          a.preload = 'auto';
+          a.src = src;
+          a.load();
+          return;
+        }
+        if (/\.(mp4|webm|mov)$/.test(ext)) {
+          const v = document.createElement('video');
+          const done = () => { v.removeEventListener('loadeddata', done); v.removeEventListener('error', done); resolve(); };
+          v.addEventListener('loadeddata', done, { once: true });
+          v.addEventListener('error', done, { once: true });
+          v.preload = 'auto';
+          v.src = src;
+          v.load();
+          return;
+        }
+        resolve();
+      });
+
+      const gatherAssets = () => {
+        const set = new Set();
+        Object.values(modeConfig).forEach((m) => set.add(m.previewImage));
+        storyPages.forEach((page) => {
+          const img = page.dataset.image;
+          if (img) {
+            set.add(`${imageBasePath}${img}`);
+            set.add(`${videoBasePath}${img.replace(/\.(jpg|jpeg|png)$/i, '.mp4')}`);
+          }
+          if (page.dataset.audio) set.add(page.dataset.audio);
+        });
+        return Array.from(set);
+      };
+
+      const runPreload = async () => {
+        const assets = gatherAssets();
+        let done = 0;
+        const update = () => {
+          const pct = assets.length ? Math.round((done / assets.length) * 100) : 100;
+          loadingFill.style.width = `${pct}%`;
+          loadingLabel.textContent = `Preparing assets… ${pct}%`;
+        };
+        update();
+        await Promise.all(assets.map(async (asset) => {
+          await preloadAsset(asset);
+          done += 1;
+          update();
+        }));
+        startJourneyButton.disabled = false;
+        startJourneyButton.textContent = 'Start Journey';
+        loadingLabel.textContent = 'Ready';
+      };
+
+      const updateModeUI = () => {
+        const mode = modeConfig[currentMode];
+        modeButtons.forEach((button) => button.classList.toggle('active', button.dataset.mode === currentMode));
+        menuPreviewImage.src = mode.previewImage;
+        menuPreviewTitle.textContent = mode.previewTitle;
+        menuPreviewDescription.textContent = mode.previewDescription;
       };
 
       modeButtons.forEach((button) => {
         button.addEventListener('click', () => {
           currentMode = button.dataset.mode;
           updateModeUI();
+          updateNextButton();
         });
       });
 
-      if (startJourneyButton) {
-        startJourneyButton.addEventListener('click', () => {
-          isJourneyStarted = true;
-          triggerTransition();
-          showPage(1);
-        });
-      }
+      startJourneyButton.addEventListener('click', async () => {
+        if (startJourneyButton.disabled) return;
+        isJourneyStarted = true;
+        await requestFullscreen();
+        fullscreenButton.hidden = true;
+        triggerTransition();
+        showPage(1);
+      });
 
-      if (nextButton) {
-        nextButton.addEventListener('click', () => {
-          nextPage();
-        });
-      }
+      nextButton.addEventListener('click', nextPage);
+      fullscreenButton.addEventListener('click', requestFullscreen);
 
-      const requestFullscreen = async () => {
-        if (document.fullscreenElement) {
-          await document.exitFullscreen();
-          return;
-        }
-        const root = document.documentElement;
-        const method = root.requestFullscreen || root.webkitRequestFullscreen || root.msRequestFullscreen;
-        if (method) {
-          try { await method.call(root); } catch (_) {}
-        }
-      };
-
-      if (fullscreenButton) fullscreenButton.addEventListener('click', requestFullscreen);
-
-      const updateFullscreenLabel = () => {
-        if (!fullscreenButton) return;
-        fullscreenButton.textContent = document.fullscreenElement ? 'Exit Fullscreen' : 'Fullscreen';
-      };
-
-      document.addEventListener('fullscreenchange', updateFullscreenLabel);
       document.addEventListener('keydown', (event) => {
         if (!isJourneyStarted) return;
         if (event.key === 'ArrowRight' || event.key === ' ') nextPage();
@@ -1032,7 +947,7 @@
 
       updateModeUI();
       showPage(0);
-      updateFullscreenLabel();
+      runPreload();
     });
   </script>
 

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -3,26 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Samurai Story Journey</title>
+  <title>Eyegaze Samurai — Story Journey</title>
   <style>
     :root {
       color-scheme: dark;
-      font-family: "Helvetica Neue", Arial, system-ui, sans-serif;
+      font-family: "Segoe UI", "Trebuchet MS", system-ui, sans-serif;
+      --gold: #f2cf86;
+      --ink: #06070b;
+      --panel: rgba(8, 10, 18, 0.78);
     }
 
-    * {
-      box-sizing: border-box;
-    }
-
-    html,
-    body {
-      margin: 0;
-      height: 100%;
-    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; }
 
     body {
-      background: #08090c;
-      color: #f9fafb;
+      background: radial-gradient(circle at top, #1a203a 0%, #0a0b14 44%, #040406 100%);
+      color: #f8fafc;
       overflow: hidden;
     }
 
@@ -33,28 +29,159 @@
       overflow: hidden;
     }
 
-    .page {
-      position: absolute;
-      inset: 0;
-      display: none;
-    }
+    .page { position: absolute; inset: 0; display: none; }
+    .page.active { display: flex; }
 
-    .page.active {
-      display: flex;
+    .landing-page {
       align-items: center;
       justify-content: center;
+      padding: clamp(20px, 3vw, 44px);
+      background:
+        linear-gradient(145deg, rgba(29, 18, 43, 0.55), rgba(5, 6, 10, 0.92)),
+        url('../../images/samurai/cherryblossombg.png') center/cover no-repeat;
+    }
+
+    .menu-shell {
+      width: min(92vw, 1180px);
+      height: min(88vh, 760px);
+      border-radius: 24px;
+      border: 1px solid rgba(255, 255, 255, 0.22);
+      display: grid;
+      grid-template-columns: 1.2fr 0.8fr;
+      overflow: hidden;
+      box-shadow: 0 28px 74px rgba(0, 0, 0, 0.55);
+      backdrop-filter: blur(4px);
+      background: rgba(7, 9, 16, 0.52);
+    }
+
+    .menu-preview {
+      position: relative;
+      overflow: hidden;
+      background: #000;
+      min-height: 420px;
+    }
+
+    .menu-preview img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      filter: saturate(1.04) brightness(1.05);
+      transform: scale(1.015);
+      transition: transform 0.55s ease, opacity 0.45s ease;
+    }
+
+    .menu-preview::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, rgba(5, 6, 8, 0) 15%, rgba(5, 6, 8, 0.3) 80%, rgba(5, 6, 8, 0.7) 100%);
+      pointer-events: none;
+    }
+
+    .menu-overlay {
+      position: absolute;
+      left: clamp(16px, 3vw, 36px);
+      right: clamp(16px, 3vw, 36px);
+      bottom: clamp(16px, 2.6vw, 36px);
+      padding: 14px 18px;
+      border: 1px solid rgba(255, 255, 255, 0.24);
+      border-radius: 14px;
+      background: rgba(6, 8, 14, 0.72);
+      z-index: 2;
+    }
+
+    .menu-overlay h1 {
+      margin: 0 0 6px;
+      font-family: "Georgia", "Times New Roman", serif;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      font-weight: 700;
+      font-size: clamp(1.05rem, 2.6vw, 1.9rem);
+      color: var(--gold);
+      text-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    }
+
+    .menu-overlay p {
+      margin: 0;
+      opacity: 0.92;
+      line-height: 1.45;
+      font-size: clamp(0.9rem, 1.45vw, 1rem);
+    }
+
+    .menu-panel {
+      background: linear-gradient(180deg, rgba(8, 10, 18, 0.92), rgba(6, 7, 13, 0.98));
+      padding: clamp(20px, 3vw, 34px);
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      justify-content: center;
+      border-left: 1px solid rgba(255, 255, 255, 0.12);
+    }
+
+    .menu-title {
+      font-family: "Georgia", "Times New Roman", serif;
+      margin: 0;
+      color: var(--gold);
+      font-size: clamp(1.2rem, 2.5vw, 2rem);
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+    }
+
+    .menu-subtitle { margin: 0 0 8px; opacity: 0.84; }
+
+    .mode-button {
+      width: 100%;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      background: linear-gradient(125deg, rgba(28, 33, 60, 0.84), rgba(20, 24, 43, 0.95));
+      color: #fff;
+      border-radius: 14px;
+      cursor: pointer;
+      text-align: left;
+      padding: 14px 16px;
+      line-height: 1.4;
+      transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .mode-button strong { display: block; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 4px; }
+    .mode-button:hover, .mode-button:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(242, 207, 134, 0.86);
+      box-shadow: 0 10px 26px rgba(0, 0, 0, 0.4);
+      outline: none;
+    }
+
+    .mode-button.active {
+      border-color: rgba(242, 207, 134, 0.95);
+      box-shadow: inset 0 0 0 1px rgba(242, 207, 134, 0.4), 0 10px 30px rgba(242, 207, 134, 0.18);
+      background: linear-gradient(125deg, rgba(88, 52, 24, 0.78), rgba(30, 21, 15, 0.96));
+    }
+
+    .start-button {
+      margin-top: 6px;
+      border-radius: 999px;
+      border: 1px solid rgba(242, 207, 134, 0.82);
+      background: linear-gradient(150deg, rgba(134, 93, 48, 0.84), rgba(70, 43, 18, 0.95));
+      color: #fff8e8;
+      padding: 14px 22px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
     }
 
     .story-page {
-      background: radial-gradient(circle at top, rgba(59, 130, 246, 0.25), transparent 60%),
-                  radial-gradient(circle at bottom, rgba(249, 115, 22, 0.15), transparent 70%),
-                  #07080b;
+      align-items: center;
+      justify-content: center;
       padding: clamp(16px, 4vw, 48px);
+      background:
+        radial-gradient(circle at top, rgba(59, 130, 246, 0.2), transparent 58%),
+        radial-gradient(circle at bottom, rgba(249, 115, 22, 0.15), transparent 70%),
+        #07080b;
     }
 
     .story-media {
       position: relative;
-      max-width: min(92vw, 1200px);
+      max-width: min(92vw, 1240px);
       max-height: min(86vh, 760px);
       width: 100%;
       height: 100%;
@@ -62,7 +189,7 @@
       align-items: center;
       justify-content: center;
       background: #000;
-      border-radius: 12px;
+      border-radius: 16px;
       overflow: hidden;
       box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
     }
@@ -87,80 +214,82 @@
       object-fit: contain;
       opacity: 0;
       display: none;
-      transition: opacity 1.2s ease-in-out;
+      transition: opacity 0.8s ease-in-out;
       z-index: 2;
+      background: #000;
     }
 
-    .story-media.video-playing .story-video {
-      opacity: 1;
-      display: block;
-    }
+    .story-media.video-playing .story-video { opacity: 1; display: block; }
+    .story-media.video-playing .story-image { opacity: 0; }
 
-    .story-media.video-playing .story-image {
+    .story-caption {
+      position: absolute;
+      left: clamp(18px, 3vw, 36px);
+      right: clamp(18px, 3vw, 36px);
+      bottom: clamp(18px, 3vw, 34px);
+      z-index: 4;
+      padding: 14px 18px;
+      border-radius: 12px;
+      background: rgba(2, 6, 14, 0.72);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      font-family: "Georgia", "Times New Roman", serif;
+      font-size: clamp(1.1rem, 2.1vw, 1.65rem);
+      line-height: 1.35;
+      letter-spacing: 0.02em;
+      text-shadow: 0 6px 20px rgba(0, 0, 0, 0.72);
       opacity: 0;
+      transform: translateY(8px);
+      transition: opacity 0.35s ease, transform 0.35s ease;
+      pointer-events: none;
     }
 
-    @keyframes colorFadeIn {
-      0% {
-        filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      }
-      20% {
-        filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      }
-      100% {
-        filter: grayscale(0%) contrast(1) brightness(1);
-      }
-    }
+    .story-caption.visible { opacity: 1; transform: translateY(0); }
 
-    .page.game-page {
-      background: #000;
-      padding: 0;
-    }
-
-    .game-frame {
-      width: 100%;
-      height: 100%;
-      display: block;
-      background: #000;
-      position: relative;
-      overflow: hidden;
-    }
-
-    .next-button {
-      position: fixed;
-      bottom: 24px;
-      right: 24px;
-      padding: 14px 26px;
-      border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      background: rgba(15, 23, 42, 0.85);
-      color: #f8fafc;
-      font-size: 16px;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
+    .gaze-target {
+      position: absolute;
+      width: clamp(90px, 9vw, 140px);
+      height: clamp(90px, 9vw, 140px);
+      border-radius: 50%;
+      border: 2px solid rgba(255, 255, 255, 0.5);
+      box-shadow: 0 0 0 4px rgba(76, 186, 255, 0.2), 0 0 22px rgba(52, 199, 255, 0.5);
+      background: radial-gradient(circle, rgba(80, 189, 255, 0.3), rgba(80, 189, 255, 0.07));
+      z-index: 5;
       cursor: pointer;
-      z-index: 20;
-      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      opacity: 0;
+      transition: opacity 0.2s ease, transform 0.2s ease;
+      pointer-events: none;
     }
 
-    .next-button:hover,
-    .next-button:focus-visible {
-      transform: translateY(-2px);
-      background: rgba(30, 41, 59, 0.95);
-      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
-      outline: none;
-    }
+    .gaze-target.visible { opacity: 1; pointer-events: auto; animation: pulse 1.4s infinite ease-in-out; }
+    .gaze-target.active { transform: scale(1.08); }
 
-    .fullscreen-button {
+    .hud {
       position: fixed;
-      top: 24px;
-      right: 24px;
+      top: 16px;
+      left: 16px;
+      z-index: 40;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .hud-pill {
+      padding: 8px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.28);
+      background: rgba(6, 8, 14, 0.7);
+      font-size: 13px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .next-button, .fullscreen-button {
+      position: fixed;
       padding: 12px 20px;
       border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      background: rgba(15, 23, 42, 0.75);
+      border: 1px solid rgba(255, 255, 255, 0.32);
+      background: rgba(15, 23, 42, 0.82);
       color: #f8fafc;
       font-size: 14px;
       font-weight: 600;
@@ -169,15 +298,46 @@
       cursor: pointer;
       z-index: 20;
       box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
     }
 
-    .fullscreen-button:hover,
-    .fullscreen-button:focus-visible {
-      transform: translateY(-2px);
-      background: rgba(30, 41, 59, 0.95);
-      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
-      outline: none;
+    .next-button { bottom: 24px; right: 24px; }
+    .fullscreen-button { top: 24px; right: 24px; }
+
+    .next-button[hidden] { display: none; }
+
+    .page.game-page { background: #000; padding: 0; align-items: stretch; justify-content: stretch; }
+    .game-frame { width: 100%; height: 100%; display: block; background: #000; position: relative; overflow: hidden; }
+
+    .samurai-challenge {
+      position: absolute;
+      top: 16px;
+      right: 16px;
+      z-index: 6;
+      width: min(280px, 40vw);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      background: rgba(6, 8, 14, 0.7);
+      border-radius: 12px;
+      padding: 10px;
+      display: none;
+    }
+
+    .samurai-challenge.visible { display: block; }
+
+    .challenge-target {
+      margin-top: 10px;
+      width: 92px;
+      height: 92px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(250, 208, 124, 0.5), rgba(250, 208, 124, 0.18));
+      border: 2px dashed rgba(250, 208, 124, 0.95);
+      display: grid;
+      place-items: center;
+      font-size: 12px;
+      text-align: center;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      cursor: pointer;
+      user-select: none;
     }
 
     .transition-overlay {
@@ -189,78 +349,122 @@
       z-index: 30;
     }
 
-    .transition-overlay.active {
-      animation: sceneFade 900ms ease-in-out forwards;
-    }
+    .transition-overlay.active { animation: sceneFade 900ms ease-in-out forwards; }
 
-    @keyframes sceneFade {
-      0% { opacity: 0; }
-      40% { opacity: 0.85; }
-      100% { opacity: 0; }
+    @keyframes colorFadeIn {
+      0%, 20% { filter: grayscale(100%) contrast(1.2) brightness(0.95); }
+      100% { filter: grayscale(0%) contrast(1) brightness(1); }
     }
+    @keyframes sceneFade { 0% { opacity: 0; } 40% { opacity: 0.85; } 100% { opacity: 0; } }
+    @keyframes pulse { 0%,100% { transform: scale(1);} 50% { transform: scale(1.06);} }
 
-    :fullscreen .story-page {
-      padding: 0;
-    }
-
-    :fullscreen .story-media {
-      max-width: 100vw;
-      max-height: 100vh;
-      border-radius: 0;
+    @media (max-width: 980px) {
+      .menu-shell { grid-template-columns: 1fr; height: min(92vh, 980px); }
+      .menu-preview { min-height: 280px; }
     }
   </style>
 </head>
 <body>
   <div id="app">
-    <section class="page story-page active" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn.">
-      <div class="story-media" data-story-media>
-        <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+    <section id="landingPage" class="page landing-page active" data-type="landing">
+      <div class="menu-shell">
+        <div class="menu-preview">
+          <img id="menuPreviewImage" src="../../images/samuraikata/paysagejapon.jpg" alt="Mode preview" />
+          <div class="menu-overlay">
+            <h1 id="menuPreviewTitle">Story Mode</h1>
+            <p id="menuPreviewDescription">Automatic progression through story scenes after narration.</p>
+          </div>
+        </div>
+        <div class="menu-panel">
+          <h2 class="menu-title">Eyegaze Samurai</h2>
+          <p class="menu-subtitle">Choose a path before beginning the journey.</p>
+          <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong>Auto advance after each narration and transition. No mini-game win condition.</button>
+          <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong>User advances pages manually. Mini-games remain free-play (no fail).</button>
+          <button class="mode-button" data-mode="samurai" type="button"><strong>Samurai</strong>User advances manually and must complete mini-game challenge or reset.</button>
+          <button id="startJourneyButton" class="start-button" type="button">Start Journey</button>
+        </div>
       </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere.">
+    <section class="page story-page" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn." data-text="At dawn, the valley waits in silence as your journey begins." data-audio="../../songs/samurai/cherryblossomsong.mp3" data-target="82,72">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
+      </div>
+    </section>
+
+    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere." data-text="You gather chi and shape it with calm breath and intent." data-audio="../../songs/samurai/samuraisong1.mp3" data-target="16,74">
+      <div class="story-media" data-story-media>
+        <img class="story-image" alt="" />
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="cherry">
       <div class="game-frame" data-game-host></div>
+      <div class="samurai-challenge" data-samurai-challenge>
+        <strong>Samurai challenge</strong>
+        <div>Hold gaze on the circle for 2 seconds to clear this game.</div>
+        <div class="challenge-target" data-challenge-target>Focus<br/>Here</div>
+      </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy.">
+    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy." data-text="Your master teaches that precision begins with patience." data-audio="../../songs/samurai/samuraisong2.mp3" data-target="84,30">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="meditation">
       <div class="game-frame" data-game-host></div>
+      <div class="samurai-challenge" data-samurai-challenge>
+        <strong>Samurai challenge</strong>
+        <div>Hold gaze on the circle for 2 seconds to clear this game.</div>
+        <div class="challenge-target" data-challenge-target>Focus<br/>Here</div>
+      </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky.">
+    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky." data-text="Lanterns rise like stars and carry your vows forward." data-audio="../../songs/samurai/samuraisong3.mp3" data-target="18,34">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="lamp">
       <div class="game-frame" data-game-host></div>
+      <div class="samurai-challenge" data-samurai-challenge>
+        <strong>Samurai challenge</strong>
+        <div>Hold gaze on the circle for 2 seconds to clear this game.</div>
+        <div class="challenge-target" data-challenge-target>Focus<br/>Here</div>
+      </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms.">
+    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms." data-text="The blade rests; your spirit does not. You are ready." data-audio="../../songs/samurai/samuraisong4.mp3" data-target="50,20">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Look here to continue" type="button"></button>
       </div>
     </section>
   </div>
 
-  <button id="nextButton" class="next-button" type="button">Next</button>
+  <div class="hud">
+    <div id="modeBadge" class="hud-pill">Mode: Story</div>
+    <div id="statusBadge" class="hud-pill">Select a mode and start.</div>
+  </div>
+
+  <button id="nextButton" class="next-button" type="button" hidden>Next</button>
   <button id="fullscreenButton" class="fullscreen-button" type="button">Fullscreen</button>
   <div id="transitionOverlay" class="transition-overlay" aria-hidden="true"></div>
 
@@ -270,13 +474,63 @@
       const nextButton = document.getElementById('nextButton');
       const fullscreenButton = document.getElementById('fullscreenButton');
       const transitionOverlay = document.getElementById('transitionOverlay');
+      const modeBadge = document.getElementById('modeBadge');
+      const statusBadge = document.getElementById('statusBadge');
+      const landingPage = document.getElementById('landingPage');
+      const modeButtons = Array.from(document.querySelectorAll('.mode-button'));
+      const startJourneyButton = document.getElementById('startJourneyButton');
+      const menuPreviewImage = document.getElementById('menuPreviewImage');
+      const menuPreviewTitle = document.getElementById('menuPreviewTitle');
+      const menuPreviewDescription = document.getElementById('menuPreviewDescription');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
       const fadeDurationMs = 4000;
+      const dwellForAdvanceMs = 1000;
+      const storyAutoDelayMs = 1300;
+      const gameAutoDelayMs = 5500;
+      const samuraiTimeoutMs = 25000;
+
+      let currentMode = 'story';
       let currentIndex = 0;
+      let narrationAudio = null;
+      let isJourneyStarted = false;
 
       const storyTimers = new WeakMap();
       const gameSessions = new Map();
+      let activeSamuraiChallenge = null;
+
+      const modeConfig = {
+        story: {
+          label: 'Story',
+          previewImage: '../../images/samuraikata/paysagejapon.jpg',
+          previewTitle: 'Story Mode',
+          previewDescription: 'Automatic progression through story scenes after narration.',
+          autoAdvanceStory: true,
+          manualAdvance: false,
+          enforceGameWin: false,
+          autoAdvanceGame: true,
+        },
+        autonomous: {
+          label: 'Autonomous Advancer',
+          previewImage: '../../images/samuraikata/maitrechi.jpg',
+          previewTitle: 'Autonomous Advancer',
+          previewDescription: 'User advances pages manually with no mini-game fail condition.',
+          autoAdvanceStory: false,
+          manualAdvance: true,
+          enforceGameWin: false,
+          autoAdvanceGame: false,
+        },
+        samurai: {
+          label: 'Samurai',
+          previewImage: '../../images/samuraikata/katanafleurs.jpg',
+          previewTitle: 'Samurai Mode',
+          previewDescription: 'Manual story advance + mini-game challenge required to continue.',
+          autoAdvanceStory: false,
+          manualAdvance: true,
+          enforceGameWin: true,
+          autoAdvanceGame: false,
+        }
+      };
 
       const triggerTransition = () => {
         if (!transitionOverlay) return;
@@ -285,14 +539,42 @@
         transitionOverlay.classList.add('active');
       };
 
+      const setStatus = (text) => {
+        if (statusBadge) statusBadge.textContent = text;
+      };
+
+      const stopNarration = () => {
+        if (!narrationAudio) return;
+        narrationAudio.pause();
+        narrationAudio.currentTime = 0;
+        narrationAudio = null;
+      };
+
+      const updateModeUI = () => {
+        const config = modeConfig[currentMode];
+        modeButtons.forEach((button) => {
+          button.classList.toggle('active', button.dataset.mode === currentMode);
+        });
+        if (menuPreviewImage) menuPreviewImage.src = config.previewImage;
+        if (menuPreviewTitle) menuPreviewTitle.textContent = config.previewTitle;
+        if (menuPreviewDescription) menuPreviewDescription.textContent = config.previewDescription;
+        if (modeBadge) modeBadge.textContent = `Mode: ${config.label}`;
+        if (!isJourneyStarted) setStatus('Select a mode and start.');
+      };
+
       const clearStoryTimers = (page) => {
         const timers = storyTimers.get(page);
         if (!timers) return;
-        if (timers.videoTimeout) {
-          clearTimeout(timers.videoTimeout);
-        }
-        if (timers.checkTimeout) {
-          clearTimeout(timers.checkTimeout);
+        ['fadeTimeout', 'hoverTimeout', 'autoTimeout', 'checkTimeout', 'samuraiTimeout'].forEach((key) => {
+          if (timers[key]) clearTimeout(timers[key]);
+        });
+        if (timers.dwellHandler && timers.gazeTarget) {
+          timers.gazeTarget.removeEventListener('mouseenter', timers.dwellHandler.enter);
+          timers.gazeTarget.removeEventListener('mouseleave', timers.dwellHandler.leave);
+          timers.gazeTarget.removeEventListener('focus', timers.dwellHandler.enter);
+          timers.gazeTarget.removeEventListener('blur', timers.dwellHandler.leave);
+          timers.gazeTarget.removeEventListener('touchstart', timers.dwellHandler.enter);
+          timers.gazeTarget.removeEventListener('touchend', timers.dwellHandler.leave);
         }
         storyTimers.delete(page);
       };
@@ -301,22 +583,37 @@
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
         const video = page.querySelector('.story-video');
+        const caption = page.querySelector('[data-story-caption]');
+        const gazeTarget = page.querySelector('[data-gaze-target]');
         if (!media || !image || !video) return;
+
         media.classList.remove('video-playing');
         video.pause();
+        video.currentTime = 0;
         video.removeAttribute('src');
         video.load();
+        video.onended = null;
         image.style.animation = 'none';
         void image.offsetHeight;
-        image.style.animation = 'colorFadeIn 4s ease-in-out forwards';
+        image.style.animation = `colorFadeIn ${fadeDurationMs / 1000}s ease-in-out forwards`;
+
+        if (caption) {
+          caption.classList.remove('visible');
+          caption.textContent = '';
+        }
+        if (gazeTarget) {
+          gazeTarget.classList.remove('visible', 'active');
+        }
       };
 
       const checkVideoExists = (path, callback) => {
         const tester = document.createElement('video');
         let settled = false;
+        let timeoutId = null;
         const clean = () => {
           tester.removeEventListener('loadeddata', onLoad);
           tester.removeEventListener('error', onError);
+          if (timeoutId) clearTimeout(timeoutId);
         };
         const onLoad = () => {
           if (settled) return;
@@ -335,56 +632,146 @@
         tester.src = path;
         tester.preload = 'metadata';
         tester.load();
-        const timeoutId = setTimeout(() => {
+        timeoutId = setTimeout(() => {
           if (settled) return;
           settled = true;
           clean();
           callback(false);
-        }, 1200);
-        return timeoutId;
+        }, 1500);
+      };
+
+      const parseTargetPos = (raw) => {
+        if (!raw) return { x: 85, y: 72 };
+        const [xStr, yStr] = raw.split(',');
+        const x = Number.parseFloat(xStr);
+        const y = Number.parseFloat(yStr);
+        if (Number.isNaN(x) || Number.isNaN(y)) return { x: 85, y: 72 };
+        return { x: Math.min(94, Math.max(6, x)), y: Math.min(92, Math.max(8, y)) };
+      };
+
+      const queueAdvance = (delayMs = 0) => {
+        const pendingPage = pages[currentIndex];
+        setTimeout(() => {
+          if (pages[currentIndex] !== pendingPage) return;
+          nextPage();
+        }, delayMs);
+      };
+
+      const playPageVideo = (page, video, media, autoAfterVideo = false) => {
+        if (!video || !media) {
+          queueAdvance();
+          return;
+        }
+        media.classList.add('video-playing');
+        video.currentTime = 0;
+        const playPromise = video.play();
+        if (playPromise && typeof playPromise.catch === 'function') {
+          playPromise.catch(() => {});
+        }
+        video.onended = () => {
+          if (pages[currentIndex] !== page) return;
+          triggerTransition();
+          queueAdvance(autoAfterVideo ? storyAutoDelayMs : 240);
+        };
       };
 
       const setupStoryPage = (page) => {
         clearStoryTimers(page);
+        stopNarration();
+
         const imageName = page.dataset.image;
         const altText = page.dataset.alt || '';
+        const text = page.dataset.text || '';
+        const audioPath = page.dataset.audio || '';
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
         const video = page.querySelector('.story-video');
-        if (!imageName || !media || !image || !video) return;
+        const caption = page.querySelector('[data-story-caption]');
+        const gazeTarget = page.querySelector('[data-gaze-target]');
+        if (!imageName || !media || !image || !video || !caption || !gazeTarget) return;
 
         resetStoryMedia(page);
         image.src = `${imageBasePath}${imageName}`;
         image.alt = altText;
-        media.classList.remove('video-playing');
+
+        const pos = parseTargetPos(page.dataset.target);
+        gazeTarget.style.left = `${pos.x}%`;
+        gazeTarget.style.top = `${pos.y}%`;
 
         const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
         const videoPath = `${videoBasePath}${videoName}`;
 
-        const timers = { videoTimeout: null, checkTimeout: null };
-        timers.checkTimeout = checkVideoExists(videoPath, (exists) => {
+        const timers = { gazeTarget, dwellHandler: null, videoAvailable: false };
+
+        const revealNarrationAndUI = () => {
+          if (pages[currentIndex] !== page) return;
+          caption.textContent = text;
+          caption.classList.add('visible');
+          gazeTarget.classList.add('visible');
+          setStatus('Look at the glowing circle to play the scene video.');
+          if (audioPath) {
+            narrationAudio = new Audio(audioPath);
+            narrationAudio.play().catch(() => {});
+          }
+
+          if (modeConfig[currentMode].autoAdvanceStory) {
+            timers.autoTimeout = setTimeout(() => {
+              if (pages[currentIndex] !== page) return;
+              if (!timers.videoAvailable) {
+                triggerTransition();
+                queueAdvance(storyAutoDelayMs);
+                return;
+              }
+              playPageVideo(page, video, media, true);
+            }, 2200);
+          }
+        };
+
+        const handleTargetEnter = () => {
+          gazeTarget.classList.add('active');
+          timers.hoverTimeout = setTimeout(() => {
+            if (pages[currentIndex] !== page) return;
+            if (modeConfig[currentMode].autoAdvanceStory) return;
+            if (!timers.videoAvailable) {
+              triggerTransition();
+              queueAdvance(240);
+              return;
+            }
+            playPageVideo(page, video, media);
+          }, dwellForAdvanceMs);
+        };
+
+        const handleTargetLeave = () => {
+          gazeTarget.classList.remove('active');
+          if (timers.hoverTimeout) {
+            clearTimeout(timers.hoverTimeout);
+            timers.hoverTimeout = null;
+          }
+        };
+
+        timers.dwellHandler = { enter: handleTargetEnter, leave: handleTargetLeave };
+        gazeTarget.addEventListener('mouseenter', handleTargetEnter);
+        gazeTarget.addEventListener('mouseleave', handleTargetLeave);
+        gazeTarget.addEventListener('focus', handleTargetEnter);
+        gazeTarget.addEventListener('blur', handleTargetLeave);
+        gazeTarget.addEventListener('touchstart', handleTargetEnter, { passive: true });
+        gazeTarget.addEventListener('touchend', handleTargetLeave);
+
+        timers.fadeTimeout = setTimeout(revealNarrationAndUI, fadeDurationMs + 80);
+
+        checkVideoExists(videoPath, (exists) => {
+          timers.videoAvailable = exists;
           if (!exists) return;
           video.src = videoPath;
           video.load();
-          timers.videoTimeout = setTimeout(() => {
-            if (pages[currentIndex] !== page) return;
-            media.classList.add('video-playing');
-            const playPromise = video.play();
-            if (playPromise && typeof playPromise.catch === 'function') {
-              playPromise.catch(() => {});
-            }
-          }, fadeDurationMs + 300);
         });
+
         storyTimers.set(page, timers);
       };
 
-      const gameTemplates = {
-        cherry: 'tpl-cherryblossom',
-        meditation: 'tpl-meditation',
-        lamp: 'tpl-lamp'
-      };
-
+      const gameTemplates = { cherry: 'tpl-cherryblossom', meditation: 'tpl-meditation', lamp: 'tpl-lamp' };
       const templateCache = {};
+
       const loadTemplate = (id) => {
         if (!templateCache[id]) {
           const tpl = document.getElementById(id);
@@ -398,80 +785,113 @@
         if (!key) return;
         const session = gameSessions.get(key);
         if (!session) return;
+        if (activeSamuraiChallenge && activeSamuraiChallenge.page === page) {
+          clearTimeout(activeSamuraiChallenge.timeoutId);
+          activeSamuraiChallenge = null;
+        }
         const attemptStop = (api) => {
           if (!api || typeof api.stop !== 'function') return;
           try {
             const maybePromise = api.stop();
-            if (maybePromise && typeof maybePromise.then === 'function') {
-              maybePromise.catch(() => {});
-            }
-          } catch (error) {
-            /* ignore stop errors */
-          }
+            if (maybePromise && typeof maybePromise.then === 'function') maybePromise.catch(() => {});
+          } catch (_) {}
         };
-        if (session.api) {
-          attemptStop(session.api);
-        } else if (session.apiPromise) {
-          session.apiPromise.then(attemptStop).catch(() => {});
-        }
-        if (session.host) {
-          session.mountedNodes = Array.from(session.host.childNodes);
-          if (session.mountedNodes.length) {
-            session.mountedNodes.forEach((node) => {
-              if (node.parentNode === session.host) {
-                session.host.removeChild(node);
-              }
-            });
-            session.detached = true;
-          }
-        }
+        if (session.api) attemptStop(session.api);
+        else if (session.apiPromise) session.apiPromise.then(attemptStop).catch(() => {});
       };
 
       const mountGameTemplate = async (host, templateId) => {
         const html = loadTemplate(templateId);
         if (!html) return null;
         let scriptPromises = [];
-        try {
-          host.innerHTML = '';
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(html, 'text/html');
-          const fragment = document.createDocumentFragment();
-          const appendChildren = (parent) => {
-            if (!parent) return;
-            parent.childNodes.forEach((node) => {
-              if (node.nodeName === 'TITLE') return;
-              fragment.appendChild(node.cloneNode(true));
-            });
-          };
-          appendChildren(doc.head);
-          appendChildren(doc.body);
-          window.storyGameApi = null;
-          host.appendChild(fragment);
-          host.querySelectorAll('script').forEach((oldScript) => {
-            const newScript = document.createElement('script');
-            newScript.async = false;
-            Array.from(oldScript.attributes).forEach((attr) => {
-              newScript.setAttribute(attr.name, attr.value);
-            });
-            newScript.textContent = oldScript.textContent;
-            const promise = newScript.src
-              ? new Promise((resolve) => {
-                  newScript.addEventListener('load', resolve, { once: true });
-                  newScript.addEventListener('error', resolve, { once: true });
-                })
-              : Promise.resolve();
-            scriptPromises.push(promise);
-            oldScript.replaceWith(newScript);
+        host.innerHTML = '';
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const fragment = document.createDocumentFragment();
+
+        const appendChildren = (parent) => {
+          if (!parent) return;
+          parent.childNodes.forEach((node) => {
+            if (node.nodeName === 'TITLE') return;
+            fragment.appendChild(node.cloneNode(true));
           });
-        } catch (error) {
-          return null;
-        }
-        try {
-          await Promise.all(scriptPromises);
-        } catch (error) {
-          /* ignore script load failures */
-        }
+        };
+
+        appendChildren(doc.head);
+        appendChildren(doc.body);
+        window.storyGameApi = null;
+        host.appendChild(fragment);
+
+        host.querySelectorAll('script').forEach((oldScript) => {
+          const newScript = document.createElement('script');
+          newScript.async = false;
+          Array.from(oldScript.attributes).forEach((attr) => newScript.setAttribute(attr.name, attr.value));
+          newScript.textContent = oldScript.textContent;
+          const promise = newScript.src
+            ? new Promise((resolve) => {
+                newScript.addEventListener('load', resolve, { once: true });
+                newScript.addEventListener('error', resolve, { once: true });
+              })
+            : Promise.resolve();
+          scriptPromises.push(promise);
+          oldScript.replaceWith(newScript);
+        });
+
+        try { await Promise.all(scriptPromises); } catch (_) {}
         return window.storyGameApi || null;
+      };
+
+      const installSamuraiChallenge = (page) => {
+        const box = page.querySelector('[data-samurai-challenge]');
+        const target = page.querySelector('[data-challenge-target]');
+        if (!box || !target) return;
+
+        box.classList.toggle('visible', modeConfig[currentMode].enforceGameWin);
+        target.onmouseenter = null;
+        target.onmouseleave = null;
+        target.onfocus = null;
+        target.onblur = null;
+
+        if (!modeConfig[currentMode].enforceGameWin) {
+          return;
+        }
+
+        let holdTimeout = null;
+        const complete = () => {
+          setStatus('Challenge complete. Transitioning to next page.');
+          if (activeSamuraiChallenge) {
+            clearTimeout(activeSamuraiChallenge.timeoutId);
+            activeSamuraiChallenge = null;
+          }
+          triggerTransition();
+          queueAdvance(350);
+        };
+
+        const startHold = () => {
+          holdTimeout = setTimeout(complete, 2000);
+          target.style.transform = 'scale(1.08)';
+        };
+
+        const clearHold = () => {
+          if (holdTimeout) {
+            clearTimeout(holdTimeout);
+            holdTimeout = null;
+          }
+          target.style.transform = '';
+        };
+
+        target.onmouseenter = startHold;
+        target.onmouseleave = clearHold;
+        target.onfocus = startHold;
+        target.onblur = clearHold;
+
+        const timeoutId = setTimeout(() => {
+          if (pages[currentIndex] !== page || currentMode !== 'samurai') return;
+          setStatus('Challenge failed. Restarting mini-game.');
+          showPage(currentIndex);
+        }, samuraiTimeoutMs);
+
+        activeSamuraiChallenge = { page, timeoutId };
       };
 
       const loadGame = (key, page) => {
@@ -483,83 +903,101 @@
           const templateId = gameTemplates[key];
           if (!templateId) return;
           const apiPromise = mountGameTemplate(host, templateId);
-          const mountedNodes = Array.from(host.childNodes);
-          session = { host, api: null, apiPromise, mountedNodes, detached: false };
+          session = { host, api: null, apiPromise };
           gameSessions.set(key, session);
-        } else {
-          session.host = host;
-          if (!session.mountedNodes || !session.mountedNodes.length) {
-            session.mountedNodes = Array.from(host.childNodes);
-          }
-          if (session.detached && session.mountedNodes && session.mountedNodes.length) {
-            host.innerHTML = '';
-            session.mountedNodes.forEach((node) => {
-              host.appendChild(node);
-            });
-            session.detached = false;
-          }
         }
 
         const startGame = async () => {
           try {
-            if (!session.api) {
-              session.api = await session.apiPromise;
-            }
-          } catch (error) {
-            return;
-          }
+            if (!session.api) session.api = await session.apiPromise;
+          } catch (_) { return; }
           if (pages[currentIndex] !== page) return;
           const api = session.api;
-          if (!api || typeof api.start !== 'function') return;
-          window.requestAnimationFrame(() => {
+          if (api && typeof api.start === 'function') {
             try {
               const maybePromise = api.start();
-              if (maybePromise && typeof maybePromise.then === 'function') {
-                maybePromise.catch(() => {});
-              }
-            } catch (error) {
-              /* ignore start errors */
-            }
-          });
+              if (maybePromise && typeof maybePromise.then === 'function') maybePromise.catch(() => {});
+            } catch (_) {}
+          }
+
+          installSamuraiChallenge(page);
+
+          if (!modeConfig[currentMode].enforceGameWin && modeConfig[currentMode].autoAdvanceGame) {
+            setStatus('Mini-game free play. Advancing automatically.');
+            setTimeout(() => {
+              if (pages[currentIndex] !== page) return;
+              triggerTransition();
+              queueAdvance(250);
+            }, gameAutoDelayMs);
+          } else if (!modeConfig[currentMode].enforceGameWin) {
+            setStatus('Mini-game free play. Use Next when ready.');
+          } else {
+            setStatus('Samurai challenge active: complete it before timeout.');
+          }
         };
 
         startGame();
       };
 
+      const updateNextButtonVisibility = () => {
+        const page = pages[currentIndex];
+        const manualMode = modeConfig[currentMode].manualAdvance;
+        const shouldShow = isJourneyStarted && manualMode && page && page.dataset.type !== 'landing';
+        if (nextButton) nextButton.hidden = !shouldShow;
+      };
+
       const showPage = (index) => {
         if (index < 0 || index >= pages.length) return;
-        if (index === currentIndex) return;
 
         const previousPage = pages[currentIndex];
         if (previousPage) {
           previousPage.classList.remove('active');
-          if (previousPage.dataset.type === 'story') {
-            clearStoryTimers(previousPage);
-            resetStoryMedia(previousPage);
-          }
-          if (previousPage.dataset.type === 'game') {
-            stopGame(previousPage);
-            triggerTransition();
-          }
+          clearStoryTimers(previousPage);
+          if (previousPage.dataset.type === 'story') resetStoryMedia(previousPage);
+          if (previousPage.dataset.type === 'game') stopGame(previousPage);
         }
 
         currentIndex = index;
         const page = pages[currentIndex];
         if (!page) return;
         page.classList.add('active');
+        updateNextButtonVisibility();
+
+        if (page.dataset.type === 'landing') {
+          setStatus('Select a mode and start.');
+          return;
+        }
 
         if (page.dataset.type === 'story') {
+          setStatus('Story scene loading...');
           setupStoryPage(page);
         }
+
         if (page.dataset.type === 'game') {
           loadGame(page.dataset.game, page);
         }
       };
 
       const nextPage = () => {
+        if (!isJourneyStarted) return;
         const nextIndex = (currentIndex + 1) % pages.length;
-        showPage(nextIndex);
+        showPage(nextIndex === 0 ? 1 : nextIndex);
       };
+
+      modeButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          currentMode = button.dataset.mode;
+          updateModeUI();
+        });
+      });
+
+      if (startJourneyButton) {
+        startJourneyButton.addEventListener('click', () => {
+          isJourneyStarted = true;
+          triggerTransition();
+          showPage(1);
+        });
+      }
 
       if (nextButton) {
         nextButton.addEventListener('click', () => {
@@ -575,19 +1013,11 @@
         const root = document.documentElement;
         const method = root.requestFullscreen || root.webkitRequestFullscreen || root.msRequestFullscreen;
         if (method) {
-          try {
-            await method.call(root);
-          } catch (error) {
-            /* ignore fullscreen failures */
-          }
+          try { await method.call(root); } catch (_) {}
         }
       };
 
-      if (fullscreenButton) {
-        fullscreenButton.addEventListener('click', () => {
-          requestFullscreen();
-        });
-      }
+      if (fullscreenButton) fullscreenButton.addEventListener('click', requestFullscreen);
 
       const updateFullscreenLabel = () => {
         if (!fullscreenButton) return;
@@ -595,14 +1025,13 @@
       };
 
       document.addEventListener('fullscreenchange', updateFullscreenLabel);
-
       document.addEventListener('keydown', (event) => {
-        if (event.key === 'ArrowRight' || event.key === ' ') {
-          nextPage();
-        }
+        if (!isJourneyStarted) return;
+        if (event.key === 'ArrowRight' || event.key === ' ') nextPage();
       });
 
-      setupStoryPage(pages[currentIndex]);
+      updateModeUI();
+      showPage(0);
       updateFullscreenLabel();
     });
   </script>

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -47,44 +47,58 @@
       width: 100%;
       height: 100%;
       display: grid;
-      grid-template-columns: minmax(240px, 28vw) 1fr;
-      gap: clamp(10px, 1.2vw, 18px);
-      padding: clamp(14px, 2.2vw, 34px);
+      grid-template-columns: minmax(360px, 40vw) 1fr;
+      gap: 0;
+      padding: 0;
     }
 
-    .menu-controls {
+    .menu-left {
       position: relative;
-      display: grid;
-      grid-template-rows: 1fr auto;
-      align-items: end;
-      padding: 16px;
-      border-radius: 30px;
       overflow: hidden;
-      background:
-        linear-gradient(145deg, rgba(7, 8, 12, .62), rgba(7, 8, 12, .35)),
-        url('../../images/samurai/cherryblossom.png') center left / 120% auto no-repeat;
-      border: 1px solid rgba(255, 230, 195, .16);
+      background: linear-gradient(170deg, rgba(15, 10, 16, .82), rgba(8, 9, 14, .9));
+      padding: clamp(20px, 3vw, 34px);
+      display: grid;
+      grid-template-rows: auto auto 1fr auto;
+      gap: 14px;
     }
 
-    .menu-row {
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: 10px;
-      align-items: end;
-      margin-bottom: 16px;
+    .menu-top-controls {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      z-index: 3;
+      flex-wrap: wrap;
+    }
+
+    #leftBlossomField {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      z-index: 1;
+    }
+
+    .left-blossom {
+      position: absolute;
+      width: 80px;
+      height: 80px;
+      object-fit: contain;
+      opacity: .34;
+      filter: drop-shadow(0 6px 10px rgba(0,0,0,.2));
+      animation: blossomFloat 11s ease-in-out infinite;
     }
 
     .mode-button {
       border: 1px solid rgba(248, 213, 150, .18);
       border-radius: 999px;
-      background: rgba(17, 12, 18, .42);
+      background: rgba(17, 12, 18, .25);
       color: #f9efe1;
       padding: 10px 14px;
       text-align: left;
       cursor: pointer;
       min-height: 0;
       transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
-      backdrop-filter: blur(2px);
+      backdrop-filter: blur(1.5px);
+      z-index: 3;
     }
 
     .mode-button strong {
@@ -94,7 +108,7 @@
       letter-spacing: .05em;
       text-transform: uppercase;
       font-size: clamp(.84rem, 1.08vw, 1rem);
-      margin-bottom: 2px;
+      margin-bottom: 0;
     }
 
     .mode-button:hover,
@@ -107,18 +121,27 @@
 
     .mode-button.active {
       border-color: rgba(252, 216, 147, .58);
-      background: rgba(84, 51, 28, .5);
+      background: rgba(84, 51, 28, .38);
       box-shadow: inset 0 0 0 1px rgba(252,216,147,.2), 0 8px 18px rgba(0,0,0,.26);
+    }
+
+    .mode-explanation {
+      margin: 0;
+      z-index: 3;
+      color: rgba(255, 241, 226, .92);
+      line-height: 1.55;
+      font-size: clamp(.94rem, 1.1vw, 1.06rem);
+      max-width: 92%;
     }
 
     .menu-preview {
       position: relative;
       overflow: hidden;
-      border-radius: 40px;
-      border: 1px solid rgba(255,255,255,.12);
+      border-radius: 0;
+      border: 0;
       background: #000;
       min-height: 100%;
-      box-shadow: 0 24px 50px rgba(0,0,0,.38);
+      height: 100%;
     }
 
     .menu-preview img {
@@ -126,20 +149,20 @@
       height: 100%;
       object-fit: cover;
       transition: transform .45s ease;
-      transform: scale(1.035);
+      transform: scale(1);
     }
 
     .menu-overlay {
       position: absolute;
       left: 2.2vw;
       right: 2.2vw;
-      bottom: 2.2vw;
-      padding: 12px 14px;
-      border-radius: 16px;
-      border: 1px solid rgba(249, 213, 140, .18);
-      background: linear-gradient(180deg, rgba(20, 13, 14, .36), rgba(9, 11, 18, .44));
-      backdrop-filter: blur(3px);
-      box-shadow: 0 6px 14px rgba(0,0,0,.18);
+      top: 1.6vw;
+      bottom: auto;
+      padding: 0;
+      border: 0;
+      background: transparent;
+      box-shadow: none;
+      pointer-events: none;
     }
 
     .menu-overlay h1 {
@@ -149,9 +172,10 @@
       letter-spacing: .06em;
       text-transform: uppercase;
       font-size: clamp(1.2rem, 2.2vw, 2.1rem);
+      text-shadow: 0 8px 18px rgba(0,0,0,.6);
     }
 
-    .menu-overlay p { margin: 0; font-size: clamp(.95rem, 1.25vw, 1.1rem); line-height: 1.45; }
+    .menu-overlay p { display: none; }
 
     .menu-footer {
       display: flex;
@@ -160,6 +184,7 @@
       gap: 14px;
       padding: 4px 0;
       flex-wrap: wrap;
+      z-index: 3;
     }
 
     .loading-track {
@@ -379,9 +404,14 @@
     @keyframes sceneFade { 0% { opacity: 0; } 40% { opacity: .85; } 100% { opacity: 0; } }
 
     @media (max-width: 980px) {
-      .menu-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
-      .menu-controls { min-height: 260px; }
+      .menu-shell { grid-template-columns: 1fr; grid-template-rows: 46vh 54vh; }
+      .menu-left { min-height: 260px; }
       .loading-label { min-width: 100%; text-align: left; }
+    }
+
+    @keyframes blossomFloat {
+      0%, 100% { transform: translateY(0) rotate(0deg); }
+      50% { transform: translateY(-12px) rotate(7deg); }
     }
   </style>
 </head>
@@ -389,12 +419,14 @@
   <div id="app">
     <section id="landingPage" class="page landing-page active" data-type="landing">
       <div class="menu-shell">
-        <div class="menu-controls">
-          <div class="menu-row">
-            <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong>A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.</button>
-            <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong>You decide when to advance scenes, but mini-games remain relaxed and never block your journey.</button>
-            <button class="mode-button" data-mode="samurai" type="button"><strong>Samurai</strong>A demanding path: you control progression and must complete mini-game challenges to keep moving.</button>
+        <div class="menu-left">
+          <div id="leftBlossomField" aria-hidden="true"></div>
+          <div class="menu-top-controls">
+            <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong></button>
+            <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong></button>
+            <button class="mode-button" data-mode="samurai" type="button"><strong>Samurai</strong></button>
           </div>
+          <p id="modeExplanation" class="mode-explanation">A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.</p>
           <div class="menu-footer">
             <div class="loading-track"><div id="loadingFill" class="loading-fill"></div></div>
             <div id="loadingLabel" class="loading-label">Preparing assets… 0%</div>
@@ -490,9 +522,11 @@
       const menuPreviewImage = document.getElementById('menuPreviewImage');
       const menuPreviewTitle = document.getElementById('menuPreviewTitle');
       const menuPreviewDescription = document.getElementById('menuPreviewDescription');
+      const modeExplanation = document.getElementById('modeExplanation');
       const loadingFill = document.getElementById('loadingFill');
       const loadingLabel = document.getElementById('loadingLabel');
       const chiCursor = document.getElementById('chiCursor');
+      const leftBlossomField = document.getElementById('leftBlossomField');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
 
@@ -540,6 +574,26 @@
           manualAdvance: true,
           enforceGameWin: true,
           autoGameAdvance: false,
+        }
+      };
+
+      const seedLeftBlossoms = () => {
+        if (!leftBlossomField) return;
+        leftBlossomField.innerHTML = '';
+        const total = 18;
+        for (let i = 0; i < total; i += 1) {
+          const img = document.createElement('img');
+          img.src = '../../images/samurai/cherryblossom.png';
+          img.className = 'left-blossom';
+          const size = 42 + Math.random() * 84;
+          img.style.width = `${size}px`;
+          img.style.height = `${size}px`;
+          img.style.left = `${Math.random() * 82}%`;
+          img.style.top = `${Math.random() * 88}%`;
+          img.style.opacity = `${0.14 + Math.random() * 0.28}`;
+          img.style.animationDelay = `${Math.random() * 6}s`;
+          img.style.animationDuration = `${8 + Math.random() * 10}s`;
+          leftBlossomField.appendChild(img);
         }
       };
 
@@ -995,6 +1049,7 @@
         menuPreviewImage.src = mode.previewImage;
         menuPreviewTitle.textContent = mode.previewTitle;
         menuPreviewDescription.textContent = mode.previewDescription;
+        if (modeExplanation) modeExplanation.textContent = mode.previewDescription;
       };
 
       modeButtons.forEach((button) => {
@@ -1031,6 +1086,7 @@
       });
 
       updateModeUI();
+      seedLeftBlossoms();
       showPage(0);
       runPreload();
     });


### PR DESCRIPTION
### Motivation
- Introduce a friendly landing/menu experience and multiple play modes so users can choose automatic or challenge-driven flows before starting the story journey. 
- Improve visual design and responsiveness across story, game and HUD elements to create a polished, immersive presentation. 
- Provide reliable media handling and gaze-based interactions so narration, video playback and mini-game flows behave predictably. 
- Harden game lifecycle logic to safely mount/unmount templates and enforce or relax mini-game completion depending on mode.

### Description
- Add a landing page with a `menu-shell`, mode buttons (`story`, `autonomous`, `samurai`), and a `Start Journey` flow that updates the HUD and mode preview. 
- Large CSS overhaul: updated fonts, colors, layout grid, responsive rules, animations, and UI components including `.menu-panel`, `.gaze-target`, `.samurai-challenge`, and HUD pills. 
- Story pages now include `data-text` and `data-audio`, a `story-caption`, a `gaze-target` button, and robust handling for caption reveal, narration audio, and dwell-to-advance behavior. 
- Media and timers refactor: added `checkVideoExists`, generalized `storyTimers` clearing, reset video `currentTime`, and new `playPageVideo`/`queueAdvance` helpers to manage transitions and auto-advance behavior. 
- Game lifecycle improvements: simplified `mountGameTemplate` script handling, persistent `gameSessions`, safer `stopGame`, and a new `installSamuraiChallenge` that enforces hold-to-complete behavior and timeouts for `samurai` mode. 
- UI/UX additions: mode badge and status badge in HUD, `nextButton` visibility tied to mode, fullscreen support cleanup, keyboard navigation gated by journey start, and various small bug fixes and performance tweaks. 

### Testing
- Verified JavaScript syntax with a static check (`node --check`) and linting (`eslint`) with no syntax errors reported. 
- Ran an automated headless browser smoke test to load the page, switch modes, start the journey, and navigate at least one story and one game page, and it completed without errors. 
- Exercised the `mountGameTemplate` path and `stopGame` cleanup in the automated run to validate template script execution and teardown. 
- Confirmed that video existence probing (`checkVideoExists`) and narration audio playback paths were exercised during the smoke test and behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e387c429ec8325bf7df0ef72d9a7a0)