### PR TITLE
Add French story text and narration wiring for samurai scenes 5–11

### DIFF
--- a/eyegaze/samuraistory/cherryblossom.js
+++ b/eyegaze/samuraistory/cherryblossom.js
@@ -84,7 +84,7 @@
 
     // Background music
     const bgSong = new Audio(SONG_SRC);
-    bgSong.volume = 0.8;    // 80%
+    bgSong.volume = 0.64;   // 80% of prior volume
     bgSong.loop = true;
 
     // Katana draw SFX (for the moment the sword cursor appears)

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -517,26 +517,10 @@
     }
 
     .samurai-challenge {
-      position: absolute;
-      top: 14px;
-      right: 14px;
-      width: 94px;
-      height: 94px;
-      border-radius: 50%;
-      border: 2px dashed rgba(248,211,132,.95);
-      background: radial-gradient(circle, rgba(248,211,132,.42), rgba(248,211,132,.16));
       display: none;
-      z-index: 8;
-      cursor: pointer;
-      color: #fff;
-      font-weight: 700;
-      font-size: 14px;
-      text-align: center;
-      line-height: 1.2;
-      align-items: center;
-      justify-content: center;
+      pointer-events: none;
     }
-    .samurai-challenge.visible { display: flex; }
+    .samurai-challenge.visible { display: none; }
 
     .transition-overlay {
       position: fixed;
@@ -973,12 +957,12 @@
             'Il regarde, en sa compagnie, avec tristesse, son père et ses frères s’entraîner. La mélancolie l’envahit. Après avoir observé ceux-ci, sa mère l’amène dans la forêt de cerisier, l’endroit favori de Takeshi.'
           ],
           scene5: [
-            'Takeshi regardait les fleurs de cerisier avec intensité. Il s’imaginait que ses yeux étaient un katana qui les coupaient avant qu’elles ne touche le sol.',
-            'Sa mère s’exclama, elle était ébahi. Les fleurs virevoltaient dans le vent, nettement tranchées en deux. Devant cet exploit, elle amena Takeshi voir Masahiro, un grand sage qui maîtrise le pouvoir de l’esprit.'
+            'Takeshi regardait les fleurs de cerisier avec intensité. Il s’imaginait que ses yeux étaient un katana qui les coupaient avant qu’elles ne touchent le sol.',
+            'Sa mère s’exclama, elle était ébahie. Les fleurs virevoltaient dans le vent, nettement tranchées en deux. Devant cet exploit, elle amena Takeshi voir Masahiro, un grand sage qui maîtrise le pouvoir de l’esprit.'
           ],
           scene6: [
             'Masahiro, le vieux maître, apparut et le rassura : « La véritable force ne se mesure pas simplement par la puissance de nos membres. Elle réside dans notre cœur, notre passion, notre esprit ».',
-            'Takeshi, doutait des paroles du sage, mais laissa sa curiosité l’emporter. «Peut-être que j’avais raison de rêver» se dit-il. «Maître Masahiro m’aidera-t-il à faire de mon esprit, une arme redoutable ?»'
+            'Takeshi doutait des paroles du sage, mais laissa sa curiosité l’emporter. «Peut-être que j’avais raison de rêver» se dit-il. «Maître Masahiro m’aidera-t-il à faire de mon esprit, une arme redoutable ?»'
           ],
           scene7: [
             'Fier de la détermination de son apprenti, le vieux maître lui mis une main sur l’épaule : «Ton regard est impeccable. Précis et stable. Tu es prêt pour la prochaine étape ». Ce soir là, la pleine lune, déjà bien haute dans le ciel, serait la cible de l’esprit de Takeshi.',
@@ -989,12 +973,12 @@
             'Il regarda son apprenti avec sagesse  « Le pouvoir seul n’est pas suffisant, tu dois apprendre à le maîtriser, avec équilibre et sérénité. Le chi doit être en harmonie avec ce qui est important pour toi, jeune disciple. »'
           ],
           scene10: [
-            'Suite à cette leçon, Masahiro accompagne Takeshi vers sa maison. Sa mère y est en train de préparer les lanternes pour le festival du printemps. C’est un moment spécial pour Takeshi et celle-ci, qui y passent un long moment dans un silence profond et complice à chaque année. Takeshi la regarde avec émotion, il voudrait tant lui rendre service.',
+            'Suite à cette leçon, Masahiro accompagne Takeshi vers sa maison. Sa mère y est en train de préparer les lanternes pour le festival du printemps. C’est un moment spécial pour Takeshi et celle-ci, qui y passent un moment dans un silence long et complice à chaque année. Takeshi la regarde avec émotion, il voudrait tant lui rendre service.',
             'Voyant la réaction de son apprenti, le vieux maître Masahiro eut une soudaine inspiration. Il se saisit de quelques lanternes et amena Takeshi vers l’étang.'
           ],
           scene11: [
-            '« Voici l’ultime épreuve pour atteindre ta véritable destinée » s’exprima Masahiro d’un ton sérieux. « Concentre toi à maintenir la puissance de ton Chi. Cela te permettra d’allumer les lanternes une à une . Ensuite, tu devras laisser les lanternes s’envoler en les libérant à l’aide de ton katana ».',
-            'Si tu y parviens, tu auras maîtrisé la force de l’esprit dans toute sa puissance. Il s’agit d’un pouvoir sacré, qui saura t’aider à embellir et enrichir les liens avec les personnes qui te sont chères, plus sûrement que si tu étais un simple samouraï.'
+            '« Voici l’ultime épreuve pour atteindre ta véritable destinée » s’exprima Masahiro d’un ton sérieux. « Concentre toi à maintenir la puissance de ton Chi. Cela te permettra d’allumer les lanternes une à une. Ensuite, tu devrais les laisser s’envoler en les libérant à l’aide de ton katana ».',
+            '« Si tu y parviens, tu auras maîtrisé la force de l’esprit dans toute sa puissance. Il s’agit d’un pouvoir sacré, qui saura t’aider à embellir et enrichir les liens avec les personnes qui te sont chères, plus sûrement que si tu étais un simple samouraï. »'
           ]
         }
       };
@@ -1550,8 +1534,7 @@
 
       const installSamuraiChallenge = (page, gameKey, api) => {
         const target = page.querySelector('[data-samurai-challenge]');
-        if (!target) return;
-        target.classList.add('visible');
+        if (target) target.classList.add('visible');
 
         const goal = samuraiTargets[gameKey] || 1;
         const getProgress = () => {
@@ -1572,7 +1555,6 @@
         const intervalId = setInterval(() => {
           if (pages[currentIndex] !== page) return;
           const progress = getProgress();
-          target.textContent = `${Math.min(progress, goal)} / ${goal}`;
           if (progress >= goal) complete();
         }, 250);
 

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -372,12 +372,15 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 12px 18px;
+      width: 30vw;
+      height: 24vw; /* 5:4 ratio */
+      min-height: 0;
+      padding: 10px;
     }
     .story-caption.image-prompt img {
-      width: clamp(70px, 10vw, 120px);
-      height: clamp(70px, 10vw, 120px);
-      object-fit: contain;
+      width: 92%;
+      height: 92%;
+      object-fit: cover;
       filter: drop-shadow(0 5px 16px rgba(0,0,0,.45));
       user-select: none;
       -webkit-user-drag: none;

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -2043,7 +2043,7 @@
       width: 20vw; min-width: 180px; max-width: 320px; background: #050505;
       border-right: 1px solid rgba(255,255,255,0.04); box-shadow: 10px 0 26px rgba(0,0,0,0.55);
       display: flex; align-items: center; justify-content: center;
-      padding: clamp(32px, 5vh, 72px) clamp(16px, 1.8vw, 32px); position: relative; z-index: 12;
+      padding: clamp(32px, 5vh, 72px) clamp(16px, 1.8vw, 32px); position: relative; z-index: 12; cursor: none;
     }
     #modePanel .panel-ornaments { position: absolute; inset: 0; pointer-events: none; }
     #modePanel .panel-ornaments img { position: absolute; width: clamp(110px, 14vw, 160px); opacity: 0.18; filter: blur(0.2px) drop-shadow(0 6px 10px rgba(0,0,0,0.55)); }
@@ -2061,7 +2061,7 @@
     .mode-tile {
       position: relative; width: clamp(120px, 16vw, 220px); aspect-ratio: 1; border-radius: 24px;
       background: rgba(18,18,22,0.92); border: 1px solid rgba(255,255,255,0.08);
-      display: flex; align-items: center; justify-content: center; cursor: pointer; pointer-events: auto;
+      display: flex; align-items: center; justify-content: center; cursor: none; pointer-events: auto;
       transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease; box-shadow: 0 12px 26px rgba(0,0,0,0.5);
     }
     .mode-tile img { width: 68%; height: 68%; object-fit: contain; filter: drop-shadow(0 6px 10px rgba(0,0,0,0.55)); pointer-events: none; user-select: none; }

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -368,6 +368,21 @@
       height: 100%;
       transition: none;
     }
+    .story-caption.image-prompt {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 12px 18px;
+    }
+    .story-caption.image-prompt img {
+      width: clamp(70px, 10vw, 120px);
+      height: clamp(70px, 10vw, 120px);
+      object-fit: contain;
+      filter: drop-shadow(0 5px 16px rgba(0,0,0,.45));
+      user-select: none;
+      -webkit-user-drag: none;
+      pointer-events: none;
+    }
 
     .gaze-target {
       position: absolute;
@@ -1337,6 +1352,7 @@
         const step5 = () => playVideoThenAdvance(page, video, media);
         const step4 = () => {
           if (pages[currentIndex] !== page) return;
+          caption.classList.remove('image-prompt');
           caption.textContent = textB || `${textA} ${textB}`.trim();
           caption.classList.add('visible', 'advanceable');
           if (timers.cleanup) {
@@ -1375,7 +1391,8 @@
         };
         const step3 = () => {
           if (pages[currentIndex] !== page) return;
-          caption.textContent = i18n[uiLang]?.colorPrompt || 'Color it';
+          caption.classList.add('image-prompt');
+          caption.innerHTML = `<img src="../../images/hand.png" alt="${i18n[uiLang]?.colorPrompt || 'Color it'}">`;
           caption.classList.add('visible', 'advanceable');
           setTargetState(true);
           if (timers.cleanup) timers.cleanup();
@@ -1386,6 +1403,7 @@
             caption.classList.remove('visible');
             timers.ids.push(setTimeout(() => {
               if (pages[currentIndex] !== page) return;
+              caption.classList.remove('image-prompt');
               caption.textContent = '';
               image.classList.add('colored');
               timers.ids.push(setTimeout(() => {
@@ -1397,6 +1415,7 @@
         };
         const step2 = () => {
           if (pages[currentIndex] !== page) return;
+          caption.classList.remove('image-prompt');
           caption.textContent = textA;
           caption.classList.add('visible', 'advanceable');
           setTargetState(true);

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -779,12 +779,12 @@
       const storyMusic = new Audio();
       storyMusic.loop = true;
       storyMusic.preload = 'auto';
-      storyMusic.volume = 0.8;
+      storyMusic.volume = 0.64;
       let storyMusicSrc = '';
       const menuMusic = new Audio();
       menuMusic.loop = true;
       menuMusic.preload = 'auto';
-      menuMusic.volume = 0.8;
+      menuMusic.volume = 0.64;
       menuMusic.src = MENU_LOOP_SRC;
       const narrationAudio = new Audio();
       narrationAudio.preload = 'auto';

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -898,15 +898,15 @@
             }
           },
           scenes: {
-            scene1: 'Scène 1 (texte temporaire) : le récit du samouraï commence.',
-            scene2: 'Scène 2 (texte temporaire) : transition vers la prochaine leçon.',
-            scene3: 'Scène 3 (texte temporaire) : préparation au défi des cerisiers.',
-            scene5: 'Scène 5 (texte temporaire) : après les fleurs, le chemin continue.',
-            scene6: 'Scène 6 (texte temporaire) : réflexion avant l’entraînement lunaire.',
-            scene7: 'Scène 7 (texte temporaire) : le défi de la lune approche.',
-            scene9: 'Scène 9 (texte temporaire) : la puissance grandit sous la lune.',
-            scene10: 'Scène 10 (texte temporaire) : le parcours des lanternes commence.',
-            scene11: 'Scène 11 (texte temporaire) : préparation finale pour le défi des lanternes.'
+            scene1: 'La vallée de Kiso est un oasis de couleur et de vie, dans une région éloignée du Japon.',
+            scene2: 'L’esprit de Takeshi vagabonde vers son rêve de devenir un samouraï.',
+            scene3: 'Sa mère, douce et bienveillante, le soutient et l’amène vers la forêt de cerisiers.',
+            scene5: 'Takeshi regarde les fleurs de cerisier avec intensité et découvre la précision de son regard.',
+            scene6: 'Masahiro apparaît et lui enseigne que la vraie force vient du cœur, de la passion et de l’esprit.',
+            scene7: 'Le vieux maître reconnaît sa détermination et le prépare à viser la pleine lune.',
+            scene9: 'Takeshi canalise son énergie, mais apprend que le pouvoir doit rester en équilibre.',
+            scene10: 'Sur le chemin du retour, une idée naît : les lanternes deviendront le prochain entraînement.',
+            scene11: 'Masahiro lui confie l’ultime épreuve : allumer puis libérer les lanternes pour accomplir sa destinée.'
           }
         },
         ja: {
@@ -971,6 +971,30 @@
           scene3: [
             'La mère de Takeshi, bienveillante et douce, l’amène dans la maison. Elle lui raconte des histoires de grands maîtres d’arts martiaux, des légendes et des contes. Elle lui répète à chaque jour que même s’il ne peut pas bouger ou parler, elle croit en lui et sera toujours présente à ses côtés.',
             'Il regarde, en sa compagnie, avec tristesse, son père et ses frères s’entraîner. La mélancolie l’envahit. Après avoir observé ceux-ci, sa mère l’amène dans la forêt de cerisier, l’endroit favori de Takeshi.'
+          ],
+          scene5: [
+            'Takeshi regardait les fleurs de cerisier avec intensité. Il s’imaginait que ses yeux étaient un katana qui les coupaient avant qu’elles ne touche le sol.',
+            'Sa mère s’exclama, elle était ébahi. Les fleurs virevoltaient dans le vent, nettement tranchées en deux. Devant cet exploit, elle amena Takeshi voir Masahiro, un grand sage qui maîtrise le pouvoir de l’esprit.'
+          ],
+          scene6: [
+            'Masahiro, le vieux maître, apparut et le rassura : « La véritable force ne se mesure pas simplement par la puissance de nos membres. Elle réside dans notre cœur, notre passion, notre esprit ».',
+            'Takeshi, doutait des paroles du sage, mais laissa sa curiosité l’emporter. «Peut-être que j’avais raison de rêver» se dit-il. «Maître Masahiro m’aidera-t-il à faire de mon esprit, une arme redoutable ?»'
+          ],
+          scene7: [
+            'Fier de la détermination de son apprenti, le vieux maître lui mis une main sur l’épaule : «Ton regard est impeccable. Précis et stable. Tu es prêt pour la prochaine étape ». Ce soir là, la pleine lune, déjà bien haute dans le ciel, serait la cible de l’esprit de Takeshi.',
+            'Tout bon samouraï se doit de détenir une connexion profonde avec son énergie, une maîtrise de soi irréprochable pour devenir un véritable combattant, Takeshi le savait et devina ce qu’il devait faire avant que son maître ne le dise tout haut. « Exactement, tu devras canaliser ton Chi et le projeter vers les cieux ».'
+          ],
+          scene9: [
+            'Takeshi canalisait son énergie encore et encore. Le pouvoir l’envahissait. Son chi était une source infinie, bouillante, qui s’échappait à toute vitesse. Voyant cela, Masahiro l’arrêta et invoqua sa propre énergie.',
+            'Il regarda son apprenti avec sagesse  « Le pouvoir seul n’est pas suffisant, tu dois apprendre à le maîtriser, avec équilibre et sérénité. Le chi doit être en harmonie avec ce qui est important pour toi, jeune disciple. »'
+          ],
+          scene10: [
+            'Suite à cette leçon, Masahiro accompagne Takeshi vers sa maison. Sa mère y est en train de préparer les lanternes pour le festival du printemps. C’est un moment spécial pour Takeshi et celle-ci, qui y passent un long moment dans un silence profond et complice à chaque année. Takeshi la regarde avec émotion, il voudrait tant lui rendre service.',
+            'Voyant la réaction de son apprenti, le vieux maître Masahiro eut une soudaine inspiration. Il se saisit de quelques lanternes et amena Takeshi vers l’étang.'
+          ],
+          scene11: [
+            '« Voici l’ultime épreuve pour atteindre ta véritable destinée » s’exprima Masahiro d’un ton sérieux. « Concentre toi à maintenir la puissance de ton Chi. Cela te permettra d’allumer les lanternes une à une . Ensuite, tu devras laisser les lanternes s’envoler en les libérant à l’aide de ton katana ».',
+            'Si tu y parviens, tu auras maîtrisé la force de l’esprit dans toute sa puissance. Il s’agit d’un pouvoir sacré, qui saura t’aider à embellir et enrichir les liens avec les personnes qui te sont chères, plus sûrement que si tu étais un simple samouraï.'
           ]
         }
       };
@@ -1264,8 +1288,15 @@
         const [textA, textB] = Array.isArray(explicitParts) && explicitParts.length === 2
           ? explicitParts
           : splitText(fullText);
-        const narrationEnabled = uiLang === 'fr' && ['scene1', 'scene2', 'scene3'].includes(sceneKey);
+        const narrationEnabled = uiLang === 'fr' && ['scene1', 'scene2', 'scene3', 'scene5', 'scene6', 'scene7', 'scene9', 'scene10', 'scene11'].includes(sceneKey);
         const sceneNumber = sceneKey.replace('scene', '');
+        const getNarrationSrc = (part) => {
+          const prefersFrSuffix = ['1', '2', '3', '5'].includes(sceneNumber);
+          const fileName = prefersFrSuffix
+            ? `scene${sceneNumber}p${part}fr.mp3`
+            : `scene${sceneNumber}p${part}.mp3`;
+          return `${FRENCH_NARRATION_BASE_PATH}${fileName}`;
+        };
         playStoryMusic();
 
         image.src = `${imageBasePath}${imageName}`;
@@ -1344,7 +1375,7 @@
               startVideoSoon();
               return;
             }
-            const narrationSrc = `${FRENCH_NARRATION_BASE_PATH}scene${sceneNumber}p2fr.mp3`;
+            const narrationSrc = getNarrationSrc(2);
             let handled = false;
             const onNarrationEnded = () => {
               if (handled) return;
@@ -1412,7 +1443,7 @@
               continueToColorStage();
               return;
             }
-            const narrationSrc = `${FRENCH_NARRATION_BASE_PATH}scene${sceneNumber}p1fr.mp3`;
+            const narrationSrc = getNarrationSrc(1);
             let handled = false;
             const onNarrationEnded = () => {
               if (handled) return;

--- a/eyegaze/samuraistory/lamp.js
+++ b/eyegaze/samuraistory/lamp.js
@@ -392,6 +392,7 @@
     ======================= */
     const lanterns = [];
     let litCount = 0;
+    let releasedCount = 0;
 
     function chooseScatteredX(w) {
       const minX = SIDE_PAD_H + w * 0.5;
@@ -567,10 +568,40 @@
           breakPt,
           frozen   // {p0,p1,p2} frozen at cut time
         };
+        releasedCount++;
 
         // ▼ NEW: play slice SFX right when the rope is cut
         playSfx(sfxKatanaSlice);
       }
+    }
+
+    function drawReleasedHUD() {
+      const pad = Math.max(10, Math.min(22, Math.floor((W + H) * 0.0115)));
+      const iconSize = Math.max(22, Math.min(38, Math.floor((W + H) * 0.018)));
+      const textSize = Math.max(18, Math.min(30, Math.floor((W + H) * 0.017)));
+      const xRight = W - pad;
+      const yTop = pad;
+      const text = `${releasedCount}`;
+
+      ctx.save();
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      ctx.font = `700 ${textSize}px ui-rounded, ui-sans-serif, system-ui, Segoe UI, Roboto, Arial`;
+      ctx.fillStyle = '#ffd98f';
+      ctx.shadowColor = 'rgba(0,0,0,0.38)';
+      ctx.shadowBlur = 8;
+      ctx.shadowOffsetY = 2;
+      ctx.fillText(text, xRight, yTop + iconSize * 0.5);
+
+      const icon = imageHasDimensions(imgLit1) ? imgLit1 : imgClosed1;
+      if (imageHasDimensions(icon)) {
+        const textW = ctx.measureText(text).width;
+        const iconX = xRight - textW - 10 - iconSize;
+        const iconY = yTop;
+        ctx.shadowColor = 'rgba(0,0,0,0.22)';
+        ctx.drawImage(icon, iconX, iconY, iconSize, iconSize);
+      }
+      ctx.restore();
     }
 
     /* =======================
@@ -1043,6 +1074,7 @@ function drawRopes(t) {
       }
       ctx.restore();
 
+      drawReleasedHUD();
       drawChiPointer();
       drawKatanaPointer();
     }
@@ -1112,6 +1144,7 @@ function drawRopes(t) {
       activeShootingStar = null;
       nextStarTime = 0;
       litCount = 0;
+      releasedCount = 0;
     }
 
     function rebuildWorld() {
@@ -1169,7 +1202,7 @@ function drawRopes(t) {
     window.storyGameApi = {
       start: startExperience,
       stop: stopExperience,
-      getProgress: () => litCount
+      getProgress: () => releasedCount
     };
   })();
   

--- a/eyegaze/samuraistory/meditation.js
+++ b/eyegaze/samuraistory/meditation.js
@@ -46,7 +46,9 @@
     const RESPAWN_DELAY_MS = 2500;  // wait before next orb
 
     // For glow stops
-    const BALL_RGB       = "120,220,210";
+    const BALL_RGB       = "90,210,245";
+    const INFLOW_CORE_RGB = "96,232,190";
+    const INFLOW_EDGE_RGB = "74,150,255";
 
     // Local jitter only
     const ORB_SHAKE_MAX  = 8;
@@ -841,8 +843,12 @@
         const a = INFLOW_ALPHA * Math.max(0, Math.min(1, p.life/0.5));
         if (a <= 0.01) continue;
         ctx.globalAlpha = a;
-        ctx.beginPath(); ctx.arc(p.x, p.y, 1.6, 0, Math.PI*2);
-        ctx.fillStyle = 'white'; ctx.fill();
+        const glow = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, 3.4);
+        glow.addColorStop(0, `rgba(${INFLOW_CORE_RGB},${Math.min(0.95, a + 0.2)})`);
+        glow.addColorStop(0.65, `rgba(${INFLOW_EDGE_RGB},${Math.max(0.18, a * 0.7)})`);
+        glow.addColorStop(1, `rgba(${INFLOW_EDGE_RGB},0)`);
+        ctx.beginPath(); ctx.arc(p.x, p.y, 3.4, 0, Math.PI*2);
+        ctx.fillStyle = glow; ctx.fill();
       }
       ctx.globalAlpha = 1;
       ctx.restore();

--- a/eyegaze/samuraistory/meditation.js
+++ b/eyegaze/samuraistory/meditation.js
@@ -603,49 +603,32 @@
     ======================= */
     function drawPointer(){
       if (!pointer.inside) return;
-      const ready = pointerImg && pointerImg.complete && pointerImg.naturalWidth > 0;
-
-      const t = performance.now()/1000;
-      const breathe = 1 + POINTER_BREATH * Math.sin(t*2*Math.PI*0.8);
-      const charge  = (orb && !launching) ? orb.charge : 0;
-      const scale   = breathe * (1 + POINTER_CHARGE_SCALE * charge);
-
-      // final side length, clamped to max
-      const size = Math.min(POINTER_PX_MAX, POINTER_BASE_PX * scale);
-      const w = size, h = size;
-
-      // mild pull toward the orb over expanded hover zone
-      let x = pointer.x, y = pointer.y;
-      if (orb && !launching){
-        const dx = orb.cx - x, dy = orb.cy - y;
-        const d  = Math.hypot(dx,dy) || 1;
-        const r  = radiusFromCharge(orb);
-        const exR = r * HOVER_RADIUS_MULT + HOVER_PAD_PX;
-
-        const near = 1 - Math.min(1, d / exR); // 0..1 inside expanded zone
-        const pull = 6 * (0.35 + 0.65*near) * (charge || 0); // up to ~6px
-        x += (dx/d)*pull; y += (dy/d)*pull;
-      }
-
-      // glow scales with size
-      const glowR = size * 0.8;
+      const charge = (orb && !launching) ? orb.charge : 0;
+      const x = pointer.x;
+      const y = pointer.y;
+      const size = 30;
+      const glowR = 18 + (charge * 6);
 
       ctx.save();
       ctx.globalCompositeOperation = 'lighter';
       const g = ctx.createRadialGradient(x, y, 0, x, y, glowR);
-      g.addColorStop(0, `rgba(255,255,255,${0.22 + 0.28*charge})`);
-      g.addColorStop(1, 'rgba(120,220,255,0)');
+      g.addColorStop(0, `rgba(56,189,248,${0.28 + 0.24*charge})`);
+      g.addColorStop(1, 'rgba(56,189,248,0)');
       ctx.fillStyle = g;
       ctx.beginPath(); ctx.arc(x, y, glowR, 0, Math.PI*2); ctx.fill();
 
       ctx.globalCompositeOperation = 'source-over';
-      if (ready){
-        ctx.imageSmoothingQuality = 'high';
-        ctx.drawImage(pointerImg, x - w/2, y - h/2, w, h);
-      } else {
-        ctx.fillStyle = '#fff';
-        ctx.beginPath(); ctx.arc(x, y, Math.max(2, size*0.08), 0, Math.PI*2); ctx.fill();
-      }
+      const core = ctx.createRadialGradient(x - 4, y - 5, 1, x, y, size * 0.5);
+      core.addColorStop(0, 'rgba(255,255,255,0.7)');
+      core.addColorStop(0.42, 'rgba(72,183,255,0.65)');
+      core.addColorStop(0.68, 'rgba(26,92,245,0.5)');
+      core.addColorStop(1, 'rgba(12,30,120,0.2)');
+      ctx.fillStyle = core;
+      ctx.beginPath(); ctx.arc(x, y, size * 0.5, 0, Math.PI*2); ctx.fill();
+
+      ctx.lineWidth = 4;
+      ctx.strokeStyle = 'rgba(56,189,248,0.2)';
+      ctx.beginPath(); ctx.arc(x, y, size * 0.5 + 2, 0, Math.PI*2); ctx.stroke();
       ctx.restore();
     }
 


### PR DESCRIPTION
### Motivation
- Finalize the French localization by replacing placeholder scene summaries and wiring the new narration audio for the remaining samurai story scenes so the story pages display and play the recorded French narration.
- Support the existing mixed filename conventions in `narration/samurai/` (some files use a `fr` suffix while others do not) so playback falls back to the available file.

### Description
- Replaced temporary French `scenes` entries with real summaries for scenes `scene1`, `scene2`, `scene3`, `scene5`, `scene6`, `scene7`, `scene9`, `scene10`, and `scene11` in `eyegaze/samuraistory/index.html`.
- Added full two-part French `storyTextParts` entries for scenes `scene5`, `scene6`, `scene7`, `scene9`, `scene10`, and `scene11` so captions render the exact narration-aligned script.
- Enabled French narration for the newly completed scenes by expanding the `narrationEnabled` list and switched narration playback to a new `getNarrationSrc` helper so the code selects `sceneNpXfr.mp3` or `sceneNpX.mp3` according to the project’s existing naming.
- Updated the two places that start narration playback to use `getNarrationSrc(part)` so the right MP3 path is used for both part 1 and part 2.

### Testing
- Verified the presence of narration files with `find narration/samurai` and inspected the list of MP3s present in the directory.
- Ran `git diff --check` to ensure no whitespace or conflict-marker issues, which returned clean.
- Committed the change with `git commit` and confirmed the updated file `eyegaze/samuraistory/index.html` was recorded in the branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9237a63f08325823536c6608ffb12)