### PR TITLE
Add instruction pages, French narration, journey stats, and refine story/game flow and UI

### DIFF
--- a/eyegaze/samuraistory/cherryblossom.js
+++ b/eyegaze/samuraistory/cherryblossom.js
@@ -12,7 +12,7 @@
     const GAME_COLOR_REVEAL_MS = 120000;
 
     // Cursor limits and hotspot (in ORIGINAL image pixels)
-    const CURSOR_MAX_PX = 170;
+    const CURSOR_MAX_PX = 124;
     const HOTSPOT_ORIG = { x: 12, y: 28 };
 
     // Play (normal game) settings

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -53,12 +53,12 @@
 
     .menu-title-localized {
       position: absolute;
-      top: 0;
+      top: 16px;
       left: 0;
       z-index: 3;
       font-family: Georgia, serif;
       color: #0a0a0a;
-      font-size: clamp(.9rem, 1.2vw, 1.35rem);
+      font-size: clamp(2.7rem, 3.6vw, 4.2rem);
       letter-spacing: .04em;
       text-transform: uppercase;
       text-shadow: 0 5px 16px rgba(0,0,0,.5);
@@ -340,7 +340,7 @@
       pointer-events: none;
       overflow: hidden;
       opacity: 0;
-      transition: opacity .35s ease, transform .35s ease;
+      transition: opacity .55s ease, transform .55s ease;
     }
 
     .story-caption.visible { opacity: 1; transform: translate(-50%, 0); }
@@ -1343,8 +1343,16 @@
             caption.classList.remove('advanceable', 'dwell');
             setTargetState(false);
             gazeTarget.classList.remove('dwell');
-            image.classList.add('colored');
-            step4();
+            caption.classList.remove('visible');
+            timers.ids.push(setTimeout(() => {
+              if (pages[currentIndex] !== page) return;
+              caption.textContent = '';
+              image.classList.add('colored');
+              timers.ids.push(setTimeout(() => {
+                if (pages[currentIndex] !== page) return;
+                step4();
+              }, colorFadeWaitMs));
+            }, 420));
           });
         };
         const step2 = () => {
@@ -1363,8 +1371,11 @@
             timers.ids.push(setTimeout(() => {
               if (pages[currentIndex] !== page) return;
               caption.classList.remove('visible', 'advanceable', 'dwell');
-              caption.textContent = '';
-              step3();
+              timers.ids.push(setTimeout(() => {
+                if (pages[currentIndex] !== page) return;
+                caption.textContent = '';
+                step3();
+              }, 420));
             }, 2000));
           };
 

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -1278,8 +1278,8 @@
           const videoName = imageName.replace(/\.(jpg|jpeg|png)$/i, '.mp4');
           const videoPath = `${videoBasePath}${videoName}`;
           video.src = videoPath;
-          video.muted = true;
-          video.volume = 0;
+          video.muted = false;
+          video.volume = 0.3;
           video.preload = 'auto';
           video.load();
         } else {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -1298,14 +1298,12 @@
         const step4 = () => {
           if (pages[currentIndex] !== page) return;
           caption.textContent = textB || `${textA} ${textB}`.trim();
-          caption.classList.add('visible');
+          caption.classList.add('visible', 'advanceable');
           if (timers.cleanup) {
             timers.cleanup();
             timers.cleanup = null;
           }
-          setTargetState(false);
-          caption.classList.remove('advanceable', 'dwell');
-          gazeTarget.classList.remove('dwell');
+          setTargetState(true);
 
           const startVideoSoon = () => {
             timers.ids.push(setTimeout(() => {
@@ -1313,8 +1311,14 @@
               step5();
             }, 2000));
           };
-
-          if (narrationEnabled) {
+          timers.cleanup = bindAdvanceTargets(() => {
+            caption.classList.remove('advanceable', 'dwell');
+            setTargetState(false);
+            gazeTarget.classList.remove('dwell');
+            if (!narrationEnabled) {
+              startVideoSoon();
+              return;
+            }
             const narrationSrc = `${FRENCH_NARRATION_BASE_PATH}scene${sceneNumber}p2fr.mp3`;
             let handled = false;
             const onNarrationEnded = () => {
@@ -1327,10 +1331,7 @@
             timers.ids.push(setTimeout(() => {
               onNarrationEnded();
             }, 20000));
-            return;
-          }
-
-          startVideoSoon();
+          });
         };
         const step3 = () => {
           if (pages[currentIndex] !== page) return;

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -791,7 +791,7 @@
       narrationAudio.preload = 'auto';
       narrationAudio.volume = 1;
       let activeSamuraiChallenge = null;
-      const samuraiTargets = { cherry: 15, meditation: 10, lamp: 10 };
+      const samuraiTargets = { cherry: 20, meditation: 10, lamp: 10 };
 
       const modeConfig = {
         story: {
@@ -1520,10 +1520,7 @@
       const installSamuraiChallenge = (page, gameKey, api) => {
         const target = page.querySelector('[data-samurai-challenge]');
         if (!target) return;
-        target.classList.toggle('visible', modeConfig[currentMode].enforceGameWin);
-        target.textContent = '';
-
-        if (!modeConfig[currentMode].enforceGameWin) return;
+        target.classList.add('visible');
 
         const goal = samuraiTargets[gameKey] || 1;
         const getProgress = () => {
@@ -1542,16 +1539,18 @@
         };
 
         const intervalId = setInterval(() => {
-          if (pages[currentIndex] !== page || currentMode !== 'samurai') return;
+          if (pages[currentIndex] !== page) return;
           const progress = getProgress();
           target.textContent = `${Math.min(progress, goal)} / ${goal}`;
           if (progress >= goal) complete();
         }, 250);
 
-        const timeoutId = setTimeout(() => {
-          if (pages[currentIndex] !== page || currentMode !== 'samurai') return;
-          showPage(currentIndex);
-        }, Math.max(samuraiTimeoutMs, 120000));
+        const timeoutId = modeConfig[currentMode].enforceGameWin
+          ? setTimeout(() => {
+              if (pages[currentIndex] !== page || currentMode !== 'samurai') return;
+              showPage(currentIndex);
+            }, Math.max(samuraiTimeoutMs, 120000))
+          : null;
 
         activeSamuraiChallenge = { page, timeoutId, intervalId };
       };

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -484,6 +484,13 @@
       min-height: 280px;
       border: 4px solid rgba(239, 146, 182, .95);
       box-shadow: 0 0 0 4px rgba(239, 146, 182, .28), 0 16px 34px rgba(0,0,0,.5);
+      background: linear-gradient(155deg, rgba(106, 48, 84, .9), rgba(148, 66, 112, .88));
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      font-size: clamp(1.15rem, 1.9vw, 1.7rem);
     }
     .instruction-page .story-caption.visible {
       transform: translate(-50%, -50%);
@@ -1413,7 +1420,7 @@
           step2();
         };
 
-        timers.ids.push(setTimeout(step1, 150));
+        timers.ids.push(setTimeout(step1, 3000));
         storyTimers.set(page, timers);
       };
 

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -885,16 +885,16 @@
           instructionHover: 'Survolez cette boîte (ou la boule verte) pour continuer.',
           instructions: {
             cherry: {
-              title: 'Défi des fleurs de cerisier',
-              text: 'Guide la lame avec vos yeux pour couper les fleurs de cerisier qui tombent. Restez concentré et coupez-en le plus possible.'
+              title: 'Défi 1 : Cerisier',
+              text: 'Avec tes yeux, coupe les fleurs qui tombent. Essaie d’en couper un maximum.'
             },
             meditation: {
-              title: 'Défi de concentration lunaire',
-              text: 'Utilisez vos yeux pour charger puis envoyer des boules de chi vers les rochers lunaires. Respirez calmement et lancez-en suffisamment.'
+              title: 'Défi 2 : Lune',
+              text: 'Avec tes yeux, charge puis envoie des boules de chi vers les rochers de la lune.'
             },
             lamp: {
-              title: 'Défi du chemin des lanternes',
-              text: 'Suivez la voie du samouraï avec vos yeux : allumez les lanternes avec le chi, puis coupez leurs cordes en mode katana pour les envoyer vers le ciel.'
+              title: 'Défi 3 : Lanternes',
+              text: 'Allume les lanternes avec le chi, puis coupe leurs cordes pour les faire monter dans le ciel.'
             }
           },
           scenes: {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -363,6 +363,11 @@
       pointer-events: none;
     }
     .story-caption.advanceable.dwell::after { width: 100%; height: 100%; }
+    .story-caption.advanceable.dwell-complete::after {
+      width: 100%;
+      height: 100%;
+      transition: none;
+    }
 
     .gaze-target {
       position: absolute;
@@ -414,6 +419,11 @@
     }
     .gaze-target.dwell { transform: scale(1.06); }
     .gaze-target.dwell::after { width: 100%; height: 100%; }
+    .gaze-target.dwell-complete::after {
+      width: 100%;
+      height: 100%;
+      transition: none;
+    }
     @keyframes gazePulse {
       0%, 100% { transform: scale(1); box-shadow: 0 0 0 5px rgba(76,255,120,.18), 0 0 14px rgba(76,255,120,.28); }
       50% { transform: scale(1.08); box-shadow: 0 0 0 11px rgba(76,255,120,.08), 0 0 28px rgba(76,255,120,.44); }
@@ -1171,17 +1181,22 @@
       };
 
       const createDwellGate = (target, onDone, autoActivateMs = 0, options = {}) => {
-        const { clearOnDone = false } = options;
+        const { holdFilledMs = 2000 } = options;
         let hold = null;
         let autoTimer = null;
+        let clearTimer = null;
         let completed = false;
 
         const finish = () => {
           if (autoTimer) clearTimeout(autoTimer);
           autoTimer = null;
           completed = true;
-          if (clearOnDone) target.classList.remove('dwell');
+          target.classList.add('dwell', 'dwell-complete');
           onDone();
+          clearTimer = setTimeout(() => {
+            target.classList.remove('dwell', 'dwell-complete');
+            clearTimer = null;
+          }, Math.max(0, holdFilledMs));
         };
 
         const start = () => {
@@ -1196,7 +1211,7 @@
           if (completed) return;
           if (hold) clearTimeout(hold);
           hold = null;
-          target.classList.remove('dwell');
+          target.classList.remove('dwell', 'dwell-complete');
         };
         if (autoActivateMs > 0) {
           autoTimer = setTimeout(() => {
@@ -1222,6 +1237,9 @@
           target.removeEventListener('touchend', cancel);
           if (autoTimer) clearTimeout(autoTimer);
           autoTimer = null;
+          if (clearTimer) clearTimeout(clearTimer);
+          clearTimer = null;
+          target.classList.remove('dwell', 'dwell-complete');
         };
       };
 

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -54,16 +54,15 @@
     .menu-title-localized {
       position: absolute;
       top: clamp(16px, 2vw, 26px);
-      left: 0;
-      right: 0;
-      z-index: 2;
+      left: clamp(16px, 2vw, 28px);
+      z-index: 3;
       font-family: Georgia, serif;
-      color: rgba(252, 220, 155, .95);
-      font-size: clamp(1.1rem, 2vw, 2rem);
+      color: #0a0a0a;
+      font-size: clamp(3.6rem, 7vw, 6.3rem);
       letter-spacing: .04em;
       text-transform: uppercase;
       text-shadow: 0 5px 16px rgba(0,0,0,.5);
-      text-align: center;
+      text-align: left;
     }
     .language-switcher {
       position: fixed;
@@ -190,7 +189,7 @@
       color: #0f1115;
       letter-spacing: .06em;
       text-transform: uppercase;
-      font-size: clamp(3.6rem, 7vw, 6.3rem);
+      font-size: clamp(1.1rem, 2vw, 2rem);
       text-shadow: 0 2px 10px rgba(255,255,255,.45);
     }
 
@@ -323,16 +322,16 @@
       position: absolute;
       left: 50%;
       bottom: 2vw;
-      width: min(56vw, 620px);
-      min-height: 150px;
+      width: min(68vw, 880px);
+      min-height: 116px;
       z-index: 4;
       transform: translate(-50%, 12px);
-      padding: 20px 24px;
+      padding: 16px 22px;
       border-radius: 10px;
       border: 1px solid rgba(255,255,255,.22);
       background: rgba(5,10,18,.7);
       font-family: "Palatino Linotype", "Book Antiqua", Palatino, serif;
-      font-size: clamp(1.15rem, 2.1vw, 1.9rem);
+      font-size: clamp(1rem, 1.6vw, 1.45rem);
       font-style: italic;
       line-height: 1.45;
       letter-spacing: .02em;
@@ -461,7 +460,43 @@
       opacity: .95;
       text-shadow: 0 8px 26px rgba(0,0,0,.8);
     }
+    .conclusion-stats {
+      width: min(720px, 92vw);
+      border: 1px solid rgba(252,216,147,.35);
+      border-radius: 16px;
+      padding: clamp(14px, 2vw, 22px);
+      background: rgba(8, 12, 18, .55);
+      box-shadow: 0 10px 24px rgba(0,0,0,.35);
+      font-size: clamp(1rem, 1.5vw, 1.2rem);
+      line-height: 1.55;
+    }
+    .conclusion-stats p { margin: 6px 0; }
+    .conclusion-stats strong { color: #f6dca4; }
     .conclusion-target {}
+
+    .instruction-page { align-items: center; justify-content: center; }
+    .instruction-page .story-caption {
+      top: 50%;
+      bottom: auto;
+      transform: translate(-50%, -42%);
+      width: min(56vw, 620px);
+      min-height: 280px;
+      border: 4px solid rgba(239, 146, 182, .95);
+      box-shadow: 0 0 0 4px rgba(239, 146, 182, .28), 0 16px 34px rgba(0,0,0,.5);
+    }
+    .instruction-page .story-caption.visible {
+      transform: translate(-50%, -50%);
+    }
+    .instruction-caption-title {
+      display: block;
+      margin-bottom: 8px;
+      font-family: Georgia, serif;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      color: #f6dca4;
+      font-style: normal;
+      font-size: 1.1em;
+    }
 
     .samurai-challenge {
       position: absolute;
@@ -517,7 +552,6 @@
             <button id="language-toggle" class="lang-toggle" type="button" title="Changer de langue / Change language / 言語を変更">FR</button>
           </div>
           <div id="menuBlossoms" class="menu-blossoms" aria-hidden="true"></div>
-          <h2 id="menuTitleLocalized" class="menu-title-localized" data-fr="La puissance de l'esprit" data-en="The Power of the Mind">La puissance de l'esprit</h2>
           <div class="menu-row">
             <button class="mode-button active" data-mode="story" type="button"><strong>Story</strong></button>
             <button class="mode-button" data-mode="autonomous" type="button"><strong>Normal</strong></button>
@@ -538,6 +572,7 @@
         </div>
 
         <div class="menu-preview">
+          <h2 id="menuTitleLocalized" class="menu-title-localized" data-fr="La puissance de l'esprit" data-en="The Power of the Mind">La puissance de l'esprit</h2>
           <img id="menuPreviewImage" src="../../images/samuraikata/cerisier.jpg" alt="Mode preview" />
           <div class="menu-overlay">
             <h1 id="menuPreviewTitle">Story</h1>
@@ -573,6 +608,13 @@
       </div>
     </section>
 
+    <section class="page instruction-page" data-type="instruction" data-game="cherry">
+      <div class="story-media" data-instruction-media>
+        <div class="story-caption visible advanceable" data-instruction-caption></div>
+        <button class="gaze-target visible active" data-instruction-target aria-label="Advance to game" type="button"></button>
+      </div>
+    </section>
+
     <section class="page game-page" data-type="game" data-game="cherry">
       <div class="game-frame" data-game-host></div>
       <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
@@ -602,6 +644,13 @@
         <video class="story-video" playsinline></video>
         <div class="story-caption" data-story-caption></div>
         <button class="gaze-target" data-gaze-target aria-label="Advance" type="button"></button>
+      </div>
+    </section>
+
+    <section class="page instruction-page" data-type="instruction" data-game="meditation">
+      <div class="story-media" data-instruction-media>
+        <div class="story-caption visible advanceable" data-instruction-caption></div>
+        <button class="gaze-target visible active" data-instruction-target aria-label="Advance to game" type="button"></button>
       </div>
     </section>
 
@@ -637,6 +686,13 @@
       </div>
     </section>
 
+    <section class="page instruction-page" data-type="instruction" data-game="lamp">
+      <div class="story-media" data-instruction-media>
+        <div class="story-caption visible advanceable" data-instruction-caption></div>
+        <button class="gaze-target visible active" data-instruction-target aria-label="Advance to game" type="button"></button>
+      </div>
+    </section>
+
     <section class="page game-page" data-type="game" data-game="lamp">
       <div class="game-frame" data-game-host></div>
       <button class="samurai-challenge" data-samurai-challenge aria-label="Challenge"></button>
@@ -644,6 +700,12 @@
 
     <section class="page conclusion-page" data-type="conclusion">
       <h2 class="conclusion-title">Thanks for playing</h2>
+      <div class="conclusion-stats" data-conclusion-stats>
+        <p><strong data-stat-flowers-label>Flowers cut</strong>: <span data-stat-flowers>0</span></p>
+        <p><strong data-stat-chi-label>Chi balls sent</strong>: <span data-stat-chi>0</span></p>
+        <p><strong data-stat-lanterns-label>Lanterns lit</strong>: <span data-stat-lanterns>0</span></p>
+        <p><strong data-stat-time-label>Total time</strong>: <span data-stat-time>0:00</span></p>
+      </div>
       <button class="gaze-target conclusion-target" data-conclusion-target aria-label="Advance" type="button"></button>
     </section>
   </div>
@@ -675,12 +737,14 @@
       const videoBasePath = '../../animations/samurai/';
       const STORY_LOOP_SRC = '../../songs/samurai/samuraisong4.mp3';
       const MENU_LOOP_SRC = '../../songs/samurai/samuraisong2.mp3';
+      const FRENCH_NARRATION_BASE_PATH = '../../narration/samurai/';
 
       const gameTemplates = { cherry: 'tpl-cherryblossom', meditation: 'tpl-meditation', lamp: 'tpl-lamp' };
       const templateCache = {};
       const storyTimers = new WeakMap();
       const gameSessions = new Map();
       let conclusionCleanup = null;
+      let instructionCleanup = null;
 
       let dwellMs = 1000;
       let isLargeGazeTarget = false;
@@ -705,6 +769,9 @@
       menuMusic.preload = 'auto';
       menuMusic.volume = 0.8;
       menuMusic.src = MENU_LOOP_SRC;
+      const narrationAudio = new Audio();
+      narrationAudio.preload = 'auto';
+      narrationAudio.volume = 1;
       let activeSamuraiChallenge = null;
       const samuraiTargets = { cherry: 15, meditation: 10, lamp: 10 };
 
@@ -742,6 +809,29 @@
           },
           dwellLabel: 'Dwell time',
           largeCircleLabel: 'Bigger green circle',
+          colorPrompt: 'Color it',
+          thanks: 'Thanks for playing',
+          stats: {
+            flowers: 'Flowers cut',
+            chi: 'Chi balls sent',
+            lanterns: 'Lanterns lit',
+            time: 'Total time'
+          },
+          instructionHover: 'Hover this box (or the green orb) to continue.',
+          instructions: {
+            cherry: {
+              title: 'Cherry Blossom Challenge',
+              text: 'Guide the blade with your eyes to slice falling cherry blossoms. Move with focus and cut as many petals as you can.'
+            },
+            meditation: {
+              title: 'Moon Focus Challenge',
+              text: 'Use your eyes to charge and send chi balls into the moon rocks. Stay calm, centered, and launch enough energy to continue.'
+            },
+            lamp: {
+              title: 'Lantern Path Challenge',
+              text: 'Follow the way of the samurai with your eyes: light each lantern with chi, then sever the ropes in katana mode so they rise to the night sky.'
+            }
+          },
           scenes: {
             scene1: 'Scene 1 placeholder: the samurai story begins.',
             scene2: 'Scene 2 placeholder: transition to the next lesson.',
@@ -766,6 +856,29 @@
           },
           dwellLabel: 'Temps de maintien',
           largeCircleLabel: 'Cercle vert plus grand',
+          colorPrompt: 'Colorie-la',
+          thanks: 'Merci d’avoir joué',
+          stats: {
+            flowers: 'Fleurs coupées',
+            chi: 'Boules de chi envoyées',
+            lanterns: 'Lanternes allumées',
+            time: 'Temps total'
+          },
+          instructionHover: 'Survolez cette boîte (ou la boule verte) pour continuer.',
+          instructions: {
+            cherry: {
+              title: 'Défi des fleurs de cerisier',
+              text: 'Guide la lame avec vos yeux pour couper les fleurs de cerisier qui tombent. Restez concentré et coupez-en le plus possible.'
+            },
+            meditation: {
+              title: 'Défi de concentration lunaire',
+              text: 'Utilisez vos yeux pour charger puis envoyer des boules de chi vers les rochers lunaires. Respirez calmement et lancez-en suffisamment.'
+            },
+            lamp: {
+              title: 'Défi du chemin des lanternes',
+              text: 'Suivez la voie du samouraï avec vos yeux : allumez les lanternes avec le chi, puis coupez leurs cordes en mode katana pour les envoyer vers le ciel.'
+            }
+          },
           scenes: {
             scene1: 'Scène 1 (texte temporaire) : le récit du samouraï commence.',
             scene2: 'Scène 2 (texte temporaire) : transition vers la prochaine leçon.',
@@ -790,6 +903,29 @@
           },
           dwellLabel: '滞留時間',
           largeCircleLabel: '緑の円を大きくする',
+          colorPrompt: '色をつけよう',
+          thanks: 'プレイしてくれてありがとう',
+          stats: {
+            flowers: '切った花',
+            chi: '放った気弾',
+            lanterns: '灯した灯籠',
+            time: '合計時間'
+          },
+          instructionHover: 'このボックス（または緑の球）にホバーして続行。',
+          instructions: {
+            cherry: {
+              title: '桜チャレンジ',
+              text: '刀カーソルで落ちてくる桜を切ってください。動き続けて、できるだけ多く切りましょう。'
+            },
+            meditation: {
+              title: '月の集中チャレンジ',
+              text: '気弾をためて月の岩へ放ちます。十分な回数の発射を目指してください。'
+            },
+            lamp: {
+              title: '灯籠の道チャレンジ',
+              text: '気で灯籠に火を灯し、刀モードで縄を切って空へ放ちましょう。'
+            }
+          },
           scenes: {
             scene1: 'シーン1（仮テキスト）：侍の物語が始まる。',
             scene2: 'シーン2（仮テキスト）：次の修行への移行。',
@@ -801,6 +937,23 @@
             scene10: 'シーン10（仮テキスト）：灯籠の道が始まる。',
             scene11: 'シーン11（仮テキスト）：灯籠の試練への最終準備。'
           }
+        }
+      };
+
+      const storyTextParts = {
+        fr: {
+          scene1: [
+            'La vallée de Kiso est un oasis de couleur et de vie, dans une région éloignée du Japon. Son peuple y est célébré pour ses valeureux samouraï, dont les prouesses sont légendaires.',
+            'Takeshi ouvre les yeux. Son regard perçant donne vie au jardin, comme une brise qui donne vie à l’eau scintillante de l’étang. Il est prisonnier de cette scène de beauté.'
+          ],
+          scene2: [
+            'Ennuyé par le paysage, l’esprit de Takeshi se met à vagabonder. Il imagine qu’il est un glorieux combattant, spécialiste des arts martiaux, maniant son katana à la perfection, comme son père et ses frères.',
+            'Takeshi le savait et il l’avait accepté tout jeune… étant né dans l’incapacité de bouger ses membres, il ne pouvait qu’y rêver.'
+          ],
+          scene3: [
+            'La mère de Takeshi, bienveillante et douce, l’amène dans la maison. Elle lui raconte des histoires de grands maîtres d’arts martiaux, des légendes et des contes. Elle lui répète à chaque jour que même s’il ne peut pas bouger ou parler, elle croit en lui et sera toujours présente à ses côtés.',
+            'Il regarde, en sa compagnie, avec tristesse, son père et ses frères s’entraîner. La mélancolie l’envahit. Après avoir observé ceux-ci, sa mère l’amène dans la forêt de cerisier, l’endroit favori de Takeshi.'
+          ]
         }
       };
 
@@ -916,6 +1069,44 @@
         menuMusic.pause();
       };
 
+      const stopNarration = () => {
+        narrationAudio.pause();
+        narrationAudio.currentTime = 0;
+        narrationAudio.removeAttribute('src');
+      };
+
+      const playNarration = (src) => {
+        if (!src) return;
+        if (narrationAudio.src !== new URL(src, window.location.href).href) {
+          narrationAudio.src = src;
+        }
+        narrationAudio.currentTime = 0;
+        const p = narrationAudio.play();
+        if (p && typeof p.catch === 'function') p.catch(() => {});
+      };
+
+      const journeyStats = {
+        cherry: 0,
+        meditation: 0,
+        lamp: 0,
+        startedAt: 0,
+        endedAt: 0
+      };
+
+      const updateJourneyStat = (key, value) => {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) return;
+        if (!Object.prototype.hasOwnProperty.call(journeyStats, key)) return;
+        journeyStats[key] = Math.max(journeyStats[key], Math.round(numeric));
+      };
+
+      const formatElapsed = (ms) => {
+        const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+        return `${minutes}:${String(seconds).padStart(2, '0')}`;
+      };
+
       const updateGlobalChiCursor = (page = pages[currentIndex]) => {
         if (!chiCursor) return;
         if (!isJourneyStarted) {
@@ -924,7 +1115,8 @@
         }
         const isStoryPage = page?.dataset?.type === 'story';
         const isMeditationGame = page?.dataset?.type === 'game' && page?.dataset?.game === 'meditation';
-        chiCursor.style.opacity = (isStoryPage || isMeditationGame) ? '1' : '0';
+        const isInstructionPage = page?.dataset?.type === 'instruction';
+        chiCursor.style.opacity = (isStoryPage || isMeditationGame || isInstructionPage) ? '1' : '0';
       };
 
       const clearStoryTimers = (page) => {
@@ -970,18 +1162,22 @@
         };
       };
 
-      const createDwellGate = (target, onDone, autoActivateMs = 0) => {
+      const createDwellGate = (target, onDone, autoActivateMs = 0, options = {}) => {
+        const { clearOnDone = false } = options;
         let hold = null;
         let autoTimer = null;
+        let completed = false;
 
         const finish = () => {
           if (autoTimer) clearTimeout(autoTimer);
           autoTimer = null;
-          target.classList.remove('dwell');
+          completed = true;
+          if (clearOnDone) target.classList.remove('dwell');
           onDone();
         };
 
         const start = () => {
+          if (completed) return;
           target.classList.add('dwell');
           hold = setTimeout(() => {
             hold = null;
@@ -989,6 +1185,7 @@
           }, dwellMs);
         };
         const cancel = () => {
+          if (completed) return;
           if (hold) clearTimeout(hold);
           hold = null;
           target.classList.remove('dwell');
@@ -1007,6 +1204,7 @@
         target.addEventListener('touchstart', start, { passive: true });
         target.addEventListener('touchend', cancel);
         return () => {
+          completed = false;
           cancel();
           target.removeEventListener('mouseenter', start);
           target.removeEventListener('mouseleave', cancel);
@@ -1021,6 +1219,7 @@
 
       const setupStoryPage = (page) => {
         clearStoryTimers(page);
+        stopNarration();
 
         const media = page.querySelector('[data-story-media]');
         const image = page.querySelector('.story-image');
@@ -1032,9 +1231,15 @@
         resetStoryMedia(page);
         const imageName = page.dataset.image;
         const sceneKey = (page.dataset.image || '').replace(/\.(jpg|jpeg|png)$/i, '');
-        const sceneText = i18n[getUiLang()]?.scenes?.[sceneKey] || page.dataset.text || '';
+        const uiLang = getUiLang();
+        const sceneText = i18n[uiLang]?.scenes?.[sceneKey] || page.dataset.text || '';
         const fullText = sceneText;
-        const [textA, textB] = splitText(fullText);
+        const explicitParts = storyTextParts[uiLang]?.[sceneKey];
+        const [textA, textB] = Array.isArray(explicitParts) && explicitParts.length === 2
+          ? explicitParts
+          : splitText(fullText);
+        const narrationEnabled = uiLang === 'fr' && ['scene1', 'scene2', 'scene3'].includes(sceneKey);
+        const sceneNumber = sceneKey.replace('scene', '');
         playStoryMusic();
 
         image.src = `${imageBasePath}${imageName}`;
@@ -1078,7 +1283,7 @@
             cleanB = null;
             onDone();
           };
-          cleanA = createDwellGate(caption, done, autoActivateMs);
+          cleanA = createDwellGate(caption, done, autoActivateMs, { clearOnDone: true });
           cleanB = createDwellGate(gazeTarget, done, autoActivateMs);
           return () => {
             if (cleanA) cleanA();
@@ -1091,57 +1296,100 @@
         const step5 = () => playVideoThenAdvance(page, video, media);
         const step4 = () => {
           if (pages[currentIndex] !== page) return;
-          caption.textContent = `${textA} ${textB}`.trim();
+          caption.textContent = textB || `${textA} ${textB}`.trim();
           caption.classList.add('visible');
-          if (!manual) {
-            timers.ids.push(setTimeout(step5, 900));
+          if (timers.cleanup) {
+            timers.cleanup();
+            timers.cleanup = null;
+          }
+          setTargetState(false);
+          caption.classList.remove('advanceable', 'dwell');
+          gazeTarget.classList.remove('dwell');
+
+          const startVideoSoon = () => {
+            timers.ids.push(setTimeout(() => {
+              if (pages[currentIndex] !== page) return;
+              step5();
+            }, 2000));
+          };
+
+          if (narrationEnabled) {
+            const narrationSrc = `${FRENCH_NARRATION_BASE_PATH}scene${sceneNumber}p2fr.mp3`;
+            let handled = false;
+            const onNarrationEnded = () => {
+              if (handled) return;
+              handled = true;
+              startVideoSoon();
+            };
+            narrationAudio.addEventListener('ended', onNarrationEnded, { once: true });
+            playNarration(narrationSrc);
+            timers.ids.push(setTimeout(() => {
+              onNarrationEnded();
+            }, 20000));
             return;
           }
+
+          startVideoSoon();
+        };
+        const step3 = () => {
+          if (pages[currentIndex] !== page) return;
+          caption.textContent = i18n[uiLang]?.colorPrompt || 'Color it';
+          caption.classList.add('visible', 'advanceable');
           setTargetState(true);
-          caption.classList.add('advanceable');
           if (timers.cleanup) timers.cleanup();
           timers.cleanup = bindAdvanceTargets(() => {
             caption.classList.remove('advanceable', 'dwell');
             setTargetState(false);
             gazeTarget.classList.remove('dwell');
-            step5();
+            image.classList.add('colored');
+            step4();
           });
-        };
-        const step3 = () => {
-          if (pages[currentIndex] !== page) return;
-          image.classList.add('colored');
-          setTargetState(false);
-          if (!manual) {
-            timers.ids.push(setTimeout(step4, colorFadeWaitMs));
-            return;
-          }
-          timers.ids.push(setTimeout(() => {
-            if (pages[currentIndex] !== page) return;
-            setTargetState(true);
-            if (timers.cleanup) timers.cleanup();
-            timers.cleanup = createDwellGate(gazeTarget, () => {
-              setTargetState(false);
-              step4();
-            }, autoActivateMs);
-          }, colorFadeWaitMs));
         };
         const step2 = () => {
           if (pages[currentIndex] !== page) return;
           caption.textContent = textA;
-          caption.classList.add('visible');
-          if (!manual) {
-            timers.ids.push(setTimeout(step3, 1100));
-            return;
+          caption.classList.add('visible', 'advanceable');
+          setTargetState(false);
+          if (timers.cleanup) {
+            timers.cleanup();
+            timers.cleanup = null;
+          }
+          let dwellDone = false;
+          let narrationDone = !narrationEnabled;
+          let transitioned = false;
+          const maybeContinue = () => {
+            if (!dwellDone || !narrationDone || transitioned) return;
+            transitioned = true;
+            timers.ids.push(setTimeout(() => {
+              if (pages[currentIndex] !== page) return;
+              caption.classList.remove('visible', 'advanceable', 'dwell');
+              caption.textContent = '';
+              step3();
+            }, 2000));
+          };
+          if (narrationEnabled) {
+            const narrationSrc = `${FRENCH_NARRATION_BASE_PATH}scene${sceneNumber}p1fr.mp3`;
+            let handled = false;
+            const onNarrationEnded = () => {
+              if (handled) return;
+              handled = true;
+              narrationDone = true;
+              maybeContinue();
+            };
+            narrationAudio.addEventListener('ended', onNarrationEnded, { once: true });
+            playNarration(narrationSrc);
+            timers.ids.push(setTimeout(() => {
+              onNarrationEnded();
+            }, 20000));
           }
           setTargetState(true);
-          caption.classList.add('advanceable');
-          if (timers.cleanup) timers.cleanup();
-          timers.cleanup = bindAdvanceTargets(() => {
+          timers.cleanup = createDwellGate(caption, () => {
+            dwellDone = true;
             caption.classList.remove('advanceable', 'dwell');
             setTargetState(false);
             gazeTarget.classList.remove('dwell');
-            step3();
-          });
+            maybeContinue();
+          }, autoActivateMs, { clearOnDone: true });
         };
         const step1 = () => {
           if (pages[currentIndex] !== page) return;
@@ -1149,14 +1397,10 @@
           caption.classList.remove('visible');
           caption.textContent = '';
           if (!manual) {
-            timers.ids.push(setTimeout(step2, 900));
+            timers.ids.push(setTimeout(step2, 600));
             return;
           }
-          setTargetState(true);
-          timers.cleanup = createDwellGate(gazeTarget, () => {
-            setTargetState(false);
-            step2();
-          }, autoActivateMs);
+          step2();
         };
 
         timers.ids.push(setTimeout(step1, 150));
@@ -1185,6 +1429,11 @@
           try {
             const maybe = session.api.stop();
             if (maybe && typeof maybe.then === 'function') maybe.catch(() => {});
+          } catch (_) {}
+        }
+        if (session.api && typeof session.api.getProgress === 'function') {
+          try {
+            updateJourneyStat(key, session.api.getProgress());
           } catch (_) {}
         }
         if (session.host) {
@@ -1325,8 +1574,38 @@
         nextButton.hidden = true;
       };
 
+      const renderConclusionStats = (page) => {
+        if (!page) return;
+        const lang = getUiLang();
+        const text = i18n[lang];
+        const flowersValue = page.querySelector('[data-stat-flowers]');
+        const chiValue = page.querySelector('[data-stat-chi]');
+        const lanternsValue = page.querySelector('[data-stat-lanterns]');
+        const timeValue = page.querySelector('[data-stat-time]');
+        const flowersLabel = page.querySelector('[data-stat-flowers-label]');
+        const chiLabel = page.querySelector('[data-stat-chi-label]');
+        const lanternsLabel = page.querySelector('[data-stat-lanterns-label]');
+        const timeLabel = page.querySelector('[data-stat-time-label]');
+
+        if (flowersValue) flowersValue.textContent = `${journeyStats.cherry}`;
+        if (chiValue) chiValue.textContent = `${journeyStats.meditation}`;
+        if (lanternsValue) lanternsValue.textContent = `${journeyStats.lamp}`;
+        if (flowersLabel) flowersLabel.textContent = text?.stats?.flowers || 'Flowers cut';
+        if (chiLabel) chiLabel.textContent = text?.stats?.chi || 'Chi balls sent';
+        if (lanternsLabel) lanternsLabel.textContent = text?.stats?.lanterns || 'Lanterns lit';
+        if (timeLabel) timeLabel.textContent = text?.stats?.time || 'Total time';
+
+        const endTime = journeyStats.endedAt || Date.now();
+        const elapsedMs = journeyStats.startedAt ? endTime - journeyStats.startedAt : 0;
+        if (timeValue) timeValue.textContent = formatElapsed(elapsedMs);
+      };
+
       const setupConclusionPage = (page) => {
         if (!page) return;
+        const lang = getUiLang();
+        const text = i18n[lang];
+        const title = page.querySelector('.conclusion-title');
+        if (title && text?.thanks) title.textContent = text.thanks;
         const target = page.querySelector('[data-conclusion-target]');
         if (!target) return;
         applyTargetSettings(target);
@@ -1339,6 +1618,49 @@
         }, currentMode === 'story' ? 30000 : 0);
       };
 
+      const setupInstructionPage = (page) => {
+        if (!page) return;
+        const gameKey = page.dataset.game;
+        const lang = getUiLang();
+        const text = i18n[lang];
+        const instruction = text?.instructions?.[gameKey] || i18n.en.instructions[gameKey];
+        const captionEl = page.querySelector('[data-instruction-caption]');
+        const target = page.querySelector('[data-instruction-target]');
+        if (!target || !captionEl) return;
+        applyTargetSettings(target);
+        target.classList.add('visible', 'active');
+        target.classList.remove('inactive');
+        captionEl.classList.add('visible', 'advanceable');
+        captionEl.classList.remove('dwell');
+        captionEl.innerHTML = `<span class="instruction-caption-title">${instruction?.title || 'Instruction'}</span>${instruction?.text || ''}`;
+
+        if (instructionCleanup) instructionCleanup();
+        const autoActivateMs = currentMode === 'story' ? 30000 : 0;
+        let cleanA = null;
+        let cleanB = null;
+        let done = false;
+        const proceed = () => {
+          if (done) return;
+          done = true;
+          if (cleanA) cleanA();
+          if (cleanB) cleanB();
+          cleanA = null;
+          cleanB = null;
+          captionEl.classList.remove('dwell');
+          target.classList.remove('dwell');
+          nextPage();
+        };
+        cleanA = createDwellGate(captionEl, proceed, autoActivateMs);
+        cleanB = createDwellGate(target, proceed, autoActivateMs);
+        instructionCleanup = () => {
+          if (cleanA) cleanA();
+          if (cleanB) cleanB();
+          cleanA = null;
+          cleanB = null;
+          done = true;
+        };
+      };
+
       const showPage = (index) => {
         if (index < 0 || index >= pages.length) return;
         const prev = pages[currentIndex];
@@ -1346,7 +1668,12 @@
           prev.classList.remove('active');
           clearStoryTimers(prev);
           if (prev.dataset.type === 'story') resetStoryMedia(prev);
+          stopNarration();
           if (prev.dataset.type === 'game') stopGame(prev);
+          if (prev.dataset.type === 'instruction' && instructionCleanup) {
+            instructionCleanup();
+            instructionCleanup = null;
+          }
           if (prev.dataset.type === 'conclusion' && conclusionCleanup) {
             conclusionCleanup();
             conclusionCleanup = null;
@@ -1361,8 +1688,13 @@
         updateGlobalChiCursor(page);
 
         if (page.dataset.type === 'story') setupStoryPage(page);
+        if (page.dataset.type === 'instruction') setupInstructionPage(page);
         if (page.dataset.type === 'game') loadGame(page.dataset.game, page);
-        if (page.dataset.type === 'conclusion') setupConclusionPage(page);
+        if (page.dataset.type === 'conclusion') {
+          if (!journeyStats.endedAt) journeyStats.endedAt = Date.now();
+          renderConclusionStats(page);
+          setupConclusionPage(page);
+        }
       };
 
       const nextPage = (withTransition = true) => {
@@ -1486,6 +1818,11 @@
       startJourneyButton.addEventListener('click', async () => {
         if (startJourneyButton.disabled) return;
         isJourneyStarted = true;
+        journeyStats.cherry = 0;
+        journeyStats.meditation = 0;
+        journeyStats.lamp = 0;
+        journeyStats.startedAt = Date.now();
+        journeyStats.endedAt = 0;
         document.body.classList.add('playing');
         pauseMenuMusic();
         await requestFullscreen();
@@ -1505,6 +1842,11 @@
         updateModeUI();
         const currentPage = pages[currentIndex];
         if (currentPage?.dataset?.type === 'story') setupStoryPage(currentPage);
+        if (currentPage?.dataset?.type === 'instruction') setupInstructionPage(currentPage);
+        if (currentPage?.dataset?.type === 'conclusion') {
+          renderConclusionStats(currentPage);
+          setupConclusionPage(currentPage);
+        }
       });
 
       dwellSlider?.addEventListener('input', () => {
@@ -1525,6 +1867,10 @@
           const target = page.querySelector('[data-conclusion-target]');
           applyTargetSettings(target);
         }
+        if (page?.dataset?.type === 'instruction') {
+          const target = page.querySelector('[data-instruction-target]');
+          applyTargetSettings(target);
+        }
       });
 
       if (nextButton) nextButton.addEventListener('click', nextPage);
@@ -1532,11 +1878,8 @@
       document.addEventListener('keydown', (event) => {
         if (!isJourneyStarted) return;
         if (event.key.toLowerCase() === 's') {
-          const page = pages[currentIndex];
-          if (page?.dataset?.type === 'game') {
-            nextPage();
-            return;
-          }
+          nextPage();
+          return;
         }
         if (event.key === 'ArrowRight' || event.key === ' ') nextPage();
       });

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -53,16 +53,17 @@
 
     .menu-title-localized {
       position: absolute;
-      top: clamp(16px, 2vw, 26px);
-      left: clamp(16px, 2vw, 28px);
+      top: 0;
+      left: 0;
       z-index: 3;
       font-family: Georgia, serif;
       color: #0a0a0a;
-      font-size: clamp(3.6rem, 7vw, 6.3rem);
+      font-size: clamp(.9rem, 1.2vw, 1.35rem);
       letter-spacing: .04em;
       text-transform: uppercase;
       text-shadow: 0 5px 16px rgba(0,0,0,.5);
       text-align: left;
+      padding: 6px 10px;
     }
     .language-switcher {
       position: fixed;
@@ -1349,16 +1350,14 @@
           if (pages[currentIndex] !== page) return;
           caption.textContent = textA;
           caption.classList.add('visible', 'advanceable');
-          setTargetState(false);
+          setTargetState(true);
           if (timers.cleanup) {
             timers.cleanup();
             timers.cleanup = null;
           }
-          let dwellDone = false;
-          let narrationDone = !narrationEnabled;
           let transitioned = false;
-          const maybeContinue = () => {
-            if (!dwellDone || !narrationDone || transitioned) return;
+          const continueToColorStage = () => {
+            if (transitioned) return;
             transitioned = true;
             timers.ids.push(setTimeout(() => {
               if (pages[currentIndex] !== page) return;
@@ -1367,29 +1366,28 @@
               step3();
             }, 2000));
           };
-          if (narrationEnabled) {
+
+          timers.cleanup = bindAdvanceTargets(() => {
+            caption.classList.remove('advanceable', 'dwell');
+            setTargetState(false);
+            gazeTarget.classList.remove('dwell');
+            if (!narrationEnabled) {
+              continueToColorStage();
+              return;
+            }
             const narrationSrc = `${FRENCH_NARRATION_BASE_PATH}scene${sceneNumber}p1fr.mp3`;
             let handled = false;
             const onNarrationEnded = () => {
               if (handled) return;
               handled = true;
-              narrationDone = true;
-              maybeContinue();
+              continueToColorStage();
             };
             narrationAudio.addEventListener('ended', onNarrationEnded, { once: true });
             playNarration(narrationSrc);
             timers.ids.push(setTimeout(() => {
               onNarrationEnded();
             }, 20000));
-          }
-          setTargetState(true);
-          timers.cleanup = createDwellGate(caption, () => {
-            dwellDone = true;
-            caption.classList.remove('advanceable', 'dwell');
-            setTargetState(false);
-            gazeTarget.classList.remove('dwell');
-            maybeContinue();
-          }, autoActivateMs, { clearOnDone: true });
+          });
         };
         const step1 = () => {
           if (pages[currentIndex] !== page) return;


### PR DESCRIPTION
### Motivation
- Add explicit instruction screens for each mini-game and provide narrated French story passages to improve pacing and accessibility.
- Track per-game progress and total session stats to present a concluding summary of the player’s run.
- Improve story sequencing and dwell/gaze gating behavior for a more robust flow across story, instruction, game, and conclusion pages.
- Tweak UI layout and styling to improve readability and adjust the katana/cursor sizing for better on-screen alignment.

### Description
- Introduced narration support in the main script (`narrationAudio`, `playNarration`, `stopNarration`, and `FRENCH_NARRATION_BASE_PATH`) and wired French narration playback for parts of scenes 1–3 using new `storyTextParts` for explicit FR text.
- Reworked story sequencing and dwell logic by extending `createDwellGate` with `clearOnDone` and completion tracking, and by splitting story display into multi-step flows that coordinate narration, dwell gates, coloring, and video playback.
- Added instruction pages (`data-type="instruction"`) and `setupInstructionPage` to present per-game instructions with localized text from `i18n`, and integrated these pages into chi cursor visibility and page lifecycle handling.
- Added journey tracking (`journeyStats`, `updateJourneyStat`, `renderConclusionStats`) with conclusion UI (`.conclusion-stats`) and code to collect game progress from game session APIs (calling `getProgress` if available) and display aggregated stats and elapsed time at the conclusion.
- UI/markup and style changes in `index.html`: relocated and restyled the localized menu title, adjusted caption/preview font sizes and colors, added instruction and conclusion markup/templates, and introduced CSS rules for instruction and conclusion panels.
- Minor gameplay and UX tweaks including changing `CURSOR_MAX_PX` from `170` to `124`, timing adjustments to story delays, and various cleanup calls (stop narration on page transitions, clear instruction/conclusion cleanup handlers).

### Testing
- Ran the project linter with `npm run lint` and the build with `npm run build`, and both commands completed successfully.
- Performed automated build-time checks (HTML/JS parsing during the build) which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ca6b653883259103e8e96fc1904d)