### PR TITLE
Add language switcher/i18n, menu music, media refactor, and pointer asset update

### DIFF
--- a/eyegaze/samuraistory/cherryblossom.js
+++ b/eyegaze/samuraistory/cherryblossom.js
@@ -9,6 +9,7 @@
     const SONG_SRC    = "../../songs/samurai/cherryblossomsong2.mp3"; // bg song
     const ENABLE_BG_SONG = false; // keep shared story music constant during games
     const KATANA_DRAW_SRC = "../../sounds/katana.mp3";               // sword drawing SFX
+    const GAME_COLOR_REVEAL_MS = 120000;
 
     // Cursor limits and hotspot (in ORIGINAL image pixels)
     const CURSOR_MAX_PX = 124;
@@ -248,6 +249,7 @@
     ======================= */
     let gameState = 'idle';  // 'idle' | 'intro' | 'play'
     let introStartMs = 0;
+    let gameStartMs = 0;
     let started = false;
     let rafId = 0;
 
@@ -377,6 +379,10 @@
        BACKGROUND IMAGE (cover)
     ======================= */
     function drawBackgroundImage() {
+      const progress = Math.max(0, Math.min(1, (performance.now() - gameStartMs) / GAME_COLOR_REVEAL_MS));
+      const gray = 100 - (progress * 100);
+      ctx.save();
+      ctx.filter = `grayscale(${gray}%)`;
       if (bgImg.complete && bgImg.naturalWidth > 0) {
         const iw = bgImg.width, ih = bgImg.height;
         const scale = Math.max(W / iw, H / ih); // cover
@@ -389,6 +395,7 @@
         ctx.fillStyle = "#fff";
         ctx.fillRect(0, 0, W, H);
       }
+      ctx.restore();
     }
 
     /* =======================
@@ -420,7 +427,13 @@
       // Whole blossoms
       for (const b of blossoms) {
         ctx.save(); ctx.translate(b.x,b.y); ctx.rotate(b.angle);
-        ctx.drawImage(img,-b.w/2,-b.h/2,b.w,b.h); ctx.restore();
+        ctx.drawImage(img,-b.w/2,-b.h/2,b.w,b.h);
+        ctx.strokeStyle = 'rgba(0,0,0,0.52)';
+        ctx.lineWidth = Math.max(2, Math.min(6, b.w * 0.018));
+        ctx.beginPath();
+        ctx.ellipse(0, 0, b.w * 0.36, b.h * 0.36, 0, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.restore();
       }
       // Shards
       const t = nowSec();
@@ -489,6 +502,7 @@
 
       started = true;
       resetGameState();
+      gameStartMs = performance.now();
       if (startOverlay) startOverlay.style.display = 'none';
       canvas.style.cursor = 'none';
 

--- a/eyegaze/samuraistory/cherryblossom.js
+++ b/eyegaze/samuraistory/cherryblossom.js
@@ -3,10 +3,11 @@
        CONFIG
     ======================= */
     const IMG_SRC = "../../images/samurai/cherryblossom.png";       // petal image
-    const BG_SRC  = "../../images/samurai/cherryblossombg.png";     // background image
+    const BG_SRC  = "../../images/samuraikata/cerisier.jpg";        // background image
     const SLASH_SOUND = "../../sounds/blade.mp3";
     const KATANA_SRC  = "../../images/samurai/katana.png";
     const SONG_SRC    = "../../songs/samurai/cherryblossomsong2.mp3"; // bg song
+    const ENABLE_BG_SONG = false; // keep shared story music constant during games
     const KATANA_DRAW_SRC = "../../sounds/katana.mp3";               // sword drawing SFX
 
     // Cursor limits and hotspot (in ORIGINAL image pixels)
@@ -491,7 +492,9 @@
       if (startOverlay) startOverlay.style.display = 'none';
       canvas.style.cursor = 'none';
 
-      try { bgSong.currentTime = 0; await bgSong.play(); } catch (e) {}
+      if (ENABLE_BG_SONG) {
+        try { bgSong.currentTime = 0; await bgSong.play(); } catch (e) {}
+      }
       try { katanaDraw.currentTime = 0; katanaDraw.pause(); } catch (e) {}
 
       gameState = 'intro';
@@ -508,7 +511,9 @@
       rafId = 0;
       resetGameState();
       canvas.style.cursor = 'default';
-      try { bgSong.pause(); bgSong.currentTime = 0; } catch (e) {}
+      if (ENABLE_BG_SONG) {
+        try { bgSong.pause(); bgSong.currentTime = 0; } catch (e) {}
+      }
       try { slashAudio.pause(); slashAudio.currentTime = 0; } catch (e) {}
       try { katanaDraw.pause(); katanaDraw.currentTime = 0; } catch (e) {}
     }

--- a/eyegaze/samuraistory/cherryblossom.js
+++ b/eyegaze/samuraistory/cherryblossom.js
@@ -12,7 +12,7 @@
     const GAME_COLOR_REVEAL_MS = 120000;
 
     // Cursor limits and hotspot (in ORIGINAL image pixels)
-    const CURSOR_MAX_PX = 124;
+    const CURSOR_MAX_PX = 170;
     const HOTSPOT_ORIG = { x: 12, y: 28 };
 
     // Play (normal game) settings
@@ -84,7 +84,7 @@
 
     // Background music
     const bgSong = new Audio(SONG_SRC);
-    bgSong.volume = 0.75;   // 75%
+    bgSong.volume = 0.8;    // 80%
     bgSong.loop = true;
 
     // Katana draw SFX (for the moment the sword cursor appears)

--- a/eyegaze/samuraistory/cherryblossom.js
+++ b/eyegaze/samuraistory/cherryblossom.js
@@ -428,11 +428,6 @@
       for (const b of blossoms) {
         ctx.save(); ctx.translate(b.x,b.y); ctx.rotate(b.angle);
         ctx.drawImage(img,-b.w/2,-b.h/2,b.w,b.h);
-        ctx.strokeStyle = 'rgba(0,0,0,0.52)';
-        ctx.lineWidth = Math.max(2, Math.min(6, b.w * 0.018));
-        ctx.beginPath();
-        ctx.ellipse(0, 0, b.w * 0.36, b.h * 0.36, 0, 0, Math.PI * 2);
-        ctx.stroke();
         ctx.restore();
       }
       // Shards

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -646,6 +646,7 @@
       const dwellMs = 1000;
       const colorFadeWaitMs = 3300;
       const samuraiTimeoutMs = 25000;
+      const storyGameDurationMs = 120000;
       const transitionFadeOutMs = 2200;
       const transitionBlackMs = 500;
       const transitionFadeInMs = 2200;
@@ -1235,6 +1236,13 @@
           }
 
           installSamuraiChallenge(page, key, session.api);
+
+          if (currentMode === 'story') {
+            setTimeout(() => {
+              if (pages[currentIndex] !== page || currentMode !== 'story') return;
+              nextPage();
+            }, storyGameDurationMs);
+          }
 
           if (!modeConfig[currentMode].enforceGameWin && modeConfig[currentMode].autoGameAdvance) {
             setTimeout(() => {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -296,12 +296,14 @@
 
     .story-caption {
       position: absolute;
-      left: 2.2vw;
-      right: 2.2vw;
+      left: 50%;
       bottom: 2vw;
+      width: min(56vw, 620px);
+      min-height: 150px;
       z-index: 4;
-      padding: 18px 20px;
-      border-radius: 12px;
+      transform: translate(-50%, 12px);
+      padding: 20px 24px;
+      border-radius: 10px;
       border: 1px solid rgba(255,255,255,.22);
       background: rgba(5,10,18,.7);
       font-family: "Palatino Linotype", "Book Antiqua", Palatino, serif;
@@ -311,12 +313,31 @@
       letter-spacing: .02em;
       text-shadow: 0 7px 24px rgba(0,0,0,.75);
       pointer-events: none;
+      overflow: hidden;
       opacity: 0;
-      transform: translateY(12px);
       transition: opacity .35s ease, transform .35s ease;
     }
 
-    .story-caption.visible { opacity: 1; transform: translateY(0); }
+    .story-caption.visible { opacity: 1; transform: translate(-50%, 0); }
+    .story-caption.advanceable {
+      pointer-events: auto;
+      cursor: pointer;
+      border-color: rgba(255, 120, 120, .75);
+      box-shadow: 0 0 0 3px rgba(255,72,72,.16), 0 10px 26px rgba(0,0,0,.45);
+    }
+    .story-caption.advanceable::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 0;
+      height: 0;
+      background: rgba(255,40,40,.33);
+      transform: translate(-50%, -50%);
+      transition: width .95s linear, height .95s linear;
+      pointer-events: none;
+    }
+    .story-caption.advanceable.dwell::after { width: 100%; height: 100%; }
 
     .gaze-target {
       position: absolute;
@@ -795,6 +816,7 @@
         video.load();
         video.onended = null;
         caption.classList.remove('visible');
+        caption.classList.remove('advanceable', 'dwell');
         caption.textContent = '';
         gazeTarget.classList.remove('visible', 'dwell');
       };
@@ -917,10 +939,10 @@
             timers.ids.push(setTimeout(step5, 900));
             return;
           }
-          gazeTarget.classList.add('visible');
+          caption.classList.add('advanceable');
           if (timers.cleanup) timers.cleanup();
-          timers.cleanup = createDwellGate(gazeTarget, () => {
-            gazeTarget.classList.remove('visible');
+          timers.cleanup = createDwellGate(caption, () => {
+            caption.classList.remove('advanceable', 'dwell');
             step5();
           }, autoActivateMs);
         };
@@ -1276,6 +1298,13 @@
 
       document.addEventListener('keydown', (event) => {
         if (!isJourneyStarted) return;
+        if (event.key.toLowerCase() === 's') {
+          const page = pages[currentIndex];
+          if (page?.dataset?.type === 'game') {
+            nextPage();
+            return;
+          }
+        }
         if (event.key === 'ArrowRight' || event.key === ' ') nextPage();
       });
 

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -63,6 +63,29 @@
       text-shadow: 0 5px 16px rgba(0,0,0,.5);
       text-align: center;
     }
+    .language-switcher {
+      position: absolute;
+      top: clamp(12px, 1.4vw, 22px);
+      right: clamp(12px, 1.4vw, 22px);
+      display: flex;
+      gap: 8px;
+      z-index: 5;
+    }
+    .lang-btn {
+      border: 1px solid rgba(252, 216, 147, .42);
+      background: rgba(12, 16, 26, .72);
+      color: #f8edd8;
+      border-radius: 999px;
+      padding: 7px 12px;
+      font-size: .82rem;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+    .lang-btn.active {
+      background: rgba(148, 83, 38, .72);
+      border-color: rgba(252, 216, 147, .82);
+    }
 
     .menu-blossoms {
       position: absolute;
@@ -392,6 +415,11 @@
     <section id="landingPage" class="page landing-page active" data-type="landing">
       <div class="menu-shell">
         <div class="menu-controls">
+          <div id="languageSwitcher" class="language-switcher" role="group" aria-label="Language switcher">
+            <button class="lang-btn" data-lang="en" type="button">EN</button>
+            <button class="lang-btn" data-lang="fr" type="button">FR</button>
+            <button class="lang-btn" data-lang="ja" type="button">日本語</button>
+          </div>
           <div id="menuBlossoms" class="menu-blossoms" aria-hidden="true"></div>
           <h2 id="menuTitleLocalized" class="menu-title-localized" data-fr="La puissance de l'esprit" data-en="The Power of the Mind">La puissance de l'esprit</h2>
           <div class="menu-row">
@@ -406,7 +434,7 @@
         </div>
 
         <div class="menu-preview">
-          <img id="menuPreviewImage" src="../../images/samuraikata/paysagejapon.jpg" alt="Mode preview" />
+          <img id="menuPreviewImage" src="../../images/samuraikata/cerisier.jpg" alt="Mode preview" />
           <div class="menu-overlay">
             <h1 id="menuPreviewTitle">Story</h1>
           </div>
@@ -414,7 +442,7 @@
       </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="paysagejapon.jpg" data-alt="A peaceful Japanese landscape at dawn." data-text="At first light, mist drifts above the valley while distant bells echo across silent fields. You stand still, breathing in the cold dawn, and feel the first promise of your long path." data-audio="../../songs/samurai/cherryblossomsong.mp3" data-target="82,72">
+    <section class="page story-page" data-type="story" data-image="scene1.jpg" data-alt="Story scene 1." data-text="Scene 1 placeholder: the samurai story begins." data-audio="../../songs/samurai/cherryblossomsong.mp3" data-target="82,72">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
         <video class="story-video" playsinline></video>
@@ -423,7 +451,16 @@
       </div>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="boulebleuchi.jpg" data-alt="A samurai focuses on a glowing chi sphere." data-text="You gather swirling chi between your palms, shaping its pulse with patience instead of force. The trembling light steadies, and your heartbeat learns to follow its rhythm." data-audio="../../songs/samurai/samuraisong1.mp3" data-target="16,74">
+    <section class="page story-page" data-type="story" data-image="scene2.jpg" data-alt="Story scene 2." data-text="Scene 2 placeholder: transition to the next lesson." data-novideo="true" data-audio="../../songs/samurai/samuraisong1.mp3" data-target="16,74">
+      <div class="story-media" data-story-media>
+        <img class="story-image" alt="" />
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
+      </div>
+    </section>
+
+    <section class="page story-page" data-type="story" data-image="scene3.jpeg" data-alt="Story scene 3." data-text="Scene 3 placeholder: preparing for the cherry blossom challenge." data-audio="../../songs/samurai/samuraisong1.mp3" data-target="42,65">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
         <video class="story-video" playsinline></video>
@@ -437,7 +474,25 @@
       <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="maitrechi.jpg" data-alt="A master guides the samurai with calm energy." data-text="Your master watches in silence, then speaks slowly about balance, restraint, and exactness. Every motion, he says, must begin in stillness before it can become a strike." data-audio="../../songs/samurai/samuraisong2.mp3" data-target="84,30">
+    <section class="page story-page" data-type="story" data-image="scene5.jpg" data-alt="Story scene 5." data-text="Scene 5 placeholder: after the blossoms, the path continues." data-audio="../../songs/samurai/samuraisong2.mp3" data-target="84,30">
+      <div class="story-media" data-story-media>
+        <img class="story-image" alt="" />
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
+      </div>
+    </section>
+
+    <section class="page story-page" data-type="story" data-image="scene6.jpg" data-alt="Story scene 6." data-text="Scene 6 placeholder: quiet reflection before moon training." data-novideo="true" data-audio="../../songs/samurai/samuraisong2.mp3" data-target="66,48">
+      <div class="story-media" data-story-media>
+        <img class="story-image" alt="" />
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
+      </div>
+    </section>
+
+    <section class="page story-page" data-type="story" data-image="scene7.jpg" data-alt="Story scene 7." data-text="Scene 7 placeholder: the moon challenge approaches." data-audio="../../songs/samurai/samuraisong2.mp3" data-target="24,26">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
         <video class="story-video" playsinline></video>
@@ -451,7 +506,25 @@
       <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
     </section>
 
-    <section class="page story-page" data-type="story" data-image="lanternesallu.jpg" data-alt="Lanterns glow softly in the night sky." data-text="Night arrives and hundreds of lanterns rise, carrying whispered hopes into the wind. Their warm glow paints the darkness, and you swear to honor each promise you have made." data-audio="../../songs/samurai/samuraisong3.mp3" data-target="18,34">
+    <section class="page story-page" data-type="story" data-image="scene9.jpg" data-alt="Story scene 9." data-text="Scene 9 placeholder: power grows under the moonlight." data-audio="../../songs/samurai/samuraisong3.mp3" data-target="18,34">
+      <div class="story-media" data-story-media>
+        <img class="story-image" alt="" />
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
+      </div>
+    </section>
+
+    <section class="page story-page" data-type="story" data-image="scene10.jpg" data-alt="Story scene 10." data-text="Scene 10 placeholder: the lantern path begins." data-novideo="true" data-audio="../../songs/samurai/samuraisong3.mp3" data-target="58,38">
+      <div class="story-media" data-story-media>
+        <img class="story-image" alt="" />
+        <video class="story-video" playsinline></video>
+        <div class="story-caption" data-story-caption></div>
+        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
+      </div>
+    </section>
+
+    <section class="page story-page" data-type="story" data-image="scene11.jpg" data-alt="Story scene 11." data-text="Scene 11 placeholder: final preparation for the lantern challenge." data-audio="../../songs/samurai/samuraisong3.mp3" data-target="50,20">
       <div class="story-media" data-story-media>
         <img class="story-image" alt="" />
         <video class="story-video" playsinline></video>
@@ -463,15 +536,6 @@
     <section class="page game-page" data-type="game" data-game="lamp">
       <div class="game-frame" data-game-host></div>
       <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
-    </section>
-
-    <section class="page story-page" data-type="story" data-image="katanafleurs.jpg" data-alt="A katana rests among drifting cherry blossoms." data-text="Cherry petals circle your resting blade as the final lesson settles in your chest. Strength, discipline, and mercy now move together, and your journey enters its next chapter." data-audio="../../songs/samurai/samuraisong4.mp3" data-target="50,20">
-      <div class="story-media" data-story-media>
-        <img class="story-image" alt="" />
-        <video class="story-video" playsinline></video>
-        <div class="story-caption" data-story-caption></div>
-        <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
-      </div>
     </section>
   </div>
 
@@ -489,12 +553,14 @@
       const menuPreviewImage = document.getElementById('menuPreviewImage');
       const menuPreviewTitle = document.getElementById('menuPreviewTitle');
       const modeDescription = document.getElementById('modeDescription');
+      const languageButtons = Array.from(document.querySelectorAll('.lang-btn'));
       const menuTitleLocalized = document.getElementById('menuTitleLocalized');
       const menuBlossoms = document.getElementById('menuBlossoms');
       const chiCursor = document.getElementById('chiCursor');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
       const STORY_LOOP_SRC = '../../songs/samurai/samuraisong4.mp3';
+      const MENU_LOOP_SRC = '../../songs/samurai/samuraisong2.mp3';
 
       const gameTemplates = { cherry: 'tpl-cherryblossom', meditation: 'tpl-meditation', lamp: 'tpl-lamp' };
       const templateCache = {};
@@ -511,36 +577,100 @@
       storyMusic.loop = true;
       storyMusic.preload = 'auto';
       let storyMusicSrc = '';
+      const menuMusic = new Audio();
+      menuMusic.loop = true;
+      menuMusic.preload = 'auto';
+      menuMusic.src = MENU_LOOP_SRC;
       let activeSamuraiChallenge = null;
       const samuraiTargets = { cherry: 15, meditation: 10, lamp: 10 };
 
       const modeConfig = {
         story: {
-          label: 'Story',
-          previewImage: '../../images/samuraikata/paysagejapon.jpg',
-          previewTitle: 'Story',
-          previewDescription: 'A cinematic tale that progresses without requiring input and preserves uninterrupted narrative flow.',
+          previewImage: '../../images/samuraikata/cerisier.jpg',
           manualAdvance: true,
           enforceGameWin: false,
           autoGameAdvance: false,
         },
         autonomous: {
-          label: 'Normal',
-          previewImage: '../../images/samuraikata/maitrechi.jpg',
-          previewTitle: 'Normal',
-          previewDescription: 'A user-paced journey where you control progression, while mini-games remain open and non-blocking.',
+          previewImage: '../../images/samuraikata/luneattaqueboulechi.jpg',
           manualAdvance: true,
           enforceGameWin: false,
           autoGameAdvance: false,
         },
         samurai: {
-          label: 'Samurai',
-          previewImage: '../../images/samuraikata/katanafleurs.jpg',
-          previewTitle: 'Samurai',
-          previewDescription: 'The strict path: you manually progress and must succeed in mini-game challenges to continue.',
+          previewImage: '../../images/samuraikata/boulediffuse.jpg',
           manualAdvance: true,
           enforceGameWin: true,
           autoGameAdvance: false,
+        }
+      };
+
+      const i18n = {
+        en: {
+          menuTitle: 'The Power of the Mind',
+          loading: 'Loading…',
+          start: 'Start Journey',
+          modes: { story: 'Story', autonomous: 'Normal', samurai: 'Samurai' },
+          descriptions: {
+            story: 'A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.',
+            autonomous: 'A user-paced journey where you control progression, while mini-games remain open and non-blocking.',
+            samurai: 'The strict path: you manually progress and must succeed in mini-game challenges to continue.'
+          },
+          scenes: {
+            scene1: 'Scene 1 placeholder: the samurai story begins.',
+            scene2: 'Scene 2 placeholder: transition to the next lesson.',
+            scene3: 'Scene 3 placeholder: preparing for the cherry blossom challenge.',
+            scene5: 'Scene 5 placeholder: after the blossoms, the path continues.',
+            scene6: 'Scene 6 placeholder: quiet reflection before moon training.',
+            scene7: 'Scene 7 placeholder: the moon challenge approaches.',
+            scene9: 'Scene 9 placeholder: power grows under the moonlight.',
+            scene10: 'Scene 10 placeholder: the lantern path begins.',
+            scene11: 'Scene 11 placeholder: final preparation for the lantern challenge.'
+          }
+        },
+        fr: {
+          menuTitle: "La puissance de l'esprit",
+          loading: 'Chargement…',
+          start: 'Commencer',
+          modes: { story: 'Histoire', autonomous: 'Normal', samurai: 'Samouraï' },
+          descriptions: {
+            story: "Une expérience cinématique guidée où chaque moment se déroule automatiquement pendant que vous profitez de l'ambiance.",
+            autonomous: 'Une aventure au rythme du joueur où vous contrôlez la progression, avec des mini-jeux non bloquants.',
+            samurai: 'La voie stricte : progression manuelle et réussite des mini-jeux obligatoire pour continuer.'
+          },
+          scenes: {
+            scene1: 'Scène 1 (texte temporaire) : le récit du samouraï commence.',
+            scene2: 'Scène 2 (texte temporaire) : transition vers la prochaine leçon.',
+            scene3: 'Scène 3 (texte temporaire) : préparation au défi des cerisiers.',
+            scene5: 'Scène 5 (texte temporaire) : après les fleurs, le chemin continue.',
+            scene6: 'Scène 6 (texte temporaire) : réflexion avant l’entraînement lunaire.',
+            scene7: 'Scène 7 (texte temporaire) : le défi de la lune approche.',
+            scene9: 'Scène 9 (texte temporaire) : la puissance grandit sous la lune.',
+            scene10: 'Scène 10 (texte temporaire) : le parcours des lanternes commence.',
+            scene11: 'Scène 11 (texte temporaire) : préparation finale pour le défi des lanternes.'
+          }
+        },
+        ja: {
+          menuTitle: '心の力',
+          loading: '読み込み中…',
+          start: '開始',
+          modes: { story: 'ストーリー', autonomous: 'ノーマル', samurai: 'サムライ' },
+          descriptions: {
+            story: '雰囲気を味わいながら、各シーンが自動で進むシネマティック体験です。',
+            autonomous: '自分のペースで進行し、ミニゲームは開放されたままのモードです。',
+            samurai: '厳しい道：手動で進行し、ミニゲームを成功しないと先に進めません。'
+          },
+          scenes: {
+            scene1: 'シーン1（仮テキスト）：侍の物語が始まる。',
+            scene2: 'シーン2（仮テキスト）：次の修行への移行。',
+            scene3: 'シーン3（仮テキスト）：桜の試練への準備。',
+            scene5: 'シーン5（仮テキスト）：桜の後、旅は続く。',
+            scene6: 'シーン6（仮テキスト）：月の修行前の静かな内省。',
+            scene7: 'シーン7（仮テキスト）：月の試練が近づく。',
+            scene9: 'シーン9（仮テキスト）：月光の下で力が増す。',
+            scene10: 'シーン10（仮テキスト）：灯籠の道が始まる。',
+            scene11: 'シーン11（仮テキスト）：灯籠の試練への最終準備。'
+          }
         }
       };
 
@@ -551,24 +681,21 @@
       };
 
       const getUiLang = () => {
-        const lang = (document.documentElement.lang || navigator.language || 'fr').toLowerCase();
-        return lang.startsWith('fr') ? 'fr' : 'en';
+        const stored = (localStorage.getItem('siteLanguage') || document.documentElement.lang || navigator.language || 'en').toLowerCase();
+        if (stored.startsWith('fr')) return 'fr';
+        if (stored.startsWith('ja')) return 'ja';
+        return 'en';
       };
 
       const localizeMenuTitle = () => {
         if (!menuTitleLocalized) return;
         const lang = getUiLang();
-        const value = lang === 'fr' ? menuTitleLocalized.dataset.fr : menuTitleLocalized.dataset.en;
-        if (value) menuTitleLocalized.textContent = value;
+        menuTitleLocalized.textContent = i18n[lang].menuTitle;
       };
 
       const localizeModeButtonLabels = () => {
         const lang = getUiLang();
-        const labels = {
-          story: lang === 'fr' ? 'Histoire' : 'Story',
-          autonomous: lang === 'fr' ? 'Normal' : 'Normal',
-          samurai: lang === 'fr' ? 'Samouraï' : 'Samurai',
-        };
+        const labels = i18n[lang].modes;
         modeButtons.forEach((button) => {
           const strong = button.querySelector('strong');
           if (!strong) return;
@@ -616,6 +743,26 @@
 
       const pauseStoryMusic = () => {
         storyMusic.pause();
+      };
+
+      const playMenuMusic = () => {
+        if (isJourneyStarted) return;
+        menuMusic.play().catch(() => {});
+      };
+
+      const pauseMenuMusic = () => {
+        menuMusic.pause();
+      };
+
+      const updateGlobalChiCursor = (page = pages[currentIndex]) => {
+        if (!chiCursor) return;
+        if (!isJourneyStarted) {
+          chiCursor.style.opacity = '0';
+          return;
+        }
+        const isStoryPage = page?.dataset?.type === 'story';
+        const isMeditationGame = page?.dataset?.type === 'game' && page?.dataset?.game === 'meditation';
+        chiCursor.style.opacity = (isStoryPage || isMeditationGame) ? '1' : '0';
       };
 
       const clearStoryTimers = (page) => {
@@ -723,7 +870,9 @@
 
         resetStoryMedia(page);
         const imageName = page.dataset.image;
-        const fullText = page.dataset.text || '';
+        const sceneKey = (page.dataset.image || '').replace(/\.(jpg|jpeg|png)$/i, '');
+        const sceneText = i18n[getUiLang()]?.scenes?.[sceneKey] || page.dataset.text || '';
+        const fullText = sceneText;
         const [textA, textB] = splitText(fullText);
         playStoryMusic();
 
@@ -734,13 +883,19 @@
         gazeTarget.style.left = `${Math.min(94, Math.max(6, Number.parseFloat(xRaw) || 82))}%`;
         gazeTarget.style.top = `${Math.min(92, Math.max(8, Number.parseFloat(yRaw) || 72))}%`;
 
-        const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
-        const videoPath = `${videoBasePath}${videoName}`;
-        video.src = videoPath;
-        video.muted = true;
-        video.volume = 0;
-        video.preload = 'auto';
-        video.load();
+        const hasVideo = page.dataset.novideo !== 'true';
+        if (hasVideo) {
+          const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
+          const videoPath = `${videoBasePath}${videoName}`;
+          video.src = videoPath;
+          video.muted = true;
+          video.volume = 0;
+          video.preload = 'auto';
+          video.load();
+        } else {
+          video.removeAttribute('src');
+          video.load();
+        }
 
         const timers = { ids: [], cleanup: null };
         const manual = modeConfig[currentMode].manualAdvance;
@@ -978,6 +1133,7 @@
         if (!page) return;
         page.classList.add('active');
         updateNextButton();
+        updateGlobalChiCursor(page);
 
         if (page.dataset.type === 'story') setupStoryPage(page);
         if (page.dataset.type === 'game') loadGame(page.dataset.game, page);
@@ -1037,12 +1193,15 @@
 
       const gatherAssets = () => {
         const set = new Set();
+        set.add(MENU_LOOP_SRC);
         Object.values(modeConfig).forEach((m) => set.add(m.previewImage));
         storyPages.forEach((page) => {
           const img = page.dataset.image;
           if (img) {
             set.add(`${imageBasePath}${img}`);
-            set.add(`${videoBasePath}${img.replace(/\.(jpg|jpeg|png)$/i, '.mp4')}`);
+            if (page.dataset.novideo !== 'true') {
+              set.add(`${videoBasePath}${img.replace(/\.(jpg|jpeg|png)$/i, '.mp4')}`);
+            }
           }
           if (page.dataset.audio) set.add(page.dataset.audio);
         });
@@ -1055,21 +1214,23 @@
           await preloadAsset(asset);
         }));
         startJourneyButton.disabled = false;
-        startJourneyButton.textContent = 'Start Journey';
+        startJourneyButton.textContent = i18n[getUiLang()].start;
+        playMenuMusic();
       };
 
       const updateModeUI = () => {
         const lang = getUiLang();
         const mode = modeConfig[currentMode];
+        const text = i18n[lang];
         modeButtons.forEach((button) => button.classList.toggle('active', button.dataset.mode === currentMode));
         menuPreviewImage.src = mode.previewImage;
-        const localizedPreviewTitle = currentMode === 'story'
-          ? (lang === 'fr' ? 'Histoire' : 'Story')
-          : currentMode === 'autonomous'
-            ? 'Normal'
-            : (lang === 'fr' ? 'Samouraï' : 'Samurai');
-        menuPreviewTitle.textContent = localizedPreviewTitle;
-        if (modeDescription) modeDescription.textContent = mode.previewDescription;
+        menuPreviewTitle.textContent = text.modes[currentMode];
+        if (modeDescription) modeDescription.textContent = text.descriptions[currentMode];
+        if (startJourneyButton.disabled) startJourneyButton.textContent = text.loading;
+        else startJourneyButton.textContent = text.start;
+        localizeMenuTitle();
+        localizeModeButtonLabels();
+        languageButtons.forEach((btn) => btn.classList.toggle('active', btn.dataset.lang === lang));
       };
 
       modeButtons.forEach((button) => {
@@ -1077,6 +1238,7 @@
           currentMode = button.dataset.mode;
           updateModeUI();
           updateNextButton();
+          updateGlobalChiCursor();
         });
       });
 
@@ -1084,10 +1246,22 @@
         if (startJourneyButton.disabled) return;
         isJourneyStarted = true;
         document.body.classList.add('playing');
-        if (chiCursor) chiCursor.style.opacity = '1';
+        pauseMenuMusic();
         await requestFullscreen();
         triggerTransition();
         showPage(1);
+      });
+
+      languageButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const lang = button.dataset.lang;
+          if (!i18n[lang]) return;
+          try { localStorage.setItem('siteLanguage', lang); } catch (_) {}
+          document.documentElement.lang = lang;
+          updateModeUI();
+          const currentPage = pages[currentIndex];
+          if (currentPage?.dataset?.type === 'story') setupStoryPage(currentPage);
+        });
       });
 
       if (nextButton) nextButton.addEventListener('click', nextPage);
@@ -1104,8 +1278,6 @@
       });
 
       updateModeUI();
-      localizeMenuTitle();
-      localizeModeButtonLabels();
       renderMenuBlossoms();
       showPage(0);
       runPreload();

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -362,13 +362,23 @@
       top: 50%;
       width: 0;
       height: 0;
-      background: rgba(70,255,120,.45);
+      background: rgba(255,40,40,.45);
       transform: translate(-50%, -50%);
       transition: width .95s linear, height .95s linear;
     }
 
     .gaze-target.visible {
-      opacity: 1;
+      opacity: .68;
+      pointer-events: none;
+      animation: none;
+    }
+    .gaze-target.inactive {
+      opacity: .42;
+      pointer-events: none;
+      animation: none;
+    }
+    .gaze-target.active {
+      opacity: .95;
       pointer-events: auto;
       animation: gazePulse 1.8s ease-in-out infinite;
     }
@@ -399,6 +409,11 @@
 
     .page.game-page { background: #000; padding: 0; align-items: stretch; justify-content: stretch; }
     .game-frame { width: 100%; height: 100%; display: block; background: #000; position: relative; overflow: hidden; }
+    .story-media.video-playing .gaze-target {
+      opacity: 0 !important;
+      pointer-events: none !important;
+      animation: none !important;
+    }
     .conclusion-page {
       background: #000;
       align-items: center;
@@ -867,7 +882,7 @@
         caption.classList.remove('visible');
         caption.classList.remove('advanceable', 'dwell');
         caption.textContent = '';
-        gazeTarget.classList.remove('visible', 'dwell');
+        gazeTarget.classList.remove('visible', 'active', 'inactive', 'dwell');
       };
 
       const playVideoThenAdvance = (page, video, media) => {
@@ -975,6 +990,12 @@
         const timers = { ids: [], cleanup: null };
         const manual = modeConfig[currentMode].manualAdvance;
         const autoActivateMs = currentMode === 'story' ? 30000 : 0;
+        const setTargetState = (isActive) => {
+          gazeTarget.classList.add('visible');
+          gazeTarget.classList.toggle('active', isActive);
+          gazeTarget.classList.toggle('inactive', !isActive);
+        };
+        setTargetState(false);
         const bindAdvanceTargets = (onDone) => {
           let finished = false;
           let cleanA = null;
@@ -1007,28 +1028,30 @@
             timers.ids.push(setTimeout(step5, 900));
             return;
           }
-          gazeTarget.classList.add('visible');
+          setTargetState(true);
           caption.classList.add('advanceable');
           if (timers.cleanup) timers.cleanup();
           timers.cleanup = bindAdvanceTargets(() => {
             caption.classList.remove('advanceable', 'dwell');
-            gazeTarget.classList.remove('visible', 'dwell');
+            setTargetState(false);
+            gazeTarget.classList.remove('dwell');
             step5();
           });
         };
         const step3 = () => {
           if (pages[currentIndex] !== page) return;
           image.classList.add('colored');
+          setTargetState(false);
           if (!manual) {
             timers.ids.push(setTimeout(step4, colorFadeWaitMs));
             return;
           }
           timers.ids.push(setTimeout(() => {
             if (pages[currentIndex] !== page) return;
-            gazeTarget.classList.add('visible');
+            setTargetState(true);
             if (timers.cleanup) timers.cleanup();
             timers.cleanup = createDwellGate(gazeTarget, () => {
-              gazeTarget.classList.remove('visible');
+              setTargetState(false);
               step4();
             }, autoActivateMs);
           }, colorFadeWaitMs));
@@ -1041,12 +1064,13 @@
             timers.ids.push(setTimeout(step3, 1100));
             return;
           }
-          gazeTarget.classList.add('visible');
+          setTargetState(true);
           caption.classList.add('advanceable');
           if (timers.cleanup) timers.cleanup();
           timers.cleanup = bindAdvanceTargets(() => {
             caption.classList.remove('advanceable', 'dwell');
-            gazeTarget.classList.remove('visible', 'dwell');
+            setTargetState(false);
+            gazeTarget.classList.remove('dwell');
             step3();
           });
         };
@@ -1059,9 +1083,9 @@
             timers.ids.push(setTimeout(step2, 900));
             return;
           }
-          gazeTarget.classList.add('visible');
+          setTargetState(true);
           timers.cleanup = createDwellGate(gazeTarget, () => {
-            gazeTarget.classList.remove('visible');
+            setTargetState(false);
             step2();
           }, autoActivateMs);
         };
@@ -1230,10 +1254,11 @@
         if (!page) return;
         const target = page.querySelector('[data-conclusion-target]');
         if (!target) return;
-        target.classList.add('visible');
+        target.classList.add('visible', 'active');
+        target.classList.remove('inactive');
         if (conclusionCleanup) conclusionCleanup();
         conclusionCleanup = createDwellGate(target, () => {
-          target.classList.remove('visible', 'dwell');
+          target.classList.remove('visible', 'active', 'dwell');
           nextPage();
         }, currentMode === 'story' ? 30000 : 0);
       };

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -342,13 +342,13 @@
 
     .gaze-target {
       position: absolute;
-      width: clamp(92px, 8.6vw, 132px);
-      height: clamp(92px, 8.6vw, 132px);
+      width: clamp(118px, 10.5vw, 168px);
+      height: clamp(118px, 10.5vw, 168px);
       border-radius: 50%;
-      border: 2px solid rgba(255,255,255,.5);
+      border: 2px solid rgba(170, 255, 170, .9);
       background:
-        radial-gradient(circle at 35% 30%, rgba(255,255,255,.4) 0 16%, rgba(255,84,84,.35) 34%, rgba(128,26,26,.26) 64%, rgba(68,0,0,.2) 100%);
-      box-shadow: 0 0 0 5px rgba(255,80,80,.13), 0 0 24px rgba(255,72,72,.45);
+        radial-gradient(circle at 35% 30%, rgba(255,255,255,.52) 0 16%, rgba(76, 255, 120, .62) 34%, rgba(24, 130, 54, .46) 64%, rgba(6, 60, 18, .34) 100%);
+      box-shadow: 0 0 0 6px rgba(76,255,120,.24), 0 0 28px rgba(76,255,120,.58);
       z-index: 6;
       opacity: 0;
       pointer-events: none;
@@ -363,7 +363,7 @@
       top: 50%;
       width: 0;
       height: 0;
-      background: rgba(255,40,40,.33);
+      background: rgba(70,255,120,.45);
       transform: translate(-50%, -50%);
       transition: width .95s linear, height .95s linear;
     }
@@ -392,6 +392,27 @@
 
     .page.game-page { background: #000; padding: 0; align-items: stretch; justify-content: stretch; }
     .game-frame { width: 100%; height: 100%; display: block; background: #000; position: relative; overflow: hidden; }
+    .conclusion-page {
+      background: #000;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      position: relative;
+    }
+    .conclusion-title {
+      color: #f5f8fa;
+      font-family: Georgia, serif;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      font-size: clamp(2rem, 5vw, 4.4rem);
+      text-align: center;
+      opacity: .95;
+      text-shadow: 0 8px 26px rgba(0,0,0,.8);
+    }
+    .conclusion-target {
+      left: 88% !important;
+      top: 84% !important;
+    }
 
     .samurai-challenge {
       position: absolute;
@@ -563,6 +584,11 @@
       <div class="game-frame" data-game-host></div>
       <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
     </section>
+
+    <section class="page conclusion-page" data-type="conclusion">
+      <h2 class="conclusion-title">Thanks for playing</h2>
+      <button class="gaze-target conclusion-target" data-conclusion-target aria-label="Advance" type="button"></button>
+    </section>
   </div>
 
   <div id="chiCursor" aria-hidden="true"></div>
@@ -592,6 +618,7 @@
       const templateCache = {};
       const storyTimers = new WeakMap();
       const gameSessions = new Map();
+      let conclusionCleanup = null;
 
       const dwellMs = 1000;
       const colorFadeWaitMs = 3300;
@@ -921,9 +948,8 @@
         image.src = `${imageBasePath}${imageName}`;
         image.alt = page.dataset.alt || '';
 
-        const [xRaw, yRaw] = (page.dataset.target || '82,72').split(',');
-        gazeTarget.style.left = `${Math.min(94, Math.max(6, Number.parseFloat(xRaw) || 82))}%`;
-        gazeTarget.style.top = `${Math.min(92, Math.max(8, Number.parseFloat(yRaw) || 72))}%`;
+        gazeTarget.style.left = '88%';
+        gazeTarget.style.top = '84%';
 
         const hasVideo = page.dataset.novideo !== 'true';
         if (hasVideo) {
@@ -1193,6 +1219,18 @@
         nextButton.hidden = true;
       };
 
+      const setupConclusionPage = (page) => {
+        if (!page) return;
+        const target = page.querySelector('[data-conclusion-target]');
+        if (!target) return;
+        target.classList.add('visible');
+        if (conclusionCleanup) conclusionCleanup();
+        conclusionCleanup = createDwellGate(target, () => {
+          target.classList.remove('visible', 'dwell');
+          nextPage();
+        }, currentMode === 'story' ? 30000 : 0);
+      };
+
       const showPage = (index) => {
         if (index < 0 || index >= pages.length) return;
         const prev = pages[currentIndex];
@@ -1201,6 +1239,10 @@
           clearStoryTimers(prev);
           if (prev.dataset.type === 'story') resetStoryMedia(prev);
           if (prev.dataset.type === 'game') stopGame(prev);
+          if (prev.dataset.type === 'conclusion' && conclusionCleanup) {
+            conclusionCleanup();
+            conclusionCleanup = null;
+          }
         }
 
         currentIndex = index;
@@ -1212,6 +1254,7 @@
 
         if (page.dataset.type === 'story') setupStoryPage(page);
         if (page.dataset.type === 'game') loadGame(page.dataset.game, page);
+        if (page.dataset.type === 'conclusion') setupConclusionPage(page);
       };
 
       const nextPage = (withTransition = true) => {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -345,10 +345,9 @@
       width: clamp(118px, 10.5vw, 168px);
       height: clamp(118px, 10.5vw, 168px);
       border-radius: 50%;
-      border: 2px solid rgba(170, 255, 170, .9);
-      background:
-        radial-gradient(circle at 35% 30%, rgba(255,255,255,.52) 0 16%, rgba(76, 255, 120, .62) 34%, rgba(24, 130, 54, .46) 64%, rgba(6, 60, 18, .34) 100%);
-      box-shadow: 0 0 0 6px rgba(76,255,120,.24), 0 0 28px rgba(76,255,120,.58);
+      border: 2px solid rgba(72, 220, 102, .95);
+      background: rgba(54, 185, 84, .7);
+      box-shadow: 0 0 0 6px rgba(76,255,120,.22), 0 0 18px rgba(76,255,120,.35);
       z-index: 6;
       opacity: 0;
       pointer-events: none;
@@ -368,9 +367,17 @@
       transition: width .95s linear, height .95s linear;
     }
 
-    .gaze-target.visible { opacity: 1; pointer-events: auto; }
+    .gaze-target.visible {
+      opacity: 1;
+      pointer-events: auto;
+      animation: gazePulse 1.8s ease-in-out infinite;
+    }
     .gaze-target.dwell { transform: scale(1.06); }
     .gaze-target.dwell::after { width: 100%; height: 100%; }
+    @keyframes gazePulse {
+      0%, 100% { transform: scale(1); box-shadow: 0 0 0 5px rgba(76,255,120,.18), 0 0 14px rgba(76,255,120,.28); }
+      50% { transform: scale(1.08); box-shadow: 0 0 0 11px rgba(76,255,120,.08), 0 0 28px rgba(76,255,120,.44); }
+    }
 
     .fullscreen-button {
       position: fixed;
@@ -411,7 +418,7 @@
     }
     .conclusion-target {
       left: 88% !important;
-      top: 84% !important;
+      top: 78% !important;
     }
 
     .samurai-challenge {
@@ -949,7 +956,7 @@
         image.alt = page.dataset.alt || '';
 
         gazeTarget.style.left = '88%';
-        gazeTarget.style.top = '84%';
+        gazeTarget.style.top = '78%';
 
         const hasVideo = page.dataset.novideo !== 'true';
         if (hasVideo) {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -10,6 +10,7 @@
       font-family: "Segoe UI", system-ui, sans-serif;
       --gold: #f2cf86;
       --scene-transition-total: 4900ms;
+      --dwell-fill-ms: 1000ms;
     }
 
     * { box-sizing: border-box; }
@@ -219,6 +220,15 @@
     }
     .dwell-control label { display: block; margin-bottom: 8px; }
     .dwell-control input[type="range"] { width: 100%; accent-color: #6de67f; }
+    .dwell-toggle {
+      margin-top: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      font-size: .86rem;
+    }
+    .dwell-toggle input[type="checkbox"] { accent-color: #6de67f; }
 
     .start-button {
       border-radius: 999px;
@@ -349,7 +359,7 @@
       height: 0;
       background: rgba(255,40,40,.33);
       transform: translate(-50%, -50%);
-      transition: width .95s linear, height .95s linear;
+      transition: width var(--dwell-fill-ms) linear, height var(--dwell-fill-ms) linear;
       pointer-events: none;
     }
     .story-caption.advanceable.dwell::after { width: 100%; height: 100%; }
@@ -369,6 +379,10 @@
       transition: opacity .2s ease, transform .2s ease;
       cursor: none;
     }
+    .gaze-target.large {
+      width: clamp(150px, 13.2vw, 220px);
+      height: clamp(150px, 13.2vw, 220px);
+    }
 
     .gaze-target::after {
       content: "";
@@ -380,7 +394,7 @@
       background: rgba(255,40,40,.45);
       transform: translate(-50%, -50%);
       border-radius: 50%;
-      transition: width .95s linear, height .95s linear;
+      transition: width var(--dwell-fill-ms) linear, height var(--dwell-fill-ms) linear;
     }
 
     .gaze-target.visible {
@@ -447,10 +461,7 @@
       opacity: .95;
       text-shadow: 0 8px 26px rgba(0,0,0,.8);
     }
-    .conclusion-target {
-      left: 86% !important;
-      top: 78% !important;
-    }
+    .conclusion-target {}
 
     .samurai-challenge {
       position: absolute;
@@ -516,6 +527,10 @@
           <div class="dwell-control">
             <label id="dwellLabel" for="dwellSlider">Dwell time: <span id="dwellValue">1.0s</span></label>
             <input id="dwellSlider" type="range" min="500" max="2000" step="100" value="1000" />
+            <label class="dwell-toggle" for="largeCircleToggle">
+              <input id="largeCircleToggle" type="checkbox" />
+              <span id="largeCircleLabel">Bigger green circle</span>
+            </label>
           </div>
           <div class="menu-footer">
             <button id="startJourneyButton" class="start-button" type="button" disabled>Loading…</button>
@@ -650,6 +665,8 @@
       const dwellSlider = document.getElementById('dwellSlider');
       const dwellValue = document.getElementById('dwellValue');
       const dwellLabel = document.getElementById('dwellLabel');
+      const largeCircleToggle = document.getElementById('largeCircleToggle');
+      const largeCircleLabel = document.getElementById('largeCircleLabel');
       const languageToggleButton = document.getElementById('language-toggle');
       const menuTitleLocalized = document.getElementById('menuTitleLocalized');
       const menuBlossoms = document.getElementById('menuBlossoms');
@@ -666,6 +683,7 @@
       let conclusionCleanup = null;
 
       let dwellMs = 1000;
+      let isLargeGazeTarget = false;
       const colorFadeWaitMs = 4950;
       const samuraiTimeoutMs = 25000;
       const storyGameDurationMs = 120000;
@@ -721,6 +739,7 @@
             samurai: 'The strict path: you manually progress and must succeed in mini-game challenges to continue.'
           },
           dwellLabel: 'Dwell time',
+          largeCircleLabel: 'Bigger green circle',
           scenes: {
             scene1: 'Scene 1 placeholder: the samurai story begins.',
             scene2: 'Scene 2 placeholder: transition to the next lesson.',
@@ -744,6 +763,7 @@
             samurai: 'La voie stricte : progression manuelle et réussite des mini-jeux obligatoire pour continuer.'
           },
           dwellLabel: 'Temps de maintien',
+          largeCircleLabel: 'Cercle vert plus grand',
           scenes: {
             scene1: 'Scène 1 (texte temporaire) : le récit du samouraï commence.',
             scene2: 'Scène 2 (texte temporaire) : transition vers la prochaine leçon.',
@@ -767,6 +787,7 @@
             samurai: '厳しい道：手動で進行し、ミニゲームを成功しないと先に進めません。'
           },
           dwellLabel: '滞留時間',
+          largeCircleLabel: '緑の円を大きくする',
           scenes: {
             scene1: 'シーン1（仮テキスト）：侍の物語が始まる。',
             scene2: 'シーン2（仮テキスト）：次の修行への移行。',
@@ -827,6 +848,20 @@
         const seconds = (dwellMs / 1000).toFixed(1);
         if (dwellValue) dwellValue.textContent = `${seconds}s`;
         if (dwellLabel) dwellLabel.childNodes[0].textContent = `${i18n[getUiLang()].dwellLabel}: `;
+        if (largeCircleLabel) largeCircleLabel.textContent = i18n[getUiLang()].largeCircleLabel;
+        document.documentElement.style.setProperty('--dwell-fill-ms', `${dwellMs}ms`);
+      };
+
+      const getTargetPosition = () => isLargeGazeTarget
+        ? { left: '84%', top: '74%' }
+        : { left: '86%', top: '78%' };
+
+      const applyTargetSettings = (target) => {
+        if (!target) return;
+        const pos = getTargetPosition();
+        target.style.left = pos.left;
+        target.style.top = pos.top;
+        target.classList.toggle('large', isLargeGazeTarget);
       };
 
       const renderMenuBlossoms = () => {
@@ -1003,8 +1038,7 @@
         image.src = `${imageBasePath}${imageName}`;
         image.alt = page.dataset.alt || '';
 
-        gazeTarget.style.left = '86%';
-        gazeTarget.style.top = '78%';
+        applyTargetSettings(gazeTarget);
 
         const hasVideo = page.dataset.novideo !== 'true';
         if (hasVideo) {
@@ -1293,6 +1327,7 @@
         if (!page) return;
         const target = page.querySelector('[data-conclusion-target]');
         if (!target) return;
+        applyTargetSettings(target);
         target.classList.add('visible', 'active');
         target.classList.remove('inactive');
         if (conclusionCleanup) conclusionCleanup();
@@ -1475,6 +1510,19 @@
         const clamped = Math.max(500, Math.min(2000, Number.isFinite(raw) ? raw : 1000));
         dwellMs = clamped;
         updateDwellUI();
+      });
+
+      largeCircleToggle?.addEventListener('change', () => {
+        isLargeGazeTarget = !!largeCircleToggle.checked;
+        const page = pages[currentIndex];
+        if (page?.dataset?.type === 'story') {
+          const target = page.querySelector('[data-gaze-target]');
+          applyTargetSettings(target);
+        }
+        if (page?.dataset?.type === 'conclusion') {
+          const target = page.querySelector('[data-conclusion-target]');
+          applyTargetSettings(target);
+        }
       });
 
       if (nextButton) nextButton.addEventListener('click', nextPage);

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -9,6 +9,7 @@
       color-scheme: dark;
       font-family: "Segoe UI", system-ui, sans-serif;
       --gold: #f2cf86;
+      --scene-transition-total: 4900ms;
     }
 
     * { box-sizing: border-box; }
@@ -422,8 +423,13 @@
       pointer-events: none;
       z-index: 30;
     }
-    .transition-overlay.active { animation: sceneFade 900ms ease-in-out forwards; }
-    @keyframes sceneFade { 0% { opacity: 0; } 40% { opacity: .85; } 100% { opacity: 0; } }
+    .transition-overlay.active { animation: sceneFade var(--scene-transition-total) linear forwards; }
+    @keyframes sceneFade {
+      0% { opacity: 0; }
+      45% { opacity: 1; }
+      55% { opacity: 1; }
+      100% { opacity: 0; }
+    }
 
     @media (max-width: 980px) {
       .menu-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
@@ -590,9 +596,14 @@
       const dwellMs = 1000;
       const colorFadeWaitMs = 3300;
       const samuraiTimeoutMs = 25000;
+      const transitionFadeOutMs = 2200;
+      const transitionBlackMs = 500;
+      const transitionFadeInMs = 2200;
+      const transitionSwitchDelayMs = transitionFadeOutMs + transitionBlackMs;
       let currentMode = 'story';
       let currentIndex = 0;
       let isJourneyStarted = false;
+      let isTransitioning = false;
       const storyMusic = new Audio();
       storyMusic.loop = true;
       storyMusic.preload = 'auto';
@@ -695,6 +706,9 @@
       };
 
       const triggerTransition = () => {
+        if (transitionOverlay) {
+          transitionOverlay.style.setProperty('--scene-transition-total', `${transitionFadeOutMs + transitionBlackMs + transitionFadeInMs}ms`);
+        }
         transitionOverlay.classList.remove('active');
         void transitionOverlay.offsetHeight;
         transitionOverlay.classList.add('active');
@@ -824,8 +838,7 @@
 
       const playVideoThenAdvance = (page, video, media) => {
         if (!video || !media || !video.src) {
-          triggerTransition();
-          setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 260);
+          if (pages[currentIndex] === page) nextPage();
           return;
         }
         media.classList.add('video-playing');
@@ -834,8 +847,7 @@
         if (p && typeof p.catch === 'function') p.catch(() => {});
         video.onended = () => {
           if (pages[currentIndex] !== page) return;
-          triggerTransition();
-          setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 300);
+          nextPage();
         };
       };
 
@@ -1116,8 +1128,7 @@
             clearInterval(activeSamuraiChallenge.intervalId);
             activeSamuraiChallenge = null;
           }
-          triggerTransition();
-          setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 300);
+          if (pages[currentIndex] === page) nextPage();
         };
 
         const intervalId = setInterval(() => {
@@ -1171,8 +1182,7 @@
           if (!modeConfig[currentMode].enforceGameWin && modeConfig[currentMode].autoGameAdvance) {
             setTimeout(() => {
               if (pages[currentIndex] !== page) return;
-              triggerTransition();
-              setTimeout(() => { if (pages[currentIndex] === page) nextPage(); }, 260);
+              nextPage();
             }, 5200);
           }
         })();
@@ -1204,10 +1214,21 @@
         if (page.dataset.type === 'game') loadGame(page.dataset.game, page);
       };
 
-      const nextPage = () => {
+      const nextPage = (withTransition = true) => {
         if (!isJourneyStarted) return;
+        if (withTransition && isTransitioning) return;
         const n = (currentIndex + 1) % pages.length;
-        showPage(n === 0 ? 1 : n);
+        const target = n === 0 ? 1 : n;
+        if (!withTransition) {
+          showPage(target);
+          return;
+        }
+        isTransitioning = true;
+        triggerTransition();
+        setTimeout(() => {
+          if (isJourneyStarted) showPage(target);
+          isTransitioning = false;
+        }, transitionSwitchDelayMs);
       };
 
       const requestFullscreen = async () => {
@@ -1316,8 +1337,12 @@
         document.body.classList.add('playing');
         pauseMenuMusic();
         await requestFullscreen();
+        isTransitioning = true;
         triggerTransition();
-        showPage(1);
+        setTimeout(() => {
+          showPage(1);
+          isTransitioning = false;
+        }, transitionSwitchDelayMs);
       });
 
       languageToggleButton?.addEventListener('click', () => {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -270,7 +270,7 @@
       height: 100%;
       object-fit: cover;
       filter: grayscale(100%) contrast(1.2) brightness(.95);
-      transition: filter 6s ease, opacity .6s ease;
+      transition: filter 9s ease, opacity .6s ease;
       opacity: 1;
     }
 
@@ -644,7 +644,7 @@
       let conclusionCleanup = null;
 
       const dwellMs = 1000;
-      const colorFadeWaitMs = 3300;
+      const colorFadeWaitMs = 4950;
       const samuraiTimeoutMs = 25000;
       const storyGameDurationMs = 120000;
       const transitionFadeOutMs = 2200;

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -698,10 +698,12 @@
       const storyMusic = new Audio();
       storyMusic.loop = true;
       storyMusic.preload = 'auto';
+      storyMusic.volume = 0.8;
       let storyMusicSrc = '';
       const menuMusic = new Audio();
       menuMusic.loop = true;
       menuMusic.preload = 'auto';
+      menuMusic.volume = 0.8;
       menuMusic.src = MENU_LOOP_SRC;
       let activeSamuraiChallenge = null;
       const samuraiTargets = { cherry: 15, meditation: 10, lamp: 10 };

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -67,24 +67,24 @@
       position: absolute;
       top: clamp(12px, 1.4vw, 22px);
       right: clamp(12px, 1.4vw, 22px);
-      display: flex;
-      gap: 8px;
       z-index: 5;
     }
-    .lang-btn {
+    .lang-toggle {
       border: 1px solid rgba(252, 216, 147, .42);
       background: rgba(12, 16, 26, .72);
       color: #f8edd8;
       border-radius: 999px;
-      padding: 7px 12px;
+      padding: 8px 14px;
       font-size: .82rem;
       letter-spacing: .04em;
       text-transform: uppercase;
       cursor: pointer;
     }
-    .lang-btn.active {
+    .lang-toggle:hover,
+    .lang-toggle:focus-visible {
       background: rgba(148, 83, 38, .72);
       border-color: rgba(252, 216, 147, .82);
+      outline: none;
     }
 
     .menu-blossoms {
@@ -415,10 +415,8 @@
     <section id="landingPage" class="page landing-page active" data-type="landing">
       <div class="menu-shell">
         <div class="menu-controls">
-          <div id="languageSwitcher" class="language-switcher" role="group" aria-label="Language switcher">
-            <button class="lang-btn" data-lang="en" type="button">EN</button>
-            <button class="lang-btn" data-lang="fr" type="button">FR</button>
-            <button class="lang-btn" data-lang="ja" type="button">日本語</button>
+          <div id="languageSwitcher" class="language-switcher">
+            <button id="language-toggle" class="lang-toggle" type="button" title="Changer de langue / Change language / 言語を変更">FR</button>
           </div>
           <div id="menuBlossoms" class="menu-blossoms" aria-hidden="true"></div>
           <h2 id="menuTitleLocalized" class="menu-title-localized" data-fr="La puissance de l'esprit" data-en="The Power of the Mind">La puissance de l'esprit</h2>
@@ -553,7 +551,7 @@
       const menuPreviewImage = document.getElementById('menuPreviewImage');
       const menuPreviewTitle = document.getElementById('menuPreviewTitle');
       const modeDescription = document.getElementById('modeDescription');
-      const languageButtons = Array.from(document.querySelectorAll('.lang-btn'));
+      const languageToggleButton = document.getElementById('language-toggle');
       const menuTitleLocalized = document.getElementById('menuTitleLocalized');
       const menuBlossoms = document.getElementById('menuBlossoms');
       const chiCursor = document.getElementById('chiCursor');
@@ -685,6 +683,15 @@
         if (stored.startsWith('fr')) return 'fr';
         if (stored.startsWith('ja')) return 'ja';
         return 'en';
+      };
+
+      const languageOrder = ['en', 'fr', 'ja'];
+      const languageLabels = { en: 'EN', fr: 'FR', ja: '日本語' };
+
+      const getNextLanguage = (lang) => {
+        const index = languageOrder.indexOf(lang);
+        if (index < 0) return 'en';
+        return languageOrder[(index + 1) % languageOrder.length];
       };
 
       const localizeMenuTitle = () => {
@@ -1230,7 +1237,10 @@
         else startJourneyButton.textContent = text.start;
         localizeMenuTitle();
         localizeModeButtonLabels();
-        languageButtons.forEach((btn) => btn.classList.toggle('active', btn.dataset.lang === lang));
+        if (languageToggleButton) {
+          const nextLang = getNextLanguage(lang);
+          languageToggleButton.textContent = languageLabels[nextLang] || nextLang.toUpperCase();
+        }
       };
 
       modeButtons.forEach((button) => {
@@ -1252,16 +1262,14 @@
         showPage(1);
       });
 
-      languageButtons.forEach((button) => {
-        button.addEventListener('click', () => {
-          const lang = button.dataset.lang;
-          if (!i18n[lang]) return;
-          try { localStorage.setItem('siteLanguage', lang); } catch (_) {}
-          document.documentElement.lang = lang;
-          updateModeUI();
-          const currentPage = pages[currentIndex];
-          if (currentPage?.dataset?.type === 'story') setupStoryPage(currentPage);
-        });
+      languageToggleButton?.addEventListener('click', () => {
+        const lang = getNextLanguage(getUiLang());
+        if (!i18n[lang]) return;
+        try { localStorage.setItem('siteLanguage', lang); } catch (_) {}
+        document.documentElement.lang = lang;
+        updateModeUI();
+        const currentPage = pages[currentIndex];
+        if (currentPage?.dataset?.type === 'story') setupStoryPage(currentPage);
       });
 
       if (nextButton) nextButton.addEventListener('click', nextPage);

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -64,10 +64,10 @@
       text-align: center;
     }
     .language-switcher {
-      position: absolute;
+      position: fixed;
       top: clamp(12px, 1.4vw, 22px);
       right: clamp(12px, 1.4vw, 22px);
-      z-index: 5;
+      z-index: 25;
     }
     .lang-toggle {
       border: 1px solid rgba(252, 216, 147, .42);
@@ -429,6 +429,7 @@
       .menu-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
       .menu-controls { min-height: 300px; }
     }
+    body.playing .language-switcher { display: none; }
   </style>
 </head>
 <body>
@@ -929,6 +930,28 @@
         const timers = { ids: [], cleanup: null };
         const manual = modeConfig[currentMode].manualAdvance;
         const autoActivateMs = currentMode === 'story' ? 30000 : 0;
+        const bindAdvanceTargets = (onDone) => {
+          let finished = false;
+          let cleanA = null;
+          let cleanB = null;
+          const done = () => {
+            if (finished) return;
+            finished = true;
+            if (cleanA) cleanA();
+            if (cleanB) cleanB();
+            cleanA = null;
+            cleanB = null;
+            onDone();
+          };
+          cleanA = createDwellGate(caption, done, autoActivateMs);
+          cleanB = createDwellGate(gazeTarget, done, autoActivateMs);
+          return () => {
+            if (cleanA) cleanA();
+            if (cleanB) cleanB();
+            cleanA = null;
+            cleanB = null;
+          };
+        };
 
         const step5 = () => playVideoThenAdvance(page, video, media);
         const step4 = () => {
@@ -939,12 +962,14 @@
             timers.ids.push(setTimeout(step5, 900));
             return;
           }
+          gazeTarget.classList.add('visible');
           caption.classList.add('advanceable');
           if (timers.cleanup) timers.cleanup();
-          timers.cleanup = createDwellGate(caption, () => {
+          timers.cleanup = bindAdvanceTargets(() => {
             caption.classList.remove('advanceable', 'dwell');
+            gazeTarget.classList.remove('visible', 'dwell');
             step5();
-          }, autoActivateMs);
+          });
         };
         const step3 = () => {
           if (pages[currentIndex] !== page) return;
@@ -967,7 +992,18 @@
           if (pages[currentIndex] !== page) return;
           caption.textContent = textA;
           caption.classList.add('visible');
-          timers.ids.push(setTimeout(step3, 1100));
+          if (!manual) {
+            timers.ids.push(setTimeout(step3, 1100));
+            return;
+          }
+          gazeTarget.classList.add('visible');
+          caption.classList.add('advanceable');
+          if (timers.cleanup) timers.cleanup();
+          timers.cleanup = bindAdvanceTargets(() => {
+            caption.classList.remove('advanceable', 'dwell');
+            gazeTarget.classList.remove('visible', 'dwell');
+            step3();
+          });
         };
         const step1 = () => {
           if (pages[currentIndex] !== page) return;

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -205,6 +205,20 @@
       padding: 4px 0;
       flex-wrap: wrap;
     }
+    .dwell-control {
+      position: relative;
+      z-index: 2;
+      margin: 6px 0 14px;
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid rgba(252,216,147,.24);
+      background: rgba(9, 13, 20, .5);
+      color: #f6e8cd;
+      text-align: center;
+      font-size: .9rem;
+    }
+    .dwell-control label { display: block; margin-bottom: 8px; }
+    .dwell-control input[type="range"] { width: 100%; accent-color: #6de67f; }
 
     .start-button {
       border-radius: 999px;
@@ -365,6 +379,7 @@
       height: 0;
       background: rgba(255,40,40,.45);
       transform: translate(-50%, -50%);
+      border-radius: 50%;
       transition: width .95s linear, height .95s linear;
     }
 
@@ -498,6 +513,10 @@
             <button class="mode-button" data-mode="samurai" type="button"><strong>Samurai</strong></button>
           </div>
           <p id="modeDescription" class="mode-description">A cinematic guided experience where each beat unfolds automatically while you absorb the atmosphere.</p>
+          <div class="dwell-control">
+            <label id="dwellLabel" for="dwellSlider">Dwell time: <span id="dwellValue">1.0s</span></label>
+            <input id="dwellSlider" type="range" min="500" max="2000" step="100" value="1000" />
+          </div>
           <div class="menu-footer">
             <button id="startJourneyButton" class="start-button" type="button" disabled>Loading…</button>
           </div>
@@ -628,6 +647,9 @@
       const menuPreviewImage = document.getElementById('menuPreviewImage');
       const menuPreviewTitle = document.getElementById('menuPreviewTitle');
       const modeDescription = document.getElementById('modeDescription');
+      const dwellSlider = document.getElementById('dwellSlider');
+      const dwellValue = document.getElementById('dwellValue');
+      const dwellLabel = document.getElementById('dwellLabel');
       const languageToggleButton = document.getElementById('language-toggle');
       const menuTitleLocalized = document.getElementById('menuTitleLocalized');
       const menuBlossoms = document.getElementById('menuBlossoms');
@@ -643,7 +665,7 @@
       const gameSessions = new Map();
       let conclusionCleanup = null;
 
-      const dwellMs = 1000;
+      let dwellMs = 1000;
       const colorFadeWaitMs = 4950;
       const samuraiTimeoutMs = 25000;
       const storyGameDurationMs = 120000;
@@ -698,6 +720,7 @@
             autonomous: 'A user-paced journey where you control progression, while mini-games remain open and non-blocking.',
             samurai: 'The strict path: you manually progress and must succeed in mini-game challenges to continue.'
           },
+          dwellLabel: 'Dwell time',
           scenes: {
             scene1: 'Scene 1 placeholder: the samurai story begins.',
             scene2: 'Scene 2 placeholder: transition to the next lesson.',
@@ -720,6 +743,7 @@
             autonomous: 'Une aventure au rythme du joueur où vous contrôlez la progression, avec des mini-jeux non bloquants.',
             samurai: 'La voie stricte : progression manuelle et réussite des mini-jeux obligatoire pour continuer.'
           },
+          dwellLabel: 'Temps de maintien',
           scenes: {
             scene1: 'Scène 1 (texte temporaire) : le récit du samouraï commence.',
             scene2: 'Scène 2 (texte temporaire) : transition vers la prochaine leçon.',
@@ -742,6 +766,7 @@
             autonomous: '自分のペースで進行し、ミニゲームは開放されたままのモードです。',
             samurai: '厳しい道：手動で進行し、ミニゲームを成功しないと先に進めません。'
           },
+          dwellLabel: '滞留時間',
           scenes: {
             scene1: 'シーン1（仮テキスト）：侍の物語が始まる。',
             scene2: 'シーン2（仮テキスト）：次の修行への移行。',
@@ -796,6 +821,12 @@
           const label = labels[button.dataset.mode];
           if (label) strong.textContent = label;
         });
+      };
+
+      const updateDwellUI = () => {
+        const seconds = (dwellMs / 1000).toFixed(1);
+        if (dwellValue) dwellValue.textContent = `${seconds}s`;
+        if (dwellLabel) dwellLabel.childNodes[0].textContent = `${i18n[getUiLang()].dwellLabel}: `;
       };
 
       const renderMenuBlossoms = () => {
@@ -1403,6 +1434,7 @@
           const nextLang = getNextLanguage(lang);
           languageToggleButton.textContent = languageLabels[nextLang] || nextLang.toUpperCase();
         }
+        updateDwellUI();
       };
 
       modeButtons.forEach((button) => {
@@ -1436,6 +1468,13 @@
         updateModeUI();
         const currentPage = pages[currentIndex];
         if (currentPage?.dataset?.type === 'story') setupStoryPage(currentPage);
+      });
+
+      dwellSlider?.addEventListener('input', () => {
+        const raw = Number(dwellSlider.value);
+        const clamped = Math.max(500, Math.min(2000, Number.isFinite(raw) ? raw : 1000));
+        dwellMs = clamped;
+        updateDwellUI();
       });
 
       if (nextButton) nextButton.addEventListener('click', nextPage);

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -322,7 +322,7 @@
     .story-caption.visible { opacity: 1; transform: translate(-50%, 0); }
     .story-caption.advanceable {
       pointer-events: auto;
-      cursor: pointer;
+      cursor: none;
       border-color: rgba(255, 120, 120, .75);
       box-shadow: 0 0 0 3px rgba(255,72,72,.16), 0 10px 26px rgba(0,0,0,.45);
     }
@@ -353,6 +353,7 @@
       pointer-events: none;
       overflow: hidden;
       transition: opacity .2s ease, transform .2s ease;
+      cursor: none;
     }
 
     .gaze-target::after {
@@ -432,7 +433,7 @@
       text-shadow: 0 8px 26px rgba(0,0,0,.8);
     }
     .conclusion-target {
-      left: 88% !important;
+      left: 86% !important;
       top: 78% !important;
     }
 
@@ -970,7 +971,7 @@
         image.src = `${imageBasePath}${imageName}`;
         image.alt = page.dataset.alt || '';
 
-        gazeTarget.style.left = '88%';
+        gazeTarget.style.left = '86%';
         gazeTarget.style.top = '78%';
 
         const hasVideo = page.dataset.novideo !== 'true';
@@ -1206,7 +1207,6 @@
       const loadGame = (key, page) => {
         const host = page.querySelector('[data-game-host]');
         if (!host) return;
-        pauseStoryMusic();
         const templateId = gameTemplates[key];
         if (!templateId) return;
 

--- a/eyegaze/samuraistory/lamp.js
+++ b/eyegaze/samuraistory/lamp.js
@@ -110,6 +110,7 @@
     const CHI_POINTER_MAX = 118;
     const CHI_POINTER_BREATH = 0.05;
     const CHI_POINTER_BREATH_FREQ = 0.8;
+    const GAME_COLOR_REVEAL_MS = 120000;
 
     /* =======================
        SETUP
@@ -898,8 +899,13 @@ function drawRopes(t) {
     let lastT = performance.now();
     let started = false;
     let rafId = 0;
+    let gameStartMs = 0;
 
     function drawBackgroundImage() {
+      const progress = Math.max(0, Math.min(1, (performance.now() - gameStartMs) / GAME_COLOR_REVEAL_MS));
+      const gray = 100 - (progress * 100);
+      ctx.save();
+      ctx.filter = `grayscale(${gray}%)`;
       if (bgImg.complete && bgImg.naturalWidth > 0) {
         const iw = bgImg.width, ih = bgImg.height;
         const scale = Math.max(W / iw, H / ih); // cover
@@ -912,6 +918,7 @@ function drawRopes(t) {
         ctx.fillStyle = "#001028";
         ctx.fillRect(0, 0, W, H);
       }
+      ctx.restore();
     }
 
     function update(dt) {
@@ -1130,6 +1137,7 @@ function drawRopes(t) {
       resetGameState();
       quietAudio();
       started = true;
+      gameStartMs = performance.now();
       if (startOverlay) startOverlay.style.display = 'none';
       canvas.style.cursor = 'none';
 

--- a/eyegaze/samuraistory/lamp.js
+++ b/eyegaze/samuraistory/lamp.js
@@ -2,7 +2,7 @@
     /* =======================
        TUNABLES
     ======================= */
-    const BG_SRC      = "../../images/samurai/lampbg.png";
+    const BG_SRC      = "../../images/samuraikata/texte1.jpg";
 
     // Two lamp variants
     const CLOSED1_SRC = "../../images/samurai/closedlamp1.png";

--- a/eyegaze/samuraistory/meditation.js
+++ b/eyegaze/samuraistory/meditation.js
@@ -27,8 +27,8 @@
     /* =======================
        TUNABLES
     ======================= */
-    const MIN_DIAMETER = 100;
-    const MAX_DIAMETER = 200;
+    const MIN_DIAMETER = 140;
+    const MAX_DIAMETER = 280;
     const DWELL_MS     = 2000;
     const DECAY_PER_SEC= 0.5;
     const ENTRY_GRACE_MS = 200;
@@ -89,7 +89,8 @@
     const AURA_COLOR      = { r:120, g:220, b:255 };
     const RING_COUNT      = 3;
     const RING_ALPHA      = 0.18;
-    const RING_PULSE_HZ   = 1.0;
+    const RING_PULSE_HZ   = 1.8;
+    const GAME_COLOR_REVEAL_MS = 120000;
 
     // Inflow particles: near-rim and outer ring
     const INFLOW_RATE      = 60;
@@ -118,6 +119,7 @@
     const ctx = canvas.getContext('2d');
     let W = canvas.width  = window.innerWidth;
     let H = canvas.height = window.innerHeight;
+    let gameStartMs = 0;
 
     const bgImg = new Image(); bgImg.src = BG_SRC;
 
@@ -420,6 +422,10 @@
        BACKGROUND + FX
     ======================= */
     function drawBackground(){
+      const progress = Math.max(0, Math.min(1, (performance.now() - gameStartMs) / GAME_COLOR_REVEAL_MS));
+      const gray = 100 - (progress * 100);
+      ctx.save();
+      ctx.filter = `grayscale(${gray}%)`;
       if (bgImg.complete && bgImg.naturalWidth>0){
         const iw=bgImg.width, ih=bgImg.height;
         const sc=Math.max(W/iw, H/ih);
@@ -427,6 +433,7 @@
       } else {
         ctx.fillStyle="#041017"; ctx.fillRect(0,0,W,H);
       }
+      ctx.restore();
     }
 
     function drawShards(){
@@ -579,6 +586,12 @@
         ctx.stroke();
       }
       ctx.globalAlpha = 1;
+
+      ctx.strokeStyle = `rgba(0,0,0,${0.75 - charge * 0.2})`;
+      ctx.lineWidth = Math.max(2, r * 0.08);
+      ctx.beginPath();
+      ctx.arc(cx, cy, r * 1.01, 0, Math.PI * 2);
+      ctx.stroke();
 
       ctx.restore();
     }
@@ -862,7 +875,6 @@
 
     function render(){
       drawBackground();
-      drawMoon();
       drawInflow();
       drawOrb();        // draw the ball first
       drawPointer();    // then pointer on top of the ball
@@ -963,6 +975,7 @@
       if (started) return;
       resetMutableState();
       started = true;
+      gameStartMs = performance.now();
       if (startOverlay) startOverlay.style.display = 'none';
       resize();
 

--- a/eyegaze/samuraistory/meditation.js
+++ b/eyegaze/samuraistory/meditation.js
@@ -5,7 +5,7 @@
     const BG_SRC = "../../images/samurai/lampbg.png";
 
     // Pointer image (square, per your update)
-    const POINTER_SRC = "../../images/samurai/chi.png";
+    const POINTER_SRC = "../../images/samurai/transparentchi.png";
 
     // Moonrock shards (random)
     const ROCK_SRCS = [

--- a/eyegaze/samuraistory/meditation.js
+++ b/eyegaze/samuraistory/meditation.js
@@ -2,7 +2,7 @@
     /* =======================
        ASSETS
     ======================= */
-    const BG_SRC = "../../images/samurai/lampbg.png";
+    const BG_SRC = "../../images/samuraikata/luneattaqueboulechi.jpg";
 
     // Pointer image (square, per your update)
     const POINTER_SRC = "../../images/samurai/transparentchi.png";


### PR DESCRIPTION
### Motivation
- Introduce localized UI and allow users to switch languages from the landing menu. 
- Improve the menu experience with background music and clearer scene/media handling for story pages. 
- Replace the meditation pointer asset with a transparent variant and make video loading optional per scene.

### Description
- Adds a language switcher UI and an `i18n` map for `en`, `fr`, and `ja`, persists choice to `localStorage`, and updates menu labels via `updateModeUI` and `localizeMenuTitle`. 
- Adds `menuMusic` (looping) loaded from `MENU_LOOP_SRC`, starts menu music after preload and pauses it when the journey begins. 
- Refactors story pages to use a unified `story-media` block (image, video, caption, gaze target), supports `data-novideo="true"` to skip loading video, and resolves localized scene text via `i18n` keys derived from the image name. 
- Updates asset handling to conditionally preload videos only when `novideo` is not set, adds `MENU_LOOP_SRC` to the preload set, and switches several preview and scene image paths in `modeConfig` and page data attributes. 
- Adds `updateGlobalChiCursor` to control the global chi cursor visibility based on journey state and page type, and moves some UI state logic into `updateModeUI`. 
- Updates `meditation.js` to use a transparent pointer image (`transparentchi.png`) and replaces the pointer constant accordingly.

### Testing
- Executed the project build script (`npm run build`), which completed successfully. 
- Ran the project's automated test command (`npm test`), which reported no tests to run (no failures). 
- Verified asset preloading path changes by running the page preload routine in development (preload completed and `startJourneyButton` enabled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e523db47948325ae1794c48ea3ec91)