### PR TITLE
Add landing mode selector, hotspots, narration, and refactor story/game flow

### DIFF
--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -7,42 +7,120 @@
   <style>
     :root {
       color-scheme: dark;
-      font-family: "Helvetica Neue", Arial, system-ui, sans-serif;
+      font-family: "Trebuchet MS", "Segoe UI", system-ui, sans-serif;
     }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; }
+    body { background: #08090c; color: #f9fafb; overflow: hidden; }
 
-    * {
-      box-sizing: border-box;
-    }
+    #app { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
 
-    html,
-    body {
-      margin: 0;
-      height: 100%;
-    }
+    .page { position: absolute; inset: 0; display: none; }
+    .page.active { display: flex; align-items: center; justify-content: center; }
 
-    body {
-      background: #08090c;
-      color: #f9fafb;
-      overflow: hidden;
-    }
-
-    #app {
-      position: relative;
-      width: 100vw;
-      height: 100vh;
-      overflow: hidden;
-    }
-
-    .page {
-      position: absolute;
-      inset: 0;
-      display: none;
-    }
-
-    .page.active {
+    .landing {
       display: flex;
-      align-items: center;
+      background: radial-gradient(circle at top, rgba(192, 57, 43, 0.34), transparent 55%),
+                  radial-gradient(circle at 84% 20%, rgba(59, 130, 246, 0.18), transparent 45%),
+                  #03040a;
+      padding: clamp(18px, 3.8vw, 48px);
+      gap: clamp(16px, 2vw, 30px);
+      align-items: stretch;
       justify-content: center;
+    }
+
+    .landing-panel {
+      width: min(46vw, 520px);
+      min-width: 320px;
+      background: linear-gradient(170deg, rgba(15, 20, 30, 0.92), rgba(12, 7, 9, 0.85));
+      border: 1px solid rgba(255, 230, 182, 0.25);
+      border-radius: 20px;
+      box-shadow: 0 24px 56px rgba(0, 0, 0, 0.6);
+      padding: clamp(16px, 2.1vw, 28px);
+      backdrop-filter: blur(5px);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      z-index: 2;
+    }
+
+    .landing h1 {
+      font-size: clamp(28px, 4vw, 48px);
+      margin: 0;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #ffe5b9;
+      text-shadow: 0 6px 20px rgba(0,0,0,.45);
+    }
+
+    .landing-sub {
+      margin: 0 0 10px;
+      color: #d4c7ad;
+      line-height: 1.45;
+      font-size: clamp(14px, 1.5vw, 18px);
+    }
+
+    .mode-grid { display: grid; gap: 10px; }
+
+    .mode-button {
+      text-align: left;
+      padding: 14px 16px;
+      border-radius: 14px;
+      border: 1px solid rgba(255,255,255,0.22);
+      background: linear-gradient(150deg, rgba(31, 41, 55, .88), rgba(10, 12, 17, .9));
+      color: #f8fafc;
+      cursor: pointer;
+      font-size: 15px;
+      line-height: 1.35;
+      transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+    }
+    .mode-button:hover,
+    .mode-button:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(255, 210, 120, .9);
+      box-shadow: 0 16px 32px rgba(0,0,0,.45);
+      outline: none;
+    }
+
+    .mode-button strong {
+      display: block;
+      text-transform: uppercase;
+      letter-spacing: .06em;
+      margin-bottom: 4px;
+      color: #ffe6bd;
+    }
+
+    .hero-card {
+      position: relative;
+      flex: 1;
+      max-width: min(47vw, 780px);
+      border-radius: 20px;
+      overflow: hidden;
+      border: 1px solid rgba(255,255,255,.18);
+      box-shadow: 0 26px 55px rgba(0,0,0,.65);
+      background: #000;
+    }
+    .hero-card img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+      transition: opacity .35s ease, transform .35s ease;
+    }
+    .hero-card:hover img { transform: scale(1.02); }
+
+    .mode-tag {
+      position: absolute;
+      left: 16px;
+      bottom: 16px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.24);
+      background: rgba(2, 6, 12, .66);
+      font-size: 13px;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+      color: #f2e4c9;
     }
 
     .story-page {
@@ -56,23 +134,14 @@
       position: relative;
       max-width: min(92vw, 1200px);
       max-height: min(86vh, 760px);
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: #000;
-      border-radius: 12px;
-      overflow: hidden;
+      width: 100%; height: 100%;
+      display: flex; align-items: center; justify-content: center;
+      background: #000; border-radius: 12px; overflow: hidden;
       box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
     }
 
     .story-image {
-      display: block;
-      max-width: 100%;
-      max-height: 100%;
-      width: auto;
-      height: auto;
+      display: block; max-width: 100%; max-height: 100%; width: auto; height: auto;
       filter: grayscale(100%) contrast(1.2) brightness(0.95);
       animation: colorFadeIn 4s ease-in-out forwards;
       transition: filter 0.3s ease, opacity 0.8s ease-in-out;
@@ -80,303 +149,513 @@
     }
 
     .story-video {
+      position: absolute; inset: 0; width: 100%; height: 100%; object-fit: contain;
+      opacity: 0; display: none; transition: opacity 1.1s ease-in-out; z-index: 2;
+      background: #000;
+    }
+    .story-media.video-playing .story-video { opacity: 1; display: block; }
+    .story-media.video-playing .story-image { opacity: 0; }
+
+    .story-text {
+      position: absolute;
+      left: 50%; transform: translateX(-50%);
+      bottom: clamp(20px, 3vh, 34px);
+      width: min(90%, 900px);
+      padding: 14px 18px;
+      border-radius: 14px;
+      background: rgba(5, 10, 16, .62);
+      border: 1px solid rgba(255, 232, 200, .25);
+      color: #ffedcc;
+      font-size: clamp(20px, 2.5vw, 34px);
+      line-height: 1.28;
+      text-align: center;
+      letter-spacing: .02em;
+      font-family: "Georgia", "Times New Roman", serif;
+      text-shadow: 0 3px 10px rgba(0,0,0,.45);
+      opacity: 0;
+      transition: opacity .35s ease;
+      z-index: 3;
+      pointer-events: none;
+    }
+    .story-text.visible { opacity: 1; }
+
+    .gaze-hotspot {
+      position: absolute;
+      right: 6%;
+      top: 58%;
+      width: clamp(72px, 9vw, 130px);
+      height: clamp(72px, 9vw, 130px);
+      border-radius: 999px;
+      border: 2px dashed rgba(255, 215, 160, .75);
+      background: rgba(255, 182, 88, .13);
+      box-shadow: 0 0 0 0 rgba(255, 204, 120, .6);
+      z-index: 4;
+      transition: transform .2s ease, opacity .3s ease;
+      opacity: 0;
+      pointer-events: auto;
+    }
+    .gaze-hotspot.active { opacity: 1; animation: pulseHotspot 1.7s ease-in-out infinite; }
+    .gaze-hotspot.focused { transform: scale(1.08); }
+
+    .hotspot-ring {
       position: absolute;
       inset: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
-      opacity: 0;
-      display: none;
-      transition: opacity 1.2s ease-in-out;
-      z-index: 2;
-    }
-
-    .story-media.video-playing .story-video {
-      opacity: 1;
-      display: block;
-    }
-
-    .story-media.video-playing .story-image {
-      opacity: 0;
-    }
-
-    @keyframes colorFadeIn {
-      0% {
-        filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      }
-      20% {
-        filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      }
-      100% {
-        filter: grayscale(0%) contrast(1) brightness(1);
-      }
-    }
-
-    .page.game-page {
-      background: #000;
-      padding: 0;
-    }
-
-    .game-frame {
-      width: 100%;
-      height: 100%;
-      display: block;
-      background: #000;
-      position: relative;
-      overflow: hidden;
-    }
-
-    .next-button {
-      position: fixed;
-      bottom: 24px;
-      right: 24px;
-      padding: 14px 26px;
       border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      background: rgba(15, 23, 42, 0.85);
-      color: #f8fafc;
-      font-size: 16px;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      cursor: pointer;
-      z-index: 20;
-      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      background: rgba(255, 236, 196, .18);
+      transform-origin: center;
+      transform: scale(0);
+      opacity: .9;
     }
 
-    .next-button:hover,
-    .next-button:focus-visible {
-      transform: translateY(-2px);
-      background: rgba(30, 41, 59, 0.95);
-      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
-      outline: none;
+    .status-pill {
+      position: fixed;
+      top: 24px;
+      left: 24px;
+      z-index: 24;
+      padding: 10px 14px;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.82);
+      border: 1px solid rgba(255,255,255,.24);
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      font-size: 12px;
+      color: #f8fafc;
+    }
+
+    .game-page { background: #000; padding: 0; }
+    .game-frame { width: 100%; height: 100%; display:block; background:#000; position: relative; overflow: hidden; }
+
+    .game-overlay {
+      position: absolute; right: 20px; top: 20px;
+      z-index: 40;
+      background: rgba(2, 6, 10, .7);
+      border: 1px solid rgba(255,255,255,.28);
+      padding: 10px 12px;
+      border-radius: 10px;
+      min-width: 190px;
+      display: none;
+    }
+    .game-overlay.active { display: block; }
+    .game-overlay p { margin: 0 0 8px; font-size: 13px; color: #f2e8d5; }
+    .game-overlay button {
+      width: 100%; border: 1px solid rgba(255,255,255,.26); border-radius: 8px;
+      background: rgba(30,41,59,.82); color:#fff; padding:8px 10px; cursor:pointer;
     }
 
     .fullscreen-button {
-      position: fixed;
-      top: 24px;
-      right: 24px;
-      padding: 12px 20px;
-      border-radius: 999px;
+      position: fixed; top: 24px; right: 24px;
+      padding: 12px 20px; border-radius: 999px;
       border: 1px solid rgba(255, 255, 255, 0.3);
-      background: rgba(15, 23, 42, 0.75);
-      color: #f8fafc;
-      font-size: 14px;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      cursor: pointer;
-      z-index: 20;
+      background: rgba(15, 23, 42, 0.75); color: #f8fafc;
+      font-size: 14px; font-weight: 600; letter-spacing: 0.08em;
+      text-transform: uppercase; cursor: pointer; z-index: 20;
       box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
       transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
     }
 
     .fullscreen-button:hover,
-    .fullscreen-button:focus-visible {
-      transform: translateY(-2px);
-      background: rgba(30, 41, 59, 0.95);
-      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
-      outline: none;
+    .fullscreen-button:focus-visible { transform: translateY(-2px); background: rgba(30, 41, 59, 0.95); outline: none; }
+
+    .transition-overlay { position: fixed; inset: 0; background: #050505; opacity:0; pointer-events:none; z-index:30; }
+    .transition-overlay.active { animation: sceneFade 900ms ease-in-out forwards; }
+
+    @keyframes colorFadeIn {
+      0%,20% { filter: grayscale(100%) contrast(1.2) brightness(0.95); }
+      100% { filter: grayscale(0%) contrast(1) brightness(1); }
+    }
+    @keyframes sceneFade { 0% { opacity: 0; } 40% { opacity: .85; } 100% { opacity: 0; } }
+    @keyframes pulseHotspot {
+      0% { box-shadow: 0 0 0 0 rgba(255, 204, 120, .62); }
+      70% { box-shadow: 0 0 0 22px rgba(255, 204, 120, 0); }
+      100% { box-shadow: 0 0 0 0 rgba(255, 204, 120, 0); }
     }
 
-    .transition-overlay {
-      position: fixed;
-      inset: 0;
-      background: #050505;
-      opacity: 0;
-      pointer-events: none;
-      z-index: 30;
-    }
-
-    .transition-overlay.active {
-      animation: sceneFade 900ms ease-in-out forwards;
-    }
-
-    @keyframes sceneFade {
-      0% { opacity: 0; }
-      40% { opacity: 0.85; }
-      100% { opacity: 0; }
-    }
-
-    :fullscreen .story-page {
-      padding: 0;
-    }
-
-    :fullscreen .story-media {
-      max-width: 100vw;
-      max-height: 100vh;
-      border-radius: 0;
-    }
+    :fullscreen .story-page { padding: 0; }
+    :fullscreen .story-media { max-width:100vw; max-height:100vh; border-radius:0; }
   </style>
 </head>
 <body>
   <div id="app">
-    <section class="page story-page active" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn.">
-      <div class="story-media" data-story-media>
-        <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+    <section id="landingPage" class="page landing active" data-type="landing">
+      <div class="landing-panel">
+        <h1>Eyegaze Samurai</h1>
+        <p class="landing-sub">Choose a journey mode. Each mode changes progression rules and visual theme.</p>
+        <div class="mode-grid">
+          <button class="mode-button" data-select-mode="story">
+            <strong>Story Mode</strong>
+            Auto-advances the story after narration. Mini-games play without fail conditions.
+          </button>
+          <button class="mode-button" data-select-mode="autonomous">
+            <strong>Autonomous Advancer</strong>
+            Player advances story pages manually via gaze/hover hotspots. Mini-games have no fail conditions.
+          </button>
+          <button class="mode-button" data-select-mode="samurai">
+            <strong>Samurai</strong>
+            Manual story progression plus challenge rules in mini-games. Failed challenge resets the journey.
+          </button>
+        </div>
+      </div>
+      <div class="hero-card">
+        <img id="modeHeroImage" src="../../images/samuraikata/paysagejapon.jpg" alt="Samurai mode preview" />
+        <span id="modeHeroTag" class="mode-tag">Story Mode</span>
       </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere.">
+    <section class="page story-page" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn." data-text="At dawn, the mountain wind whispers the first lesson of focus." data-audio="../../songs/samurai/samuraisong1.mp3">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <p class="story-text" data-story-text></p>
+        <div class="gaze-hotspot" data-hotspot aria-label="Look here to continue"><div class="hotspot-ring" data-hotspot-ring></div></div>
+      </div>
+    </section>
+
+    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere." data-text="The chi awakens in his hands, and silence becomes power." data-audio="../../songs/samurai/samuraisong2.mp3">
+      <div class="story-media" data-story-media>
+        <img class="story-image" alt="" />
+        <video class="story-video" playsinline></video>
+        <p class="story-text" data-story-text></p>
+        <div class="gaze-hotspot" data-hotspot aria-label="Look here to continue"><div class="hotspot-ring" data-hotspot-ring></div></div>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="cherry">
-      <div class="game-frame" data-game-host></div>
+      <div class="game-frame" data-game-host>
+        <div class="game-overlay" data-game-overlay>
+          <p data-game-message></p>
+          <button type="button" data-game-continue>Continue</button>
+        </div>
+      </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy.">
+    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy." data-text="A master appears: strength without patience is only noise." data-audio="../../songs/samurai/samuraisong3.mp3">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <p class="story-text" data-story-text></p>
+        <div class="gaze-hotspot" data-hotspot aria-label="Look here to continue"><div class="hotspot-ring" data-hotspot-ring></div></div>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="meditation">
-      <div class="game-frame" data-game-host></div>
+      <div class="game-frame" data-game-host>
+        <div class="game-overlay" data-game-overlay>
+          <p data-game-message></p>
+          <button type="button" data-game-continue>Continue</button>
+        </div>
+      </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky.">
+    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky." data-text="Night falls, and each lantern carries a promise upward." data-audio="../../songs/samurai/samuraisong4.mp3">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <p class="story-text" data-story-text></p>
+        <div class="gaze-hotspot" data-hotspot aria-label="Look here to continue"><div class="hotspot-ring" data-hotspot-ring></div></div>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="lamp">
-      <div class="game-frame" data-game-host></div>
+      <div class="game-frame" data-game-host>
+        <div class="game-overlay" data-game-overlay>
+          <p data-game-message></p>
+          <button type="button" data-game-continue>Continue</button>
+        </div>
+      </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms.">
+    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms." data-text="The blade rests. The samurai remains. The journey begins again." data-audio="../../songs/samurai/cherryblossomsong.mp3">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <p class="story-text" data-story-text></p>
+        <div class="gaze-hotspot" data-hotspot aria-label="Look here to continue"><div class="hotspot-ring" data-hotspot-ring></div></div>
       </div>
     </section>
   </div>
 
-  <button id="nextButton" class="next-button" type="button">Next</button>
+  <div id="modeStatus" class="status-pill">Mode: not selected</div>
   <button id="fullscreenButton" class="fullscreen-button" type="button">Fullscreen</button>
   <div id="transitionOverlay" class="transition-overlay" aria-hidden="true"></div>
 
   <script>
     window.addEventListener('DOMContentLoaded', () => {
+      const app = document.getElementById('app');
       const pages = Array.from(document.querySelectorAll('.page'));
-      const nextButton = document.getElementById('nextButton');
+      const landingPage = document.getElementById('landingPage');
+      const modeButtons = Array.from(document.querySelectorAll('[data-select-mode]'));
+      const modeHeroImage = document.getElementById('modeHeroImage');
+      const modeHeroTag = document.getElementById('modeHeroTag');
+      const modeStatus = document.getElementById('modeStatus');
       const fullscreenButton = document.getElementById('fullscreenButton');
       const transitionOverlay = document.getElementById('transitionOverlay');
+
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
       const fadeDurationMs = 4000;
+      const textDelayMs = fadeDurationMs + 180;
+      const autoVideoDelayMs = 1200;
+      const hotspotDwellMs = 1200;
+      const defaultGameDurationMs = 18000;
+      const samuraiGameLimitMs = 20000;
+
+      const modeConfig = {
+        story: {
+          label: 'Story Mode',
+          hero: '../../images/samuraikata/paysagejapon.jpg',
+          autoAdvanceStories: true,
+          manualHotspotToVideo: false,
+          enforceMiniGameFail: false
+        },
+        autonomous: {
+          label: 'Autonomous Advancer',
+          hero: '../../images/samuraikata/maitrechi.jpg',
+          autoAdvanceStories: false,
+          manualHotspotToVideo: true,
+          enforceMiniGameFail: false
+        },
+        samurai: {
+          label: 'Samurai',
+          hero: '../../images/samuraikata/katanafleurs.jpg',
+          autoAdvanceStories: false,
+          manualHotspotToVideo: true,
+          enforceMiniGameFail: true
+        }
+      };
+
+      let mode = null;
       let currentIndex = 0;
+      let narration = null;
 
-      const storyTimers = new WeakMap();
+      const storySessions = new WeakMap();
       const gameSessions = new Map();
+      let currentGameTimer = null;
+      let currentGameInterval = null;
 
-      const triggerTransition = () => {
-        if (!transitionOverlay) return;
+      function triggerTransition() {
         transitionOverlay.classList.remove('active');
         void transitionOverlay.offsetHeight;
         transitionOverlay.classList.add('active');
-      };
+      }
 
-      const clearStoryTimers = (page) => {
-        const timers = storyTimers.get(page);
-        if (!timers) return;
-        if (timers.videoTimeout) {
-          clearTimeout(timers.videoTimeout);
-        }
-        if (timers.checkTimeout) {
-          clearTimeout(timers.checkTimeout);
-        }
-        storyTimers.delete(page);
-      };
+      function stopNarration() {
+        if (!narration) return;
+        try {
+          narration.pause();
+          narration.src = '';
+        } catch (_) {}
+        narration = null;
+      }
 
-      const resetStoryMedia = (page) => {
+      function clearStorySession(page) {
+        const session = storySessions.get(page);
+        if (!session) return;
+        if (session.videoExistsTimeout) clearTimeout(session.videoExistsTimeout);
+        if (session.textTimer) clearTimeout(session.textTimer);
+        if (session.autoVideoTimer) clearTimeout(session.autoVideoTimer);
+        if (session.autoNextTimer) clearTimeout(session.autoNextTimer);
+        if (session.hotspotInterval) clearInterval(session.hotspotInterval);
+        if (session.hoverStartTimer) clearTimeout(session.hoverStartTimer);
+        stopNarration();
+        storySessions.delete(page);
+      }
+
+      function resetStoryMedia(page) {
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
         const video = page.querySelector('.story-video');
+        const text = page.querySelector('[data-story-text]');
+        const hotspot = page.querySelector('[data-hotspot]');
+        const ring = page.querySelector('[data-hotspot-ring]');
         if (!media || !image || !video) return;
+
         media.classList.remove('video-playing');
         video.pause();
+        video.currentTime = 0;
         video.removeAttribute('src');
         video.load();
+
         image.style.animation = 'none';
         void image.offsetHeight;
         image.style.animation = 'colorFadeIn 4s ease-in-out forwards';
-      };
 
-      const checkVideoExists = (path, callback) => {
+        if (text) {
+          text.classList.remove('visible');
+          text.textContent = '';
+        }
+        if (hotspot) {
+          hotspot.classList.remove('active', 'focused');
+        }
+        if (ring) {
+          ring.style.transform = 'scale(0)';
+        }
+      }
+
+      function checkVideoExists(path, callback) {
         const tester = document.createElement('video');
-        let settled = false;
+        let done = false;
         const clean = () => {
           tester.removeEventListener('loadeddata', onLoad);
           tester.removeEventListener('error', onError);
         };
-        const onLoad = () => {
-          if (settled) return;
-          settled = true;
+        const finish = (exists) => {
+          if (done) return;
+          done = true;
           clean();
-          callback(true);
+          callback(exists);
         };
-        const onError = () => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(false);
-        };
+        const onLoad = () => finish(true);
+        const onError = () => finish(false);
+
         tester.addEventListener('loadeddata', onLoad);
         tester.addEventListener('error', onError);
         tester.src = path;
         tester.preload = 'metadata';
         tester.load();
-        const timeoutId = setTimeout(() => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(false);
-        }, 1200);
-        return timeoutId;
-      };
 
-      const setupStoryPage = (page) => {
-        clearStoryTimers(page);
+        return setTimeout(() => finish(false), 1400);
+      }
+
+      function showModePreview(nextModeKey) {
+        const config = modeConfig[nextModeKey];
+        if (!config) return;
+        if (modeHeroImage) modeHeroImage.src = config.hero;
+        if (modeHeroTag) modeHeroTag.textContent = config.label;
+      }
+
+      function updateModeBadge() {
+        modeStatus.textContent = mode ? `Mode: ${modeConfig[mode].label}` : 'Mode: not selected';
+      }
+
+      function playStoryVideo(page, videoPath, advanceWhenComplete) {
+        const media = page.querySelector('[data-story-media]');
+        const video = page.querySelector('.story-video');
+        const hotspot = page.querySelector('[data-hotspot]');
+        if (!media || !video) return;
+
+        if (hotspot) hotspot.classList.remove('active', 'focused');
+
+        video.src = videoPath;
+        video.currentTime = 0;
+        video.loop = false;
+        video.load();
+        media.classList.add('video-playing');
+
+        const playPromise = video.play();
+        if (playPromise && typeof playPromise.catch === 'function') {
+          playPromise.catch(() => {});
+        }
+
+        video.onended = () => {
+          if (pages[currentIndex] !== page) return;
+          triggerTransition();
+          if (advanceWhenComplete) {
+            setTimeout(() => nextPage(), 500);
+          }
+        };
+      }
+
+      function beginHotspotTracking(page, videoPath) {
+        const hotspot = page.querySelector('[data-hotspot]');
+        const ring = page.querySelector('[data-hotspot-ring]');
+        if (!hotspot) return;
+        hotspot.classList.add('active');
+
+        const session = storySessions.get(page);
+        if (!session) return;
+        let hoverStart = 0;
+
+        const update = () => {
+          const rect = hotspot.getBoundingClientRect();
+          const x = session.pointer.x;
+          const y = session.pointer.y;
+          const inside = x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+          if (inside) {
+            hotspot.classList.add('focused');
+            if (!hoverStart) hoverStart = performance.now();
+            const ratio = Math.min(1, (performance.now() - hoverStart) / hotspotDwellMs);
+            if (ring) ring.style.transform = `scale(${ratio.toFixed(3)})`;
+            if (ratio >= 1) {
+              clearInterval(session.hotspotInterval);
+              session.hotspotInterval = null;
+              playStoryVideo(page, videoPath, true);
+            }
+          } else {
+            hoverStart = 0;
+            hotspot.classList.remove('focused');
+            if (ring) ring.style.transform = 'scale(0)';
+          }
+        };
+
+        session.hotspotInterval = setInterval(update, 60);
+      }
+
+      function setupStoryPage(page) {
+        clearStorySession(page);
+        resetStoryMedia(page);
+
         const imageName = page.dataset.image;
         const altText = page.dataset.alt || '';
-        const media = page.querySelector('[data-story-media]');
+        const storyText = page.dataset.text || '';
+        const audioSrc = page.dataset.audio || '';
+
         const image = page.querySelector('.story-image');
         const video = page.querySelector('.story-video');
-        if (!imageName || !media || !image || !video) return;
+        const text = page.querySelector('[data-story-text]');
+        if (!image || !video) return;
 
-        resetStoryMedia(page);
         image.src = `${imageBasePath}${imageName}`;
         image.alt = altText;
-        media.classList.remove('video-playing');
+
+        const pointer = { x: -9999, y: -9999 };
+        const pointerMove = (event) => {
+          pointer.x = event.clientX;
+          pointer.y = event.clientY;
+        };
+        window.addEventListener('pointermove', pointerMove, { passive: true });
+
+        const session = { pointer, pointerMove, textTimer: null, autoVideoTimer: null, autoNextTimer: null, videoExistsTimeout: null, hotspotInterval: null, hoverStartTimer: null };
+        storySessions.set(page, session);
 
         const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
         const videoPath = `${videoBasePath}${videoName}`;
 
-        const timers = { videoTimeout: null, checkTimeout: null };
-        timers.checkTimeout = checkVideoExists(videoPath, (exists) => {
-          if (!exists) return;
-          video.src = videoPath;
-          video.load();
-          timers.videoTimeout = setTimeout(() => {
-            if (pages[currentIndex] !== page) return;
-            media.classList.add('video-playing');
-            const playPromise = video.play();
-            if (playPromise && typeof playPromise.catch === 'function') {
-              playPromise.catch(() => {});
-            }
-          }, fadeDurationMs + 300);
+        const revealTextAndNarrate = () => {
+          if (pages[currentIndex] !== page) return;
+          if (text) {
+            text.textContent = storyText;
+            text.classList.add('visible');
+          }
+          if (audioSrc) {
+            stopNarration();
+            narration = new Audio(audioSrc);
+            narration.volume = 0.85;
+            narration.play().catch(() => {});
+          }
+        };
+
+        session.textTimer = setTimeout(revealTextAndNarrate, textDelayMs);
+
+        session.videoExistsTimeout = checkVideoExists(videoPath, (exists) => {
+          if (!exists || pages[currentIndex] !== page) return;
+
+          if (modeConfig[mode].manualHotspotToVideo) {
+            beginHotspotTracking(page, videoPath);
+          } else {
+            session.autoVideoTimer = setTimeout(() => {
+              if (pages[currentIndex] !== page) return;
+              playStoryVideo(page, videoPath, true);
+            }, textDelayMs + autoVideoDelayMs);
+          }
         });
-        storyTimers.set(page, timers);
-      };
+      }
+
+      function clearGameTimers() {
+        if (currentGameTimer) clearTimeout(currentGameTimer);
+        if (currentGameInterval) clearInterval(currentGameInterval);
+        currentGameTimer = null;
+        currentGameInterval = null;
+      }
 
       const gameTemplates = {
         cherry: 'tpl-cherryblossom',
@@ -385,57 +664,49 @@
       };
 
       const templateCache = {};
-      const loadTemplate = (id) => {
+      function loadTemplate(id) {
         if (!templateCache[id]) {
           const tpl = document.getElementById(id);
           templateCache[id] = tpl ? tpl.innerHTML.trim() : '';
         }
         return templateCache[id];
-      };
+      }
 
-      const stopGame = (page) => {
+      function stopGame(page) {
         const key = page?.dataset.game;
         if (!key) return;
         const session = gameSessions.get(key);
         if (!session) return;
-        const attemptStop = (api) => {
+
+        clearGameTimers();
+
+        const stopApi = (api) => {
           if (!api || typeof api.stop !== 'function') return;
-          try {
-            const maybePromise = api.stop();
-            if (maybePromise && typeof maybePromise.then === 'function') {
-              maybePromise.catch(() => {});
-            }
-          } catch (error) {
-            /* ignore stop errors */
-          }
+          try { api.stop(); } catch (_) {}
         };
-        if (session.api) {
-          attemptStop(session.api);
-        } else if (session.apiPromise) {
-          session.apiPromise.then(attemptStop).catch(() => {});
-        }
+
+        if (session.api) stopApi(session.api);
+        else if (session.apiPromise) session.apiPromise.then(stopApi).catch(() => {});
+
         if (session.host) {
           session.mountedNodes = Array.from(session.host.childNodes);
-          if (session.mountedNodes.length) {
-            session.mountedNodes.forEach((node) => {
-              if (node.parentNode === session.host) {
-                session.host.removeChild(node);
-              }
-            });
-            session.detached = true;
-          }
+          session.mountedNodes.forEach((node) => {
+            if (node.parentNode === session.host) session.host.removeChild(node);
+          });
+          session.detached = true;
         }
-      };
+      }
 
-      const mountGameTemplate = async (host, templateId) => {
+      async function mountGameTemplate(host, templateId) {
         const html = loadTemplate(templateId);
         if (!html) return null;
         let scriptPromises = [];
+
         try {
-          host.innerHTML = '';
           const parser = new DOMParser();
           const doc = parser.parseFromString(html, 'text/html');
           const fragment = document.createDocumentFragment();
+
           const appendChildren = (parent) => {
             if (!parent) return;
             parent.childNodes.forEach((node) => {
@@ -443,16 +714,17 @@
               fragment.appendChild(node.cloneNode(true));
             });
           };
+
           appendChildren(doc.head);
           appendChildren(doc.body);
           window.storyGameApi = null;
+          host.innerHTML = '';
           host.appendChild(fragment);
+
           host.querySelectorAll('script').forEach((oldScript) => {
             const newScript = document.createElement('script');
             newScript.async = false;
-            Array.from(oldScript.attributes).forEach((attr) => {
-              newScript.setAttribute(attr.name, attr.value);
-            });
+            Array.from(oldScript.attributes).forEach((attr) => newScript.setAttribute(attr.name, attr.value));
             newScript.textContent = oldScript.textContent;
             const promise = newScript.src
               ? new Promise((resolve) => {
@@ -463,18 +735,57 @@
             scriptPromises.push(promise);
             oldScript.replaceWith(newScript);
           });
-        } catch (error) {
+        } catch (_) {
           return null;
         }
-        try {
-          await Promise.all(scriptPromises);
-        } catch (error) {
-          /* ignore script load failures */
-        }
-        return window.storyGameApi || null;
-      };
 
-      const loadGame = (key, page) => {
+        await Promise.all(scriptPromises).catch(() => {});
+        return window.storyGameApi || null;
+      }
+
+      function setupGameOverlay(page, onSuccess, onFail) {
+        const overlay = page.querySelector('[data-game-overlay]');
+        const message = page.querySelector('[data-game-message]');
+        const btn = page.querySelector('[data-game-continue]');
+        if (!overlay || !message || !btn) return;
+
+        overlay.classList.add('active');
+
+        if (modeConfig[mode].enforceMiniGameFail) {
+          let remaining = Math.ceil(samuraiGameLimitMs / 1000);
+          message.textContent = `Samurai challenge: prove your skill then press Continue. Time left: ${remaining}s`;
+          btn.disabled = false;
+          btn.onclick = () => {
+            clearGameTimers();
+            overlay.classList.remove('active');
+            onSuccess();
+          };
+          currentGameInterval = setInterval(() => {
+            remaining -= 1;
+            message.textContent = `Samurai challenge: prove your skill then press Continue. Time left: ${Math.max(0, remaining)}s`;
+          }, 1000);
+          currentGameTimer = setTimeout(() => {
+            overlay.classList.remove('active');
+            btn.onclick = null;
+            onFail();
+          }, samuraiGameLimitMs);
+        } else {
+          let remaining = Math.ceil(defaultGameDurationMs / 1000);
+          message.textContent = `Mini-game free play. Continuing automatically in ${remaining}s.`;
+          btn.disabled = true;
+          btn.onclick = null;
+          currentGameInterval = setInterval(() => {
+            remaining -= 1;
+            message.textContent = `Mini-game free play. Continuing automatically in ${Math.max(0, remaining)}s.`;
+          }, 1000);
+          currentGameTimer = setTimeout(() => {
+            overlay.classList.remove('active');
+            onSuccess();
+          }, defaultGameDurationMs);
+        }
+      }
+
+      function loadGame(key, page) {
         const host = page.querySelector('[data-game-host]');
         if (!host) return;
 
@@ -483,64 +794,64 @@
           const templateId = gameTemplates[key];
           if (!templateId) return;
           const apiPromise = mountGameTemplate(host, templateId);
-          const mountedNodes = Array.from(host.childNodes);
-          session = { host, api: null, apiPromise, mountedNodes, detached: false };
+          session = { host, api: null, apiPromise, mountedNodes: Array.from(host.childNodes), detached: false };
           gameSessions.set(key, session);
         } else {
           session.host = host;
-          if (!session.mountedNodes || !session.mountedNodes.length) {
-            session.mountedNodes = Array.from(host.childNodes);
-          }
-          if (session.detached && session.mountedNodes && session.mountedNodes.length) {
+          if (session.detached && session.mountedNodes?.length) {
             host.innerHTML = '';
-            session.mountedNodes.forEach((node) => {
-              host.appendChild(node);
-            });
+            session.mountedNodes.forEach((node) => host.appendChild(node));
             session.detached = false;
           }
         }
 
         const startGame = async () => {
           try {
-            if (!session.api) {
-              session.api = await session.apiPromise;
-            }
-          } catch (error) {
-            return;
-          }
+            if (!session.api) session.api = await session.apiPromise;
+          } catch (_) {}
+
           if (pages[currentIndex] !== page) return;
-          const api = session.api;
-          if (!api || typeof api.start !== 'function') return;
-          window.requestAnimationFrame(() => {
-            try {
-              const maybePromise = api.start();
-              if (maybePromise && typeof maybePromise.then === 'function') {
-                maybePromise.catch(() => {});
-              }
-            } catch (error) {
-              /* ignore start errors */
+          if (session.api && typeof session.api.start === 'function') {
+            try { session.api.start(); } catch (_) {}
+          }
+
+          setupGameOverlay(
+            page,
+            () => {
+              triggerTransition();
+              setTimeout(() => nextPage(), 500);
+            },
+            () => {
+              triggerTransition();
+              resetJourney('Challenge failed. Returning to the beginning.');
             }
-          });
+          );
         };
 
         startGame();
-      };
+      }
 
-      const showPage = (index) => {
+      function teardownPage(page) {
+        if (!page) return;
+        if (page.dataset.type === 'story') {
+          const session = storySessions.get(page);
+          if (session?.pointerMove) {
+            window.removeEventListener('pointermove', session.pointerMove);
+          }
+          clearStorySession(page);
+          resetStoryMedia(page);
+        }
+        if (page.dataset.type === 'game') {
+          stopGame(page);
+        }
+      }
+
+      function showPage(index) {
         if (index < 0 || index >= pages.length) return;
-        if (index === currentIndex) return;
-
-        const previousPage = pages[currentIndex];
-        if (previousPage) {
-          previousPage.classList.remove('active');
-          if (previousPage.dataset.type === 'story') {
-            clearStoryTimers(previousPage);
-            resetStoryMedia(previousPage);
-          }
-          if (previousPage.dataset.type === 'game') {
-            stopGame(previousPage);
-            triggerTransition();
-          }
+        const previous = pages[currentIndex];
+        if (previous) {
+          previous.classList.remove('active');
+          teardownPage(previous);
         }
 
         currentIndex = index;
@@ -548,62 +859,71 @@
         if (!page) return;
         page.classList.add('active');
 
-        if (page.dataset.type === 'story') {
-          setupStoryPage(page);
-        }
-        if (page.dataset.type === 'game') {
-          loadGame(page.dataset.game, page);
-        }
-      };
-
-      const nextPage = () => {
-        const nextIndex = (currentIndex + 1) % pages.length;
-        showPage(nextIndex);
-      };
-
-      if (nextButton) {
-        nextButton.addEventListener('click', () => {
-          nextPage();
-        });
+        if (page.dataset.type === 'story') setupStoryPage(page);
+        if (page.dataset.type === 'game') loadGame(page.dataset.game, page);
       }
 
-      const requestFullscreen = async () => {
+      function nextPage() {
+        let nextIndex = currentIndex + 1;
+        if (nextIndex >= pages.length) {
+          nextIndex = 1;
+        }
+        showPage(nextIndex);
+      }
+
+      function resetJourney(labelText) {
+        for (const page of pages) {
+          page.classList.remove('active');
+          teardownPage(page);
+        }
+        if (labelText) modeStatus.textContent = labelText;
+        setTimeout(() => updateModeBadge(), 2600);
+        currentIndex = 1;
+        pages[1].classList.add('active');
+        setupStoryPage(pages[1]);
+      }
+
+      function startSelectedMode(selectedMode) {
+        if (!modeConfig[selectedMode]) return;
+        mode = selectedMode;
+        updateModeBadge();
+        triggerTransition();
+
+        landingPage.classList.remove('active');
+        showPage(1);
+      }
+
+      modeButtons.forEach((button) => {
+        const key = button.dataset.selectMode;
+        button.addEventListener('mouseenter', () => showModePreview(key));
+        button.addEventListener('focus', () => showModePreview(key));
+        button.addEventListener('click', () => startSelectedMode(key));
+      });
+
+      async function requestFullscreen() {
         if (document.fullscreenElement) {
           await document.exitFullscreen();
           return;
         }
         const root = document.documentElement;
         const method = root.requestFullscreen || root.webkitRequestFullscreen || root.msRequestFullscreen;
-        if (method) {
-          try {
-            await method.call(root);
-          } catch (error) {
-            /* ignore fullscreen failures */
-          }
-        }
-      };
-
-      if (fullscreenButton) {
-        fullscreenButton.addEventListener('click', () => {
-          requestFullscreen();
-        });
+        if (!method) return;
+        try { await method.call(root); } catch (_) {}
       }
 
-      const updateFullscreenLabel = () => {
-        if (!fullscreenButton) return;
+      fullscreenButton.addEventListener('click', requestFullscreen);
+      document.addEventListener('fullscreenchange', () => {
         fullscreenButton.textContent = document.fullscreenElement ? 'Exit Fullscreen' : 'Fullscreen';
-      };
-
-      document.addEventListener('fullscreenchange', updateFullscreenLabel);
-
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'ArrowRight' || event.key === ' ') {
-          nextPage();
-        }
       });
 
-      setupStoryPage(pages[currentIndex]);
-      updateFullscreenLabel();
+      document.addEventListener('keydown', (event) => {
+        if (!mode) return;
+        if (event.key === 'ArrowRight') nextPage();
+      });
+
+      showModePreview('story');
+      updateModeBadge();
+      landingPage.classList.add('active');
     });
   </script>
 


### PR DESCRIPTION
### Motivation

- Introduce a selectable entry experience so users can choose progression rules and visual themes before starting the journey.  
- Improve robustness of story media handling (image/video/audio) and support gaze/hover hotspots for manual progression.  
- Standardize game mounting and lifecycle handling to support timed overlays and fail conditions for the new `samurai` challenge mode.

### Description

- Add a landing page with mode selection UI and preview (`[data-select-mode]`, `#landingPage`, hero card, and `modeConfig`) and replace the old `Next` button with `modeStatus`.  
- Refactor story handling into session-based logic using `storySessions`, add narration support via an `Audio` instance, and implement safe video existence checking and controlled playback with `checkVideoExists` and `playStoryVideo`.  
- Implement gaze/hover hotspot tracking (`.gaze-hotspot`, `beginHotspotTracking`) to trigger videos in manual modes and add story text reveal timing, improved reset/cleanup via `clearStorySession`, `resetStoryMedia`, and `teardownPage`.  
- Improve game lifecycle: template mounting (`mountGameTemplate`), session caching via `gameSessions`, safe `start`/`stop` invocation, and an in-page `game-overlay` that enforces timed success/fail behavior depending on mode (free play vs `samurai` enforced timeout); added helpers `loadGame`, `stopGame`, `clearGameTimers`, and `resetJourney`.  
- Misc: extensive CSS overhaul (fonts, layout, responsive sizes, visual polish), remove unused `muted loop` attributes from story videos to support audio narration, and simplify fullscreen handling (`requestFullscreen`).

### Testing

- No automated tests were configured or executed for this HTML/JS change as part of this rollout, so no automated test results are available.  
- Recommend adding unit tests for `checkVideoExists`, story session cleanup (`clearStorySession`), and game overlay timeout behavior, and integration/visual tests for the landing and hotspot flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e387c429ec8325bf7df0ef72d9a7a0)