### PR TITLE
Add landing/menu, modes, asset preloading, and gaze-driven interactions for Samurai story

### DIFF
--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -43,7 +43,7 @@
       position: relative;
       display: flex;
       flex-direction: column;
-      justify-content: flex-start;
+      justify-content: center;
       padding: clamp(20px, 2.2vw, 36px);
       overflow: hidden;
       background: transparent;
@@ -65,6 +65,20 @@
       gap: 10px;
       align-items: start;
       margin-bottom: 12px;
+    }
+
+    .menu-title-main {
+      position: absolute;
+      left: clamp(20px, 2.2vw, 36px);
+      top: clamp(16px, 2.1vw, 30px);
+      z-index: 3;
+      margin: 0;
+      font-family: Georgia, serif;
+      font-size: clamp(1.3rem, 2.4vw, 2.3rem);
+      letter-spacing: .05em;
+      color: rgba(252, 218, 152, .96);
+      text-shadow: 0 6px 18px rgba(0,0,0,.5);
+      text-transform: uppercase;
     }
 
     .mode-button {
@@ -157,32 +171,9 @@
       display: flex;
       align-items: center;
       justify-content: flex-start;
-      gap: 14px;
+      gap: 10px;
       padding: 4px 0;
       flex-wrap: wrap;
-    }
-
-    .loading-track {
-      flex: 1;
-      height: 12px;
-      border-radius: 999px;
-      border: 1px solid rgba(250, 218, 154, .25);
-      background: rgba(23,12,13,.42);
-      overflow: hidden;
-    }
-
-    .loading-fill {
-      width: 0%;
-      height: 100%;
-      background: linear-gradient(90deg, rgba(155,42,42,.92), rgba(209,128,72,.92), rgba(250,210,130,.92));
-      transition: width .2s linear;
-    }
-
-    .loading-label {
-      min-width: 140px;
-      text-align: left;
-      font-size: .9rem;
-      opacity: .9;
     }
 
     .start-button {
@@ -382,7 +373,6 @@
       .menu-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
       .menu-row { grid-template-columns: 1fr; }
       .menu-controls { min-height: 300px; }
-      .loading-label { min-width: 100%; text-align: left; }
     }
   </style>
 </head>
@@ -392,6 +382,7 @@
       <div class="menu-shell">
         <div class="menu-controls">
           <div id="menuBlossoms" class="menu-blossoms" aria-hidden="true"></div>
+          <h1 id="menuTitleMain" class="menu-title-main">La puissance de l'esprit</h1>
           <div class="menu-row">
             <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong></button>
             <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong></button>
@@ -399,8 +390,6 @@
           </div>
           <p id="modeDescription" class="mode-description">A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.</p>
           <div class="menu-footer">
-            <div class="loading-track"><div id="loadingFill" class="loading-fill"></div></div>
-            <div id="loadingLabel" class="loading-label">Preparing assets… 0%</div>
             <button id="startJourneyButton" class="start-button" type="button" disabled>Loading…</button>
           </div>
         </div>
@@ -495,8 +484,7 @@
       const menuPreviewDescription = document.getElementById('menuPreviewDescription');
       const modeDescription = document.getElementById('modeDescription');
       const menuBlossoms = document.getElementById('menuBlossoms');
-      const loadingFill = document.getElementById('loadingFill');
-      const loadingLabel = document.getElementById('loadingLabel');
+      const menuTitleMain = document.getElementById('menuTitleMain');
       const chiCursor = document.getElementById('chiCursor');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
@@ -557,7 +545,7 @@
       const renderMenuBlossoms = () => {
         if (!menuBlossoms) return;
         menuBlossoms.innerHTML = '';
-        const blossomCount = 26;
+        const blossomCount = 54;
         for (let i = 0; i < blossomCount; i += 1) {
           const bloom = document.createElement('img');
           bloom.src = '../../images/samurai/cherryblossom.png';
@@ -572,6 +560,14 @@
           bloom.style.filter = 'drop-shadow(0 6px 10px rgba(0,0,0,.25))';
           menuBlossoms.appendChild(bloom);
         }
+      };
+
+      const setLocalizedMenuTitle = () => {
+        if (!menuTitleMain) return;
+        const lang = (navigator.language || '').toLowerCase();
+        menuTitleMain.textContent = lang.startsWith('fr')
+          ? \"La puissance de l'esprit\"
+          : 'The Power of the Mind';
       };
 
       const splitText = (text) => {
@@ -997,21 +993,11 @@
 
       const runPreload = async () => {
         const assets = gatherAssets();
-        let done = 0;
-        const update = () => {
-          const pct = assets.length ? Math.round((done / assets.length) * 100) : 100;
-          loadingFill.style.width = `${pct}%`;
-          loadingLabel.textContent = `Preparing assets… ${pct}%`;
-        };
-        update();
         await Promise.all(assets.map(async (asset) => {
           await preloadAsset(asset);
-          done += 1;
-          update();
         }));
         startJourneyButton.disabled = false;
         startJourneyButton.textContent = 'Start Journey';
-        loadingLabel.textContent = 'Ready';
       };
 
       const updateModeUI = () => {
@@ -1057,6 +1043,7 @@
       });
 
       updateModeUI();
+      setLocalizedMenuTitle();
       renderMenuBlossoms();
       showPage(0);
       runPreload();

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -3,80 +3,258 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Samurai Story Journey</title>
+  <title>Eyegaze Samurai — Story Journey</title>
   <style>
     :root {
       color-scheme: dark;
-      font-family: "Helvetica Neue", Arial, system-ui, sans-serif;
+      font-family: "Segoe UI", system-ui, sans-serif;
+      --gold: #f2cf86;
     }
 
-    * {
-      box-sizing: border-box;
-    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; }
+    body { background: #030409; color: #f8fafc; overflow: hidden; }
+    #app { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
+    .page { position: absolute; inset: 0; display: none; }
+    .page.active { display: flex; }
 
-    html,
-    body {
-      margin: 0;
-      height: 100%;
-    }
-
-    body {
-      background: #08090c;
-      color: #f9fafb;
-      overflow: hidden;
-    }
-
-    #app {
+    .landing-page {
       position: relative;
-      width: 100vw;
-      height: 100vh;
-      overflow: hidden;
+      padding: 0;
+      background:
+        linear-gradient(160deg, rgba(10, 11, 16, .72), rgba(7, 8, 12, .82)),
+        url('../../images/samurai/cherryblossombg.png') center/cover no-repeat;
+      align-items: stretch;
+      justify-content: stretch;
     }
 
-    .page {
+    .menu-shell {
+      position: relative;
+      z-index: 1;
+      width: 100%;
+      height: 100%;
+      display: grid;
+      grid-template-columns: minmax(320px, 42vw) 1fr;
+      gap: 0;
+      padding: 0;
+    }
+
+    .menu-controls {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      padding: clamp(20px, 2.2vw, 36px);
+      overflow: hidden;
+      background: transparent;
+    }
+
+    .menu-blossoms {
       position: absolute;
       inset: 0;
-      display: none;
+      overflow: hidden;
+      pointer-events: none;
+      z-index: 0;
     }
 
-    .page.active {
+    .menu-row {
+      position: relative;
+      z-index: 2;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+      align-items: start;
+      margin-bottom: 12px;
+    }
+
+    .mode-button {
+      border: 1px solid rgba(248, 213, 150, .18);
+      border-radius: 12px;
+      background: rgba(17, 12, 18, .42);
+      color: #f9efe1;
+      padding: 10px 10px;
+      text-align: center;
+      cursor: pointer;
+      min-height: 0;
+      transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+      backdrop-filter: blur(2px);
+    }
+
+    .mode-button strong {
+      display: inline-block;
+      font-family: Georgia, serif;
+      color: var(--gold);
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      font-size: clamp(.8rem, .95vw, .96rem);
+      margin-bottom: 0;
+    }
+
+    .mode-button:hover,
+    .mode-button:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(252, 216, 147, .52);
+      box-shadow: 0 6px 16px rgba(0,0,0,.22), 0 0 0 1px rgba(252,216,147,.12);
+      outline: none;
+    }
+
+    .mode-button.active {
+      border-color: rgba(252, 216, 147, .58);
+      background: rgba(84, 51, 28, .5);
+      box-shadow: inset 0 0 0 1px rgba(252,216,147,.2), 0 8px 18px rgba(0,0,0,.26);
+    }
+
+    .mode-description {
+      position: relative;
+      z-index: 2;
+      width: min(92%, 640px);
+      margin-top: 10px;
+      font-size: clamp(.95rem, 1.2vw, 1.1rem);
+      line-height: 1.5;
+      color: rgba(252, 240, 225, .92);
+      text-shadow: 0 3px 10px rgba(0,0,0,.45);
+    }
+
+    .menu-preview {
+      position: relative;
+      overflow: hidden;
+      background: #000;
+      min-height: 100vh;
+      height: 100vh;
+    }
+
+    .menu-preview img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      transition: transform .45s ease;
+      transform: scale(1.02);
+    }
+
+    .menu-overlay {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      padding: 10px 14px 14px;
+      background: linear-gradient(180deg, rgba(0,0,0,0), rgba(8,10,16,.45));
+    }
+
+    .menu-overlay h1 {
+      margin: 0 0 6px;
+      font-family: Georgia, serif;
+      color: var(--gold);
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      font-size: clamp(1.2rem, 2.2vw, 2.1rem);
+    }
+
+    .menu-overlay p { margin: 0; font-size: clamp(.95rem, 1.25vw, 1.1rem); line-height: 1.45; }
+
+    .menu-footer {
+      position: relative;
+      z-index: 2;
       display: flex;
       align-items: center;
-      justify-content: center;
+      justify-content: flex-start;
+      gap: 14px;
+      padding: 4px 0;
+      flex-wrap: wrap;
     }
 
+    .loading-track {
+      flex: 1;
+      height: 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(250, 218, 154, .25);
+      background: rgba(23,12,13,.42);
+      overflow: hidden;
+    }
+
+    .loading-fill {
+      width: 0%;
+      height: 100%;
+      background: linear-gradient(90deg, rgba(155,42,42,.92), rgba(209,128,72,.92), rgba(250,210,130,.92));
+      transition: width .2s linear;
+    }
+
+    .loading-label {
+      min-width: 140px;
+      text-align: left;
+      font-size: .9rem;
+      opacity: .9;
+    }
+
+    .start-button {
+      border-radius: 999px;
+      border: 1px solid rgba(252,216,147,.75);
+      background: linear-gradient(150deg, rgba(170,98,44,.74), rgba(95,42,20,.82));
+      color: #fff8e8;
+      padding: 14px 26px;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      font-weight: 700;
+      cursor: pointer;
+      box-shadow: 0 8px 18px rgba(0,0,0,.3);
+    }
+
+    .start-button:disabled { opacity: .55; cursor: not-allowed; }
+
     .story-page {
-      background: radial-gradient(circle at top, rgba(59, 130, 246, 0.25), transparent 60%),
-                  radial-gradient(circle at bottom, rgba(249, 115, 22, 0.15), transparent 70%),
-                  #07080b;
-      padding: clamp(16px, 4vw, 48px);
+      align-items: center;
+      justify-content: center;
+      padding: clamp(14px, 2vw, 28px);
+      background:
+        radial-gradient(circle at top, rgba(59,130,246,.18), transparent 58%),
+        radial-gradient(circle at bottom, rgba(249,115,22,.13), transparent 72%),
+        #06070b;
+    }
+
+    body.playing {
+      cursor: none;
+    }
+
+    #chiCursor {
+      position: fixed;
+      width: 30px;
+      height: 30px;
+      border-radius: 50%;
+      pointer-events: none;
+      z-index: 120;
+      opacity: 0;
+      transform: translate(-50%, -50%);
+      background: radial-gradient(circle at 35% 30%, rgba(255,255,255,.7), rgba(72,183,255,.65) 42%, rgba(26,92,245,.5) 68%, rgba(12,30,120,.2) 100%);
+      box-shadow: 0 0 0 4px rgba(56,189,248,.2), 0 0 18px rgba(56,189,248,.9);
+      transition: opacity .2s ease;
     }
 
     .story-media {
       position: relative;
-      max-width: min(92vw, 1200px);
-      max-height: min(86vh, 760px);
       width: 100%;
       height: 100%;
+      max-width: min(96vw, 1380px);
+      max-height: min(94vh, 860px);
       display: flex;
       align-items: center;
       justify-content: center;
       background: #000;
-      border-radius: 12px;
+      border-radius: 14px;
       overflow: hidden;
-      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+      box-shadow: 0 24px 60px rgba(0,0,0,.55);
     }
 
     .story-image {
       display: block;
-      max-width: 100%;
-      max-height: 100%;
-      width: auto;
-      height: auto;
-      filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      animation: colorFadeIn 4s ease-in-out forwards;
-      transition: filter 0.3s ease, opacity 0.8s ease-in-out;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      filter: grayscale(100%) contrast(1.2) brightness(.95);
+      transition: filter 6s ease, opacity .6s ease;
       opacity: 1;
+    }
+
+    .story-image.colored {
+      filter: grayscale(0%) contrast(1) brightness(1);
     }
 
     .story-video {
@@ -87,98 +265,107 @@
       object-fit: contain;
       opacity: 0;
       display: none;
-      transition: opacity 1.2s ease-in-out;
+      transition: opacity .75s ease;
       z-index: 2;
+      background: #000;
     }
 
-    .story-media.video-playing .story-video {
-      opacity: 1;
-      display: block;
-    }
+    .story-media.video-playing .story-video { display: block; opacity: 1; }
+    .story-media.video-playing .story-image,
+    .story-media.video-playing .story-caption { opacity: 0; }
 
-    .story-media.video-playing .story-image {
+    .story-caption {
+      position: absolute;
+      left: 2.2vw;
+      right: 2.2vw;
+      bottom: 2vw;
+      z-index: 4;
+      padding: 18px 20px;
+      border-radius: 12px;
+      border: 1px solid rgba(255,255,255,.22);
+      background: rgba(5,10,18,.7);
+      font-family: "Palatino Linotype", "Book Antiqua", Palatino, serif;
+      font-size: clamp(1.15rem, 2.1vw, 1.9rem);
+      font-style: italic;
+      line-height: 1.45;
+      letter-spacing: .02em;
+      text-shadow: 0 7px 24px rgba(0,0,0,.75);
+      pointer-events: none;
       opacity: 0;
+      transform: translateY(12px);
+      transition: opacity .35s ease, transform .35s ease;
     }
 
-    @keyframes colorFadeIn {
-      0% {
-        filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      }
-      20% {
-        filter: grayscale(100%) contrast(1.2) brightness(0.95);
-      }
-      100% {
-        filter: grayscale(0%) contrast(1) brightness(1);
-      }
-    }
+    .story-caption.visible { opacity: 1; transform: translateY(0); }
 
-    .page.game-page {
-      background: #000;
-      padding: 0;
-    }
-
-    .game-frame {
-      width: 100%;
-      height: 100%;
-      display: block;
-      background: #000;
-      position: relative;
+    .gaze-target {
+      position: absolute;
+      width: clamp(92px, 8.6vw, 132px);
+      height: clamp(92px, 8.6vw, 132px);
+      border-radius: 50%;
+      border: 2px solid rgba(255,255,255,.5);
+      background:
+        radial-gradient(circle at 35% 30%, rgba(255,255,255,.4) 0 16%, rgba(255,84,84,.35) 34%, rgba(128,26,26,.26) 64%, rgba(68,0,0,.2) 100%);
+      box-shadow: 0 0 0 5px rgba(255,80,80,.13), 0 0 24px rgba(255,72,72,.45);
+      z-index: 6;
+      opacity: 0;
+      pointer-events: none;
       overflow: hidden;
+      transition: opacity .2s ease, transform .2s ease;
     }
 
-    .next-button {
+    .gaze-target::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 0;
+      height: 0;
+      background: rgba(255,40,40,.33);
+      transform: translate(-50%, -50%);
+      transition: width .95s linear, height .95s linear;
+    }
+
+    .gaze-target.visible { opacity: 1; pointer-events: auto; }
+    .gaze-target.dwell { transform: scale(1.06); }
+    .gaze-target.dwell::after { width: 100%; height: 100%; }
+
+    .next-button, .fullscreen-button {
       position: fixed;
-      bottom: 24px;
-      right: 24px;
-      padding: 14px 26px;
-      border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      background: rgba(15, 23, 42, 0.85);
-      color: #f8fafc;
-      font-size: 16px;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      cursor: pointer;
-      z-index: 20;
-      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-    }
-
-    .next-button:hover,
-    .next-button:focus-visible {
-      transform: translateY(-2px);
-      background: rgba(30, 41, 59, 0.95);
-      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
-      outline: none;
-    }
-
-    .fullscreen-button {
-      position: fixed;
-      top: 24px;
-      right: 24px;
       padding: 12px 20px;
       border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      background: rgba(15, 23, 42, 0.75);
+      border: 1px solid rgba(255,255,255,.32);
+      background: rgba(15,23,42,.82);
       color: #f8fafc;
       font-size: 14px;
       font-weight: 600;
-      letter-spacing: 0.08em;
+      letter-spacing: .08em;
       text-transform: uppercase;
       cursor: pointer;
       z-index: 20;
-      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      box-shadow: 0 12px 32px rgba(0,0,0,.4);
     }
+    .next-button { bottom: 20px; right: 20px; }
+    .fullscreen-button { top: 20px; right: 20px; }
+    .next-button[hidden], .fullscreen-button[hidden] { display: none; }
 
-    .fullscreen-button:hover,
-    .fullscreen-button:focus-visible {
-      transform: translateY(-2px);
-      background: rgba(30, 41, 59, 0.95);
-      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
-      outline: none;
+    .page.game-page { background: #000; padding: 0; align-items: stretch; justify-content: stretch; }
+    .game-frame { width: 100%; height: 100%; display: block; background: #000; position: relative; overflow: hidden; }
+
+    .samurai-challenge {
+      position: absolute;
+      top: 14px;
+      right: 14px;
+      width: 94px;
+      height: 94px;
+      border-radius: 50%;
+      border: 2px dashed rgba(248,211,132,.95);
+      background: radial-gradient(circle, rgba(248,211,132,.42), rgba(248,211,132,.16));
+      display: none;
+      z-index: 8;
+      cursor: pointer;
     }
+    .samurai-challenge.visible { display: block; }
 
     .transition-overlay {
       position: fixed;
@@ -188,112 +375,232 @@
       pointer-events: none;
       z-index: 30;
     }
+    .transition-overlay.active { animation: sceneFade 900ms ease-in-out forwards; }
+    @keyframes sceneFade { 0% { opacity: 0; } 40% { opacity: .85; } 100% { opacity: 0; } }
 
-    .transition-overlay.active {
-      animation: sceneFade 900ms ease-in-out forwards;
-    }
-
-    @keyframes sceneFade {
-      0% { opacity: 0; }
-      40% { opacity: 0.85; }
-      100% { opacity: 0; }
-    }
-
-    :fullscreen .story-page {
-      padding: 0;
-    }
-
-    :fullscreen .story-media {
-      max-width: 100vw;
-      max-height: 100vh;
-      border-radius: 0;
+    @media (max-width: 980px) {
+      .menu-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
+      .menu-row { grid-template-columns: 1fr; }
+      .menu-controls { min-height: 300px; }
+      .loading-label { min-width: 100%; text-align: left; }
     }
   </style>
 </head>
 <body>
   <div id="app">
-    <section class="page story-page active" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn.">
-      <div class="story-media" data-story-media>
-        <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+    <section id="landingPage" class="page landing-page active" data-type="landing">
+      <div class="menu-shell">
+        <div class="menu-controls">
+          <div id="menuBlossoms" class="menu-blossoms" aria-hidden="true"></div>
+          <div class="menu-row">
+            <button class="mode-button active" data-mode="story" type="button"><strong>Story Mode</strong></button>
+            <button class="mode-button" data-mode="autonomous" type="button"><strong>Autonomous Advancer</strong></button>
+            <button class="mode-button" data-mode="samurai" type="button"><strong>Samurai</strong></button>
+          </div>
+          <p id="modeDescription" class="mode-description">A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.</p>
+          <div class="menu-footer">
+            <div class="loading-track"><div id="loadingFill" class="loading-fill"></div></div>
+            <div id="loadingLabel" class="loading-label">Preparing assets… 0%</div>
+            <button id="startJourneyButton" class="start-button" type="button" disabled>Loading…</button>
+          </div>
+        </div>
+
+        <div class="menu-preview">
+          <img id="menuPreviewImage" src="../../images/samuraikata/paysagejapon.jpg" alt="Mode preview" />
+          <div class="menu-overlay">
+            <h1 id="menuPreviewTitle">Story Mode</h1>
+            <p id="menuPreviewDescription">Witness a long-form tale of discipline and spirit as each illustrated page, narration, and animation flows continuously.</p>
+          </div>
+        </div>
       </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere.">
+    <section class="page story-page" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn." data-text="At first light, mist drifts above the valley while distant bells echo across silent fields. You stand still, breathing in the cold dawn, and feel the first promise of your long path." data-audio="../../songs/samurai/cherryblossomsong.mp3" data-target="82,72">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
+      </div>
+    </section>
+
+    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere." data-text="You gather swirling chi between your palms, shaping its pulse with patience instead of force. The trembling light steadies, and your heartbeat learns to follow its rhythm." data-audio="../../songs/samurai/samuraisong1.mp3" data-target="16,74">
+      <div class="story-media" data-story-media>
+        <img class="story-image" alt="" />
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="cherry">
       <div class="game-frame" data-game-host></div>
+      <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy.">
+    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy." data-text="Your master watches in silence, then speaks slowly about balance, restraint, and exactness. Every motion, he says, must begin in stillness before it can become a strike." data-audio="../../songs/samurai/samuraisong2.mp3" data-target="84,30">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="meditation">
       <div class="game-frame" data-game-host></div>
+      <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky.">
+    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky." data-text="Night arrives and hundreds of lanterns rise, carrying whispered hopes into the wind. Their warm glow paints the darkness, and you swear to honor each promise you have made." data-audio="../../songs/samurai/samuraisong3.mp3" data-target="18,34">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
       </div>
     </section>
 
     <section class="page game-page" data-type="game" data-game="lamp">
       <div class="game-frame" data-game-host></div>
+      <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms.">
+    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms." data-text="Cherry petals circle your resting blade as the final lesson settles in your chest. Strength, discipline, and mercy now move together, and your journey enters its next chapter." data-audio="../../songs/samurai/samuraisong4.mp3" data-target="50,20">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
-        <video class="story-video" muted loop playsinline></video>
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
       </div>
     </section>
   </div>
 
-  <button id="nextButton" class="next-button" type="button">Next</button>
+  <button id="nextButton" class="next-button" type="button" hidden>Next</button>
   <button id="fullscreenButton" class="fullscreen-button" type="button">Fullscreen</button>
+  <div id="chiCursor" aria-hidden="true"></div>
   <div id="transitionOverlay" class="transition-overlay" aria-hidden="true"></div>
 
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const pages = Array.from(document.querySelectorAll('.page'));
+      const storyPages = pages.filter((p) => p.dataset.type === 'story');
       const nextButton = document.getElementById('nextButton');
       const fullscreenButton = document.getElementById('fullscreenButton');
       const transitionOverlay = document.getElementById('transitionOverlay');
+      const modeButtons = Array.from(document.querySelectorAll('.mode-button'));
+      const startJourneyButton = document.getElementById('startJourneyButton');
+      const menuPreviewImage = document.getElementById('menuPreviewImage');
+      const menuPreviewTitle = document.getElementById('menuPreviewTitle');
+      const menuPreviewDescription = document.getElementById('menuPreviewDescription');
+      const modeDescription = document.getElementById('modeDescription');
+      const menuBlossoms = document.getElementById('menuBlossoms');
+      const loadingFill = document.getElementById('loadingFill');
+      const loadingLabel = document.getElementById('loadingLabel');
+      const chiCursor = document.getElementById('chiCursor');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
-      const fadeDurationMs = 4000;
-      let currentIndex = 0;
 
+      const gameTemplates = { cherry: 'tpl-cherryblossom', meditation: 'tpl-meditation', lamp: 'tpl-lamp' };
+      const templateCache = {};
       const storyTimers = new WeakMap();
       const gameSessions = new Map();
 
+      const dwellMs = 1000;
+      const colorFadeWaitMs = 3300;
+      const samuraiTimeoutMs = 25000;
+      let currentMode = 'story';
+      let currentIndex = 0;
+      let isJourneyStarted = false;
+      const storyMusic = new Audio();
+      storyMusic.loop = true;
+      storyMusic.preload = 'auto';
+      let storyMusicSrc = '';
+      let activeSamuraiChallenge = null;
+
+      const modeConfig = {
+        story: {
+          label: 'Story Mode',
+          previewImage: '../../images/samuraikata/paysagejapon.jpg',
+          previewTitle: 'Story Mode',
+          previewDescription: 'A cinematic tale that progresses without requiring input and preserves uninterrupted narrative flow.',
+          manualAdvance: false,
+          enforceGameWin: false,
+          autoGameAdvance: true,
+        },
+        autonomous: {
+          label: 'Autonomous Advancer',
+          previewImage: '../../images/samuraikata/maitrechi.jpg',
+          previewTitle: 'Autonomous Advancer',
+          previewDescription: 'A user-paced journey where you control progression, while mini-games remain open and non-blocking.',
+          manualAdvance: true,
+          enforceGameWin: false,
+          autoGameAdvance: false,
+        },
+        samurai: {
+          label: 'Samurai',
+          previewImage: '../../images/samuraikata/katanafleurs.jpg',
+          previewTitle: 'Samurai',
+          previewDescription: 'The strict path: you manually progress and must succeed in mini-game challenges to continue.',
+          manualAdvance: true,
+          enforceGameWin: true,
+          autoGameAdvance: false,
+        }
+      };
+
       const triggerTransition = () => {
-        if (!transitionOverlay) return;
         transitionOverlay.classList.remove('active');
         void transitionOverlay.offsetHeight;
         transitionOverlay.classList.add('active');
       };
 
+      const renderMenuBlossoms = () => {
+        if (!menuBlossoms) return;
+        menuBlossoms.innerHTML = '';
+        const blossomCount = 26;
+        for (let i = 0; i < blossomCount; i += 1) {
+          const bloom = document.createElement('img');
+          bloom.src = '../../images/samurai/cherryblossom.png';
+          bloom.alt = '';
+          bloom.style.position = 'absolute';
+          bloom.style.left = `${Math.random() * 90}%`;
+          bloom.style.top = `${Math.random() * 95}%`;
+          const size = 52 + Math.random() * 120;
+          bloom.style.width = `${size}px`;
+          bloom.style.opacity = `${0.2 + Math.random() * 0.4}`;
+          bloom.style.transform = `rotate(${Math.random() * 360}deg) scale(${0.4 + Math.random() * 0.8})`;
+          bloom.style.filter = 'drop-shadow(0 6px 10px rgba(0,0,0,.25))';
+          menuBlossoms.appendChild(bloom);
+        }
+      };
+
+      const splitText = (text) => {
+        const normalized = (text || '').trim();
+        if (!normalized) return ['', ''];
+        const words = normalized.split(/\s+/);
+        const mid = Math.ceil(words.length / 2);
+        return [words.slice(0, mid).join(' '), words.slice(mid).join(' ')];
+      };
+
+      const playStoryMusic = (src) => {
+        if (!src) return;
+        if (storyMusicSrc !== src) {
+          storyMusicSrc = src;
+          storyMusic.src = src;
+          storyMusic.load();
+        }
+        storyMusic.play().catch(() => {});
+      };
+
+      const pauseStoryMusic = () => {
+        storyMusic.pause();
+      };
+
       const clearStoryTimers = (page) => {
         const timers = storyTimers.get(page);
         if (!timers) return;
-        if (timers.videoTimeout) {
-          clearTimeout(timers.videoTimeout);
-        }
-        if (timers.checkTimeout) {
-          clearTimeout(timers.checkTimeout);
-        }
+        if (timers.ids) timers.ids.forEach((id) => clearTimeout(id));
+        if (timers.cleanup) timers.cleanup();
         storyTimers.delete(page);
       };
 
@@ -301,90 +608,162 @@
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
         const video = page.querySelector('.story-video');
-        if (!media || !image || !video) return;
+        const caption = page.querySelector('[data-story-caption]');
+        const gazeTarget = page.querySelector('[data-gaze-target]');
+        if (!media || !image || !video || !caption || !gazeTarget) return;
         media.classList.remove('video-playing');
+        image.classList.remove('colored');
         video.pause();
+        video.currentTime = 0;
         video.removeAttribute('src');
         video.load();
-        image.style.animation = 'none';
-        void image.offsetHeight;
-        image.style.animation = 'colorFadeIn 4s ease-in-out forwards';
+        video.onended = null;
+        caption.classList.remove('visible');
+        caption.textContent = '';
+        gazeTarget.classList.remove('visible', 'dwell');
       };
 
-      const checkVideoExists = (path, callback) => {
-        const tester = document.createElement('video');
-        let settled = false;
-        const clean = () => {
-          tester.removeEventListener('loadeddata', onLoad);
-          tester.removeEventListener('error', onError);
+      const playVideoThenAdvance = (page, video, media) => {
+        if (!video || !media || !video.src) {
+          triggerTransition();
+          setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 260);
+          return;
+        }
+        media.classList.add('video-playing');
+        video.currentTime = 0;
+        const p = video.play();
+        if (p && typeof p.catch === 'function') p.catch(() => {});
+        video.onended = () => {
+          if (pages[currentIndex] !== page) return;
+          triggerTransition();
+          setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 300);
         };
-        const onLoad = () => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(true);
+      };
+
+      const createDwellGate = (target, onDone) => {
+        let hold = null;
+        const start = () => {
+          target.classList.add('dwell');
+          hold = setTimeout(() => {
+            hold = null;
+            target.classList.remove('dwell');
+            onDone();
+          }, dwellMs);
         };
-        const onError = () => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(false);
+        const cancel = () => {
+          if (hold) clearTimeout(hold);
+          hold = null;
+          target.classList.remove('dwell');
         };
-        tester.addEventListener('loadeddata', onLoad);
-        tester.addEventListener('error', onError);
-        tester.src = path;
-        tester.preload = 'metadata';
-        tester.load();
-        const timeoutId = setTimeout(() => {
-          if (settled) return;
-          settled = true;
-          clean();
-          callback(false);
-        }, 1200);
-        return timeoutId;
+        target.addEventListener('mouseenter', start);
+        target.addEventListener('mouseleave', cancel);
+        target.addEventListener('focus', start);
+        target.addEventListener('blur', cancel);
+        target.addEventListener('touchstart', start, { passive: true });
+        target.addEventListener('touchend', cancel);
+        return () => {
+          cancel();
+          target.removeEventListener('mouseenter', start);
+          target.removeEventListener('mouseleave', cancel);
+          target.removeEventListener('focus', start);
+          target.removeEventListener('blur', cancel);
+          target.removeEventListener('touchstart', start);
+          target.removeEventListener('touchend', cancel);
+        };
       };
 
       const setupStoryPage = (page) => {
         clearStoryTimers(page);
-        const imageName = page.dataset.image;
-        const altText = page.dataset.alt || '';
+
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
         const video = page.querySelector('.story-video');
-        if (!imageName || !media || !image || !video) return;
+        const caption = page.querySelector('[data-story-caption]');
+        const gazeTarget = page.querySelector('[data-gaze-target]');
+        if (!media || !image || !video || !caption || !gazeTarget) return;
 
         resetStoryMedia(page);
+        const imageName = page.dataset.image;
+        const fullText = page.dataset.text || '';
+        const audioPath = page.dataset.audio || '';
+        const [textA, textB] = splitText(fullText);
+        playStoryMusic(audioPath);
+
         image.src = `${imageBasePath}${imageName}`;
-        image.alt = altText;
-        media.classList.remove('video-playing');
+        image.alt = page.dataset.alt || '';
+
+        const [xRaw, yRaw] = (page.dataset.target || '82,72').split(',');
+        gazeTarget.style.left = `${Math.min(94, Math.max(6, Number.parseFloat(xRaw) || 82))}%`;
+        gazeTarget.style.top = `${Math.min(92, Math.max(8, Number.parseFloat(yRaw) || 72))}%`;
 
         const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
         const videoPath = `${videoBasePath}${videoName}`;
+        video.src = videoPath;
+        video.preload = 'auto';
+        video.load();
 
-        const timers = { videoTimeout: null, checkTimeout: null };
-        timers.checkTimeout = checkVideoExists(videoPath, (exists) => {
-          if (!exists) return;
-          video.src = videoPath;
-          video.load();
-          timers.videoTimeout = setTimeout(() => {
+        const timers = { ids: [], cleanup: null };
+        const manual = modeConfig[currentMode].manualAdvance;
+
+        const step5 = () => playVideoThenAdvance(page, video, media);
+        const step4 = () => {
+          if (pages[currentIndex] !== page) return;
+          caption.textContent = `${textA} ${textB}`.trim();
+          caption.classList.add('visible');
+          if (!manual) {
+            timers.ids.push(setTimeout(step5, 900));
+            return;
+          }
+          gazeTarget.classList.add('visible');
+          if (timers.cleanup) timers.cleanup();
+          timers.cleanup = createDwellGate(gazeTarget, () => {
+            gazeTarget.classList.remove('visible');
+            step5();
+          });
+        };
+        const step3 = () => {
+          if (pages[currentIndex] !== page) return;
+          image.classList.add('colored');
+          if (!manual) {
+            timers.ids.push(setTimeout(step4, colorFadeWaitMs));
+            return;
+          }
+          timers.ids.push(setTimeout(() => {
             if (pages[currentIndex] !== page) return;
-            media.classList.add('video-playing');
-            const playPromise = video.play();
-            if (playPromise && typeof playPromise.catch === 'function') {
-              playPromise.catch(() => {});
-            }
-          }, fadeDurationMs + 300);
-        });
+            gazeTarget.classList.add('visible');
+            if (timers.cleanup) timers.cleanup();
+            timers.cleanup = createDwellGate(gazeTarget, () => {
+              gazeTarget.classList.remove('visible');
+              step4();
+            });
+          }, colorFadeWaitMs));
+        };
+        const step2 = () => {
+          if (pages[currentIndex] !== page) return;
+          caption.textContent = textA;
+          caption.classList.add('visible');
+          timers.ids.push(setTimeout(step3, 1100));
+        };
+        const step1 = () => {
+          if (pages[currentIndex] !== page) return;
+          image.classList.remove('colored');
+          caption.classList.remove('visible');
+          caption.textContent = '';
+          if (!manual) {
+            timers.ids.push(setTimeout(step2, 900));
+            return;
+          }
+          gazeTarget.classList.add('visible');
+          timers.cleanup = createDwellGate(gazeTarget, () => {
+            gazeTarget.classList.remove('visible');
+            step2();
+          });
+        };
+
+        timers.ids.push(setTimeout(step1, 150));
         storyTimers.set(page, timers);
       };
 
-      const gameTemplates = {
-        cherry: 'tpl-cherryblossom',
-        meditation: 'tpl-meditation',
-        lamp: 'tpl-lamp'
-      };
-
-      const templateCache = {};
       const loadTemplate = (id) => {
         if (!templateCache[id]) {
           const tpl = document.getElementById(id);
@@ -398,212 +777,289 @@
         if (!key) return;
         const session = gameSessions.get(key);
         if (!session) return;
-        const attemptStop = (api) => {
-          if (!api || typeof api.stop !== 'function') return;
-          try {
-            const maybePromise = api.stop();
-            if (maybePromise && typeof maybePromise.then === 'function') {
-              maybePromise.catch(() => {});
-            }
-          } catch (error) {
-            /* ignore stop errors */
-          }
-        };
-        if (session.api) {
-          attemptStop(session.api);
-        } else if (session.apiPromise) {
-          session.apiPromise.then(attemptStop).catch(() => {});
+        if (activeSamuraiChallenge && activeSamuraiChallenge.page === page) {
+          clearTimeout(activeSamuraiChallenge.timeoutId);
+          activeSamuraiChallenge = null;
         }
-        if (session.host) {
-          session.mountedNodes = Array.from(session.host.childNodes);
-          if (session.mountedNodes.length) {
-            session.mountedNodes.forEach((node) => {
-              if (node.parentNode === session.host) {
-                session.host.removeChild(node);
-              }
-            });
-            session.detached = true;
-          }
+        if (session.api && typeof session.api.stop === 'function') {
+          try {
+            const maybe = session.api.stop();
+            if (maybe && typeof maybe.then === 'function') maybe.catch(() => {});
+          } catch (_) {}
         }
       };
 
       const mountGameTemplate = async (host, templateId) => {
         const html = loadTemplate(templateId);
         if (!html) return null;
-        let scriptPromises = [];
-        try {
-          host.innerHTML = '';
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(html, 'text/html');
-          const fragment = document.createDocumentFragment();
-          const appendChildren = (parent) => {
-            if (!parent) return;
-            parent.childNodes.forEach((node) => {
-              if (node.nodeName === 'TITLE') return;
-              fragment.appendChild(node.cloneNode(true));
-            });
-          };
-          appendChildren(doc.head);
-          appendChildren(doc.body);
-          window.storyGameApi = null;
-          host.appendChild(fragment);
-          host.querySelectorAll('script').forEach((oldScript) => {
-            const newScript = document.createElement('script');
-            newScript.async = false;
-            Array.from(oldScript.attributes).forEach((attr) => {
-              newScript.setAttribute(attr.name, attr.value);
-            });
-            newScript.textContent = oldScript.textContent;
-            const promise = newScript.src
-              ? new Promise((resolve) => {
-                  newScript.addEventListener('load', resolve, { once: true });
-                  newScript.addEventListener('error', resolve, { once: true });
-                })
-              : Promise.resolve();
-            scriptPromises.push(promise);
-            oldScript.replaceWith(newScript);
+        host.innerHTML = '';
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const fragment = document.createDocumentFragment();
+
+        const appendChildren = (parent) => {
+          if (!parent) return;
+          parent.childNodes.forEach((node) => {
+            if (node.nodeName !== 'TITLE') fragment.appendChild(node.cloneNode(true));
           });
-        } catch (error) {
-          return null;
-        }
-        try {
-          await Promise.all(scriptPromises);
-        } catch (error) {
-          /* ignore script load failures */
-        }
+        };
+
+        appendChildren(doc.head);
+        appendChildren(doc.body);
+        window.storyGameApi = null;
+        host.appendChild(fragment);
+
+        const scriptPromises = [];
+        host.querySelectorAll('script').forEach((oldScript) => {
+          const newScript = document.createElement('script');
+          newScript.async = false;
+          Array.from(oldScript.attributes).forEach((attr) => newScript.setAttribute(attr.name, attr.value));
+          newScript.textContent = oldScript.textContent;
+          const promise = newScript.src
+            ? new Promise((resolve) => {
+                newScript.addEventListener('load', resolve, { once: true });
+                newScript.addEventListener('error', resolve, { once: true });
+              })
+            : Promise.resolve();
+          scriptPromises.push(promise);
+          oldScript.replaceWith(newScript);
+        });
+
+        try { await Promise.all(scriptPromises); } catch (_) {}
         return window.storyGameApi || null;
+      };
+
+      const installSamuraiChallenge = (page) => {
+        const target = page.querySelector('[data-samurai-challenge]');
+        if (!target) return;
+        target.classList.toggle('visible', modeConfig[currentMode].enforceGameWin);
+        target.onmouseenter = null;
+        target.onmouseleave = null;
+        target.onfocus = null;
+        target.onblur = null;
+
+        if (!modeConfig[currentMode].enforceGameWin) return;
+
+        let hold = null;
+        const complete = () => {
+          if (activeSamuraiChallenge) {
+            clearTimeout(activeSamuraiChallenge.timeoutId);
+            activeSamuraiChallenge = null;
+          }
+          triggerTransition();
+          setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 300);
+        };
+        const start = () => { hold = setTimeout(complete, 2000); };
+        const cancel = () => { if (hold) clearTimeout(hold); hold = null; };
+        target.onmouseenter = start;
+        target.onmouseleave = cancel;
+        target.onfocus = start;
+        target.onblur = cancel;
+
+        const timeoutId = setTimeout(() => {
+          if (pages[currentIndex] !== page || currentMode !== 'samurai') return;
+          showPage(currentIndex);
+        }, samuraiTimeoutMs);
+
+        activeSamuraiChallenge = { page, timeoutId };
       };
 
       const loadGame = (key, page) => {
         const host = page.querySelector('[data-game-host]');
         if (!host) return;
+        pauseStoryMusic();
 
         let session = gameSessions.get(key);
         if (!session) {
           const templateId = gameTemplates[key];
           if (!templateId) return;
-          const apiPromise = mountGameTemplate(host, templateId);
-          const mountedNodes = Array.from(host.childNodes);
-          session = { host, api: null, apiPromise, mountedNodes, detached: false };
+          session = { host, api: null, apiPromise: mountGameTemplate(host, templateId) };
           gameSessions.set(key, session);
-        } else {
-          session.host = host;
-          if (!session.mountedNodes || !session.mountedNodes.length) {
-            session.mountedNodes = Array.from(host.childNodes);
-          }
-          if (session.detached && session.mountedNodes && session.mountedNodes.length) {
-            host.innerHTML = '';
-            session.mountedNodes.forEach((node) => {
-              host.appendChild(node);
-            });
-            session.detached = false;
-          }
         }
 
-        const startGame = async () => {
+        (async () => {
           try {
-            if (!session.api) {
-              session.api = await session.apiPromise;
-            }
-          } catch (error) {
-            return;
-          }
+            if (!session.api) session.api = await session.apiPromise;
+          } catch (_) { return; }
           if (pages[currentIndex] !== page) return;
-          const api = session.api;
-          if (!api || typeof api.start !== 'function') return;
-          window.requestAnimationFrame(() => {
-            try {
-              const maybePromise = api.start();
-              if (maybePromise && typeof maybePromise.then === 'function') {
-                maybePromise.catch(() => {});
-              }
-            } catch (error) {
-              /* ignore start errors */
-            }
-          });
-        };
 
-        startGame();
+          if (session.api && typeof session.api.start === 'function') {
+            try {
+              const maybe = session.api.start();
+              if (maybe && typeof maybe.then === 'function') maybe.catch(() => {});
+            } catch (_) {}
+          }
+
+          installSamuraiChallenge(page);
+
+          if (!modeConfig[currentMode].enforceGameWin && modeConfig[currentMode].autoGameAdvance) {
+            setTimeout(() => {
+              if (pages[currentIndex] !== page) return;
+              triggerTransition();
+              setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 260);
+            }, 5200);
+          }
+        })();
+      };
+
+      const updateNextButton = () => {
+        const page = pages[currentIndex];
+        const show = isJourneyStarted && modeConfig[currentMode].manualAdvance && page && page.dataset.type !== 'landing';
+        nextButton.hidden = !show;
       };
 
       const showPage = (index) => {
         if (index < 0 || index >= pages.length) return;
-        if (index === currentIndex) return;
-
-        const previousPage = pages[currentIndex];
-        if (previousPage) {
-          previousPage.classList.remove('active');
-          if (previousPage.dataset.type === 'story') {
-            clearStoryTimers(previousPage);
-            resetStoryMedia(previousPage);
-          }
-          if (previousPage.dataset.type === 'game') {
-            stopGame(previousPage);
-            triggerTransition();
-          }
+        const prev = pages[currentIndex];
+        if (prev) {
+          prev.classList.remove('active');
+          clearStoryTimers(prev);
+          if (prev.dataset.type === 'story') resetStoryMedia(prev);
+          if (prev.dataset.type === 'game') stopGame(prev);
         }
 
         currentIndex = index;
         const page = pages[currentIndex];
         if (!page) return;
         page.classList.add('active');
+        updateNextButton();
 
-        if (page.dataset.type === 'story') {
-          setupStoryPage(page);
-        }
-        if (page.dataset.type === 'game') {
-          loadGame(page.dataset.game, page);
-        }
+        if (page.dataset.type === 'story') setupStoryPage(page);
+        if (page.dataset.type === 'game') loadGame(page.dataset.game, page);
       };
 
       const nextPage = () => {
-        const nextIndex = (currentIndex + 1) % pages.length;
-        showPage(nextIndex);
+        if (!isJourneyStarted) return;
+        const n = (currentIndex + 1) % pages.length;
+        showPage(n === 0 ? 1 : n);
       };
-
-      if (nextButton) {
-        nextButton.addEventListener('click', () => {
-          nextPage();
-        });
-      }
 
       const requestFullscreen = async () => {
-        if (document.fullscreenElement) {
-          await document.exitFullscreen();
-          return;
-        }
         const root = document.documentElement;
-        const method = root.requestFullscreen || root.webkitRequestFullscreen || root.msRequestFullscreen;
-        if (method) {
-          try {
-            await method.call(root);
-          } catch (error) {
-            /* ignore fullscreen failures */
-          }
-        }
+        if (document.fullscreenElement) return;
+        const fn = root.requestFullscreen || root.webkitRequestFullscreen || root.msRequestFullscreen;
+        if (!fn) return;
+        try { await fn.call(root); } catch (_) {}
       };
 
-      if (fullscreenButton) {
-        fullscreenButton.addEventListener('click', () => {
+      document.addEventListener('fullscreenchange', () => {
+        if (isJourneyStarted && !document.fullscreenElement) {
           requestFullscreen();
-        });
-      }
-
-      const updateFullscreenLabel = () => {
-        if (!fullscreenButton) return;
-        fullscreenButton.textContent = document.fullscreenElement ? 'Exit Fullscreen' : 'Fullscreen';
-      };
-
-      document.addEventListener('fullscreenchange', updateFullscreenLabel);
-
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'ArrowRight' || event.key === ' ') {
-          nextPage();
         }
+        fullscreenButton.textContent = document.fullscreenElement ? 'Exit Fullscreen' : 'Fullscreen';
       });
 
-      setupStoryPage(pages[currentIndex]);
-      updateFullscreenLabel();
+      const preloadAsset = (src) => new Promise((resolve) => {
+        if (!src) return resolve();
+        const ext = src.split('?')[0].toLowerCase();
+        if (/\.(jpg|jpeg|png|gif|webp|svg)$/.test(ext)) {
+          const img = new Image();
+          img.onload = img.onerror = () => resolve();
+          img.src = src;
+          return;
+        }
+        if (/\.(mp3|wav|ogg|m4a)$/.test(ext)) {
+          const a = new Audio();
+          const done = () => { a.removeEventListener('canplaythrough', done); a.removeEventListener('error', done); resolve(); };
+          a.addEventListener('canplaythrough', done, { once: true });
+          a.addEventListener('error', done, { once: true });
+          a.preload = 'auto';
+          a.src = src;
+          a.load();
+          return;
+        }
+        if (/\.(mp4|webm|mov)$/.test(ext)) {
+          const v = document.createElement('video');
+          const done = () => { v.removeEventListener('loadeddata', done); v.removeEventListener('error', done); resolve(); };
+          v.addEventListener('loadeddata', done, { once: true });
+          v.addEventListener('error', done, { once: true });
+          v.preload = 'auto';
+          v.src = src;
+          v.load();
+          return;
+        }
+        resolve();
+      });
+
+      const gatherAssets = () => {
+        const set = new Set();
+        Object.values(modeConfig).forEach((m) => set.add(m.previewImage));
+        storyPages.forEach((page) => {
+          const img = page.dataset.image;
+          if (img) {
+            set.add(`${imageBasePath}${img}`);
+            set.add(`${videoBasePath}${img.replace(/\.(jpg|jpeg|png)$/i, '.mp4')}`);
+          }
+          if (page.dataset.audio) set.add(page.dataset.audio);
+        });
+        return Array.from(set);
+      };
+
+      const runPreload = async () => {
+        const assets = gatherAssets();
+        let done = 0;
+        const update = () => {
+          const pct = assets.length ? Math.round((done / assets.length) * 100) : 100;
+          loadingFill.style.width = `${pct}%`;
+          loadingLabel.textContent = `Preparing assets… ${pct}%`;
+        };
+        update();
+        await Promise.all(assets.map(async (asset) => {
+          await preloadAsset(asset);
+          done += 1;
+          update();
+        }));
+        startJourneyButton.disabled = false;
+        startJourneyButton.textContent = 'Start Journey';
+        loadingLabel.textContent = 'Ready';
+      };
+
+      const updateModeUI = () => {
+        const mode = modeConfig[currentMode];
+        modeButtons.forEach((button) => button.classList.toggle('active', button.dataset.mode === currentMode));
+        menuPreviewImage.src = mode.previewImage;
+        menuPreviewTitle.textContent = mode.previewTitle;
+        menuPreviewDescription.textContent = mode.previewDescription;
+        if (modeDescription) modeDescription.textContent = mode.previewDescription;
+      };
+
+      modeButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          currentMode = button.dataset.mode;
+          updateModeUI();
+          updateNextButton();
+        });
+      });
+
+      startJourneyButton.addEventListener('click', async () => {
+        if (startJourneyButton.disabled) return;
+        isJourneyStarted = true;
+        document.body.classList.add('playing');
+        if (chiCursor) chiCursor.style.opacity = '1';
+        await requestFullscreen();
+        fullscreenButton.hidden = true;
+        triggerTransition();
+        showPage(1);
+      });
+
+      nextButton.addEventListener('click', nextPage);
+      fullscreenButton.addEventListener('click', requestFullscreen);
+
+      document.addEventListener('keydown', (event) => {
+        if (!isJourneyStarted) return;
+        if (event.key === 'ArrowRight' || event.key === ' ') nextPage();
+      });
+
+      document.addEventListener('mousemove', (event) => {
+        if (!isJourneyStarted || !chiCursor) return;
+        chiCursor.style.left = `${event.clientX}px`;
+        chiCursor.style.top = `${event.clientY}px`;
+      });
+
+      updateModeUI();
+      renderMenuBlossoms();
+      showPage(0);
+      runPreload();
     });
   </script>
 


### PR DESCRIPTION
### Motivation
- Modernize the Samurai experience with a landing menu, visual previews and explicit interaction modes to improve discovery and onboarding. 
- Support multiple progression models (guided story, user-paced, and challenge-enforced Samurai mode) and make media playback and mini-games more robust. 
- Improve perceived performance and reliability by preloading assets and simplifying game template mounting and lifecycle handling.

### Description
- Add a landing page and menu UI with mode selection, preview image/title/description, animated blossoms, `startJourneyButton`, and a `chiCursor` for immersive cursor feedback, plus extensive CSS restyling and responsive rules. 
- Introduce mode configuration via `modeConfig` and UI wiring so each mode controls whether progression is manual, auto-advances mini-games, or requires winning mini-games to proceed. 
- Rework story flow: split and stage captions, colorize images, play or preload per-scene video/audio, implement dwell-based gaze targets with `createDwellGate` to advance, and add `installSamuraiChallenge` to enforce timed challenge behavior in Samurai mode. 
- Simplify game mounting and lifecycle with an improved `mountGameTemplate` that safely injects templates and scripts, a `loadGame` flow that pauses story music, session tracking, safer `stopGame` behavior, and an asset preloader via `runPreload`/`preloadAsset`.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e387c429ec8325bf7df0ef72d9a7a0)