### PR TITLE
Samurai eyegaze: add multilingual narration playback and About modal

### DIFF
--- a/eyegaze/samuraistory/cherryblossom.js
+++ b/eyegaze/samuraistory/cherryblossom.js
@@ -9,7 +9,7 @@
     const SONG_SRC    = "../../songs/samurai/cherryblossomsong2.mp3"; // bg song
     const ENABLE_BG_SONG = false; // keep shared story music constant during games
     const KATANA_DRAW_SRC = "../../sounds/katana.mp3";               // sword drawing SFX
-    const GAME_COLOR_REVEAL_MS = 120000;
+    const COLOR_REVEAL_TARGET = 5;
 
     // Cursor limits and hotspot (in ORIGINAL image pixels)
     const CURSOR_MAX_PX = 124;
@@ -379,7 +379,7 @@
        BACKGROUND IMAGE (cover)
     ======================= */
     function drawBackgroundImage() {
-      const progress = Math.max(0, Math.min(1, (performance.now() - gameStartMs) / GAME_COLOR_REVEAL_MS));
+      const progress = Math.max(0, Math.min(1, sliceCount / COLOR_REVEAL_TARGET));
       const gray = 100 - (progress * 100);
       ctx.save();
       ctx.filter = `grayscale(${gray}%)`;

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -644,6 +644,11 @@
       z-index: 30;
     }
     .transition-overlay.active { animation: sceneFade var(--scene-transition-total) linear forwards; }
+    body.transitioning .gaze-target {
+      opacity: 0 !important;
+      pointer-events: none !important;
+      animation: none !important;
+    }
     @keyframes sceneFade {
       0% { opacity: 0; }
       45% { opacity: 1; }
@@ -881,7 +886,7 @@
       let dwellMs = 1000;
       let isLargeGazeTarget = false;
       const colorFadeWaitMs = 4950;
-      const samuraiTimeoutMs = 25000;
+      const samuraiTimeoutMs = 120000;
       const storyGameDurationMs = 120000;
       const transitionFadeOutMs = 2200;
       const transitionBlackMs = 500;
@@ -905,7 +910,7 @@
       narrationAudio.preload = 'auto';
       narrationAudio.volume = 1;
       let activeSamuraiChallenge = null;
-      const samuraiTargets = { cherry: 20, meditation: 10, lamp: 10 };
+      const samuraiTargets = { cherry: 5, meditation: 3, lamp: 5 };
 
       const modeConfig = {
         story: {
@@ -954,6 +959,7 @@
             time: 'Total time'
           },
           instructionHover: 'Hover this box (or the green orb) to continue.',
+          limitNote: 'Samurai mode: reach {goal} in under {seconds} seconds to continue.',
           instructions: {
             cherry: {
               title: 'Cherry Blossom Challenge',
@@ -1005,6 +1011,7 @@
             time: 'Temps total'
           },
           instructionHover: 'Survolez cette boîte (ou la boule verte) pour continuer.',
+          limitNote: 'Mode samouraï : atteignez {goal} en moins de {seconds} secondes pour continuer.',
           instructions: {
             cherry: {
               title: 'Défi 1 : Cerisier',
@@ -1056,6 +1063,7 @@
             time: '合計時間'
           },
           instructionHover: 'このボックス（または緑の球）にホバーして続行。',
+          limitNote: 'サムライモード：{seconds}秒以内に{goal}回達成すると続行できます。',
           instructions: {
             cherry: {
               title: '桜チャレンジ',
@@ -1201,9 +1209,17 @@
         }
       };
 
+      let transitionTargetHideTimer = null;
       const triggerTransition = () => {
+        const totalMs = transitionFadeOutMs + transitionBlackMs + transitionFadeInMs;
+        document.body.classList.add('transitioning');
+        if (transitionTargetHideTimer) clearTimeout(transitionTargetHideTimer);
+        transitionTargetHideTimer = setTimeout(() => {
+          document.body.classList.remove('transitioning');
+          transitionTargetHideTimer = null;
+        }, totalMs + 60);
         if (transitionOverlay) {
-          transitionOverlay.style.setProperty('--scene-transition-total', `${transitionFadeOutMs + transitionBlackMs + transitionFadeInMs}ms`);
+          transitionOverlay.style.setProperty('--scene-transition-total', `${totalMs}ms`);
         }
         transitionOverlay.classList.remove('active');
         void transitionOverlay.offsetHeight;
@@ -1824,7 +1840,7 @@
           ? setTimeout(() => {
               if (pages[currentIndex] !== page || currentMode !== 'samurai') return;
               showPage(currentIndex);
-            }, Math.max(samuraiTimeoutMs, 120000))
+            }, samuraiTimeoutMs)
           : null;
 
         activeSamuraiChallenge = { page, timeoutId, intervalId };
@@ -1961,7 +1977,13 @@
         syncBackButtonStateFrom(target);
         captionEl.classList.add('visible', 'advanceable');
         captionEl.classList.remove('dwell');
-        captionEl.innerHTML = `<span class="instruction-caption-title">${instruction?.title || 'Instruction'}</span>${instruction?.text || ''}`;
+        const limitTemplate = text?.limitNote || i18n.en.limitNote || '';
+        const goal = samuraiTargets[gameKey] || 1;
+        const seconds = Math.round(samuraiTimeoutMs / 1000);
+        const modeLimitNote = modeConfig[currentMode].enforceGameWin
+          ? `<br><br><strong>${limitTemplate.replace('{goal}', String(goal)).replace('{seconds}', String(seconds))}</strong>`
+          : '';
+        captionEl.innerHTML = `<span class="instruction-caption-title">${instruction?.title || 'Instruction'}</span>${instruction?.text || ''}${modeLimitNote}`;
 
         if (instructionCleanup) instructionCleanup();
         const autoActivateMs = currentMode === 'story' ? 30000 : 0;

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -90,20 +90,24 @@
     }
 
     .about-button {
-      position: fixed;
-      top: clamp(12px, 1.4vw, 22px);
-      left: 50%;
-      transform: translateX(-50%);
-      z-index: 25;
-      border: 1px solid rgba(252, 216, 147, .42);
-      background: rgba(12, 16, 26, .72);
-      color: #f8edd8;
-      border-radius: 999px;
-      padding: 8px 14px;
-      font-size: .82rem;
-      letter-spacing: .04em;
+      position: relative;
+      z-index: 2;
+      width: 100%;
+      border: 1px solid rgba(248, 213, 150, .18);
+      border-radius: 12px;
+      background: rgba(17, 12, 18, .42);
+      color: #f9efe1;
+      padding: 6px 8px;
+      text-align: center;
+      min-height: 36px;
+      font-family: Georgia, serif;
+      letter-spacing: .05em;
       text-transform: uppercase;
+      font-size: clamp(.65rem, .95vw, .95rem);
       cursor: pointer;
+      transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+      backdrop-filter: blur(2px);
+      margin-bottom: 14px;
     }
     .about-button:hover,
     .about-button:focus-visible {
@@ -651,8 +655,7 @@
       .menu-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
       .menu-controls { min-height: 300px; }
     }
-    body.playing .language-switcher,
-    body.playing .about-button { display: none; }
+    body.playing .language-switcher { display: none; }
   </style>
 </head>
 <body>

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -89,6 +89,74 @@
       outline: none;
     }
 
+    .about-button {
+      position: fixed;
+      top: clamp(12px, 1.4vw, 22px);
+      left: clamp(12px, 1.4vw, 22px);
+      z-index: 25;
+      border: 1px solid rgba(252, 216, 147, .42);
+      background: rgba(12, 16, 26, .72);
+      color: #f8edd8;
+      border-radius: 999px;
+      padding: 8px 14px;
+      font-size: .82rem;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+    .about-button:hover,
+    .about-button:focus-visible {
+      background: rgba(148, 83, 38, .72);
+      border-color: rgba(252, 216, 147, .82);
+      outline: none;
+    }
+
+    .about-modal-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 40;
+      display: grid;
+      place-items: center;
+      background: rgba(2, 2, 7, .72);
+      backdrop-filter: blur(3px);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .2s ease;
+    }
+    .about-modal-backdrop.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+    .about-modal {
+      width: min(92vw, 720px);
+      max-height: min(80vh, 560px);
+      overflow: auto;
+      border: 1px solid rgba(252, 216, 147, .42);
+      border-radius: 20px;
+      background:
+        linear-gradient(160deg, rgba(8, 10, 16, .95), rgba(18, 12, 16, .95)),
+        url('../../images/samurai/cherryblossombg.png') center/cover no-repeat;
+      padding: clamp(16px, 2.4vw, 30px);
+      box-shadow: 0 22px 48px rgba(0, 0, 0, .5);
+    }
+    .about-modal h3 {
+      margin: 0 0 10px;
+      font-family: Georgia, serif;
+      color: var(--gold);
+      text-transform: uppercase;
+      letter-spacing: .05em;
+    }
+    .about-modal p {
+      margin: 0;
+      line-height: 1.5;
+      color: rgba(255, 245, 230, .94);
+    }
+    .about-modal-footer {
+      margin-top: 14px;
+      display: flex;
+      justify-content: flex-end;
+    }
+
     .menu-blossoms {
       position: absolute;
       inset: 0;
@@ -593,6 +661,16 @@
           <div id="languageSwitcher" class="language-switcher">
             <button id="language-toggle" class="lang-toggle" type="button" title="Changer de langue / Change language / 言語を変更">FR</button>
           </div>
+          <button id="aboutButton" class="about-button" type="button">About this game</button>
+          <div id="aboutModalBackdrop" class="about-modal-backdrop" aria-hidden="true">
+            <div class="about-modal" role="dialog" aria-modal="true" aria-labelledby="aboutModalTitle">
+              <h3 id="aboutModalTitle">About this game</h3>
+              <p id="aboutModalText">About text coming soon.</p>
+              <div class="about-modal-footer">
+                <button id="aboutModalClose" class="start-button" type="button">Close</button>
+              </div>
+            </div>
+          </div>
           <div id="menuBlossoms" class="menu-blossoms" aria-hidden="true"></div>
           <div class="menu-row">
             <button class="mode-button active" data-mode="story" type="button"><strong>Story</strong></button>
@@ -776,12 +854,17 @@
       const languageToggleButton = document.getElementById('language-toggle');
       const menuTitleLocalized = document.getElementById('menuTitleLocalized');
       const menuBlossoms = document.getElementById('menuBlossoms');
+      const aboutButton = document.getElementById('aboutButton');
+      const aboutModalBackdrop = document.getElementById('aboutModalBackdrop');
+      const aboutModalClose = document.getElementById('aboutModalClose');
+      const aboutModalTitle = document.getElementById('aboutModalTitle');
+      const aboutModalText = document.getElementById('aboutModalText');
       const chiCursor = document.getElementById('chiCursor');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
       const STORY_LOOP_SRC = '../../songs/samurai/samuraisong4.mp3';
       const MENU_LOOP_SRC = '../../songs/samurai/samuraisong2.mp3';
-      const FRENCH_NARRATION_BASE_PATH = '../../narration/samurai/';
+      const NARRATION_BASE_PATH = '../../narration/samurai/';
 
       const gameTemplates = { cherry: 'tpl-cherryblossom', meditation: 'tpl-meditation', lamp: 'tpl-lamp' };
       const templateCache = {};
@@ -853,6 +936,10 @@
           },
           dwellLabel: 'Dwell time',
           largeCircleLabel: 'Bigger green circle',
+          aboutButton: 'About this game',
+          aboutTitle: 'About this game',
+          aboutBody: 'About text coming soon.',
+          close: 'Close',
           colorPrompt: 'Color it',
           thanks: 'Thanks for playing',
           stats: {
@@ -900,6 +987,10 @@
           },
           dwellLabel: 'Temps de maintien',
           largeCircleLabel: 'Cercle vert plus grand',
+          aboutButton: 'À propos du jeu',
+          aboutTitle: 'À propos du jeu',
+          aboutBody: 'Texte à venir.',
+          close: 'Fermer',
           colorPrompt: 'Colorie-la',
           thanks: 'Merci d’avoir joué',
           stats: {
@@ -947,6 +1038,10 @@
           },
           dwellLabel: '滞留時間',
           largeCircleLabel: '緑の円を大きくする',
+          aboutButton: 'このゲームについて',
+          aboutTitle: 'このゲームについて',
+          aboutBody: 'テキストは後で追加予定です。',
+          close: '閉じる',
           colorPrompt: '色をつけよう',
           thanks: 'プレイしてくれてありがとう',
           stats: {
@@ -1430,11 +1525,13 @@
         const [textA, textB] = Array.isArray(explicitParts) && explicitParts.length === 2
           ? explicitParts
           : splitText(fullText);
-        const narrationEnabled = uiLang === 'fr' && ['scene1', 'scene2', 'scene3', 'scene5', 'scene6', 'scene7', 'scene9', 'scene10', 'scene11'].includes(sceneKey);
+        const narratableScenes = ['scene1', 'scene2', 'scene3', 'scene5', 'scene6', 'scene7', 'scene9', 'scene10', 'scene11'];
+        const narrationLangTag = uiLang === 'ja' ? 'jp' : uiLang;
+        const narrationEnabled = narratableScenes.includes(sceneKey) && ['fr', 'en', 'jp'].includes(narrationLangTag);
         const sceneNumber = sceneKey.replace('scene', '');
         const getNarrationSrc = (part) => {
-          const fileName = `scene${sceneNumber}p${part}fr.mp3`;
-          return `${FRENCH_NARRATION_BASE_PATH}${fileName}`;
+          const fileName = `scene${sceneNumber}p${part}${narrationLangTag}.mp3`;
+          return `${NARRATION_BASE_PATH}${fileName}`;
         };
         playStoryMusic();
 
@@ -2015,6 +2112,12 @@
             if (page.dataset.novideo !== 'true') {
               set.add(`${videoBasePath}${img.replace(/\.(jpg|jpeg|png)$/i, '.mp4')}`);
             }
+            const sceneNumber = img.replace(/\.(jpg|jpeg|png)$/i, '').replace('scene', '');
+            ['fr', 'en', 'jp'].forEach((langTag) => {
+              [1, 2].forEach((part) => {
+                set.add(`${NARRATION_BASE_PATH}scene${sceneNumber}p${part}${langTag}.mp3`);
+              });
+            });
           }
           if (page.dataset.audio) set.add(page.dataset.audio);
         });
@@ -2047,6 +2150,10 @@
           const nextLang = getNextLanguage(lang);
           languageToggleButton.textContent = languageLabels[nextLang] || nextLang.toUpperCase();
         }
+        if (aboutButton) aboutButton.textContent = text.aboutButton || 'About this game';
+        if (aboutModalTitle) aboutModalTitle.textContent = text.aboutTitle || 'About this game';
+        if (aboutModalText) aboutModalText.textContent = text.aboutBody || 'About text coming soon.';
+        if (aboutModalClose) aboutModalClose.textContent = text.close || 'Close';
         updateDwellUI();
       };
 
@@ -2091,6 +2198,24 @@
           renderConclusionStats(currentPage);
           setupConclusionPage(currentPage);
         }
+      });
+
+      const closeAboutModal = () => {
+        if (!aboutModalBackdrop) return;
+        aboutModalBackdrop.classList.remove('open');
+        aboutModalBackdrop.setAttribute('aria-hidden', 'true');
+      };
+
+      const openAboutModal = () => {
+        if (!aboutModalBackdrop) return;
+        aboutModalBackdrop.classList.add('open');
+        aboutModalBackdrop.setAttribute('aria-hidden', 'false');
+      };
+
+      aboutButton?.addEventListener('click', openAboutModal);
+      aboutModalClose?.addEventListener('click', closeAboutModal);
+      aboutModalBackdrop?.addEventListener('click', (event) => {
+        if (event.target === aboutModalBackdrop) closeAboutModal();
       });
 
       dwellSlider?.addEventListener('input', () => {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -92,7 +92,8 @@
     .about-button {
       position: fixed;
       top: clamp(12px, 1.4vw, 22px);
-      left: clamp(12px, 1.4vw, 22px);
+      left: 50%;
+      transform: translateX(-50%);
       z-index: 25;
       border: 1px solid rgba(252, 216, 147, .42);
       background: rgba(12, 16, 26, .72);
@@ -650,7 +651,8 @@
       .menu-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
       .menu-controls { min-height: 300px; }
     }
-    body.playing .language-switcher { display: none; }
+    body.playing .language-switcher,
+    body.playing .about-button { display: none; }
   </style>
 </head>
 <body>
@@ -665,7 +667,7 @@
           <div id="aboutModalBackdrop" class="about-modal-backdrop" aria-hidden="true">
             <div class="about-modal" role="dialog" aria-modal="true" aria-labelledby="aboutModalTitle">
               <h3 id="aboutModalTitle">About this game</h3>
-              <p id="aboutModalText">About text coming soon.</p>
+              <p id="aboutModalText">This game is special because it is our first collaboration with an artist. All the background images were hand-drawn, and the story text was written together. Although AI can generate images and text, it is a great pleasure to work with real art to create a game. Hope you enjoy!</p>
               <div class="about-modal-footer">
                 <button id="aboutModalClose" class="start-button" type="button">Close</button>
               </div>
@@ -938,7 +940,7 @@
           largeCircleLabel: 'Bigger green circle',
           aboutButton: 'About this game',
           aboutTitle: 'About this game',
-          aboutBody: 'About text coming soon.',
+          aboutBody: "This game is special because it is our first collaboration with an artist. All the background images were hand-drawn, and the story text was written together. Although AI can generate images and text, it is a great pleasure to work with real art to create a game. Hope you enjoy!",
           close: 'Close',
           colorPrompt: 'Color it',
           thanks: 'Thanks for playing',
@@ -989,7 +991,7 @@
           largeCircleLabel: 'Cercle vert plus grand',
           aboutButton: 'À propos du jeu',
           aboutTitle: 'À propos du jeu',
-          aboutBody: 'Texte à venir.',
+          aboutBody: "Ce jeu est spécial, car c’est notre première collaboration avec un artiste. Toutes les images de fond ont été dessinées à la main, et le texte de l’histoire a été écrit ensemble. Même s’il est agréable de pouvoir générer des images et des textes avec l’IA, c’est un grand plaisir de travailler avec de l’art réel pour créer un jeu. Nous espérons que vous apprécierez !",
           close: 'Fermer',
           colorPrompt: 'Colorie-la',
           thanks: 'Merci d’avoir joué',
@@ -1040,7 +1042,7 @@
           largeCircleLabel: '緑の円を大きくする',
           aboutButton: 'このゲームについて',
           aboutTitle: 'このゲームについて',
-          aboutBody: 'テキストは後で追加予定です。',
+          aboutBody: 'このゲームが特別なのは、アーティストとの初めてのコラボレーションだからです。背景画像はすべて手描きで、物語の文章も共同で作りました。AIで画像や文章を生成できる時代ですが、本物のアートと一緒にゲームを作ることには大きな喜びがあります。楽しんでいただけたらうれしいです！',
           close: '閉じる',
           colorPrompt: '色をつけよう',
           thanks: 'プレイしてくれてありがとう',
@@ -2152,7 +2154,7 @@
         }
         if (aboutButton) aboutButton.textContent = text.aboutButton || 'About this game';
         if (aboutModalTitle) aboutModalTitle.textContent = text.aboutTitle || 'About this game';
-        if (aboutModalText) aboutModalText.textContent = text.aboutBody || 'About text coming soon.';
+        if (aboutModalText) aboutModalText.textContent = text.aboutBody || "This game is special because it is our first collaboration with an artist. All the background images were hand-drawn, and the story text was written together. Although AI can generate images and text, it is a great pleasure to work with real art to create a game. Hope you enjoy!";
         if (aboutModalClose) aboutModalClose.textContent = text.close || 'Close';
         updateDwellUI();
       };

--- a/eyegaze/samuraistory/lamp.js
+++ b/eyegaze/samuraistory/lamp.js
@@ -110,7 +110,7 @@
     const CHI_POINTER_MAX = 118;
     const CHI_POINTER_BREATH = 0.05;
     const CHI_POINTER_BREATH_FREQ = 0.8;
-    const GAME_COLOR_REVEAL_MS = 120000;
+    const COLOR_REVEAL_TARGET = 5;
 
     /* =======================
        SETUP
@@ -933,7 +933,7 @@ function drawRopes(t) {
     let gameStartMs = 0;
 
     function drawBackgroundImage() {
-      const progress = Math.max(0, Math.min(1, (performance.now() - gameStartMs) / GAME_COLOR_REVEAL_MS));
+      const progress = Math.max(0, Math.min(1, releasedCount / COLOR_REVEAL_TARGET));
       const gray = 100 - (progress * 100);
       ctx.save();
       ctx.filter = `grayscale(${gray}%)`;

--- a/eyegaze/samuraistory/meditation.js
+++ b/eyegaze/samuraistory/meditation.js
@@ -92,7 +92,7 @@
     const RING_COUNT      = 3;
     const RING_ALPHA      = 0.18;
     const RING_PULSE_HZ   = 1.8;
-    const GAME_COLOR_REVEAL_MS = 120000;
+    const COLOR_REVEAL_TARGET = 3;
 
     // Inflow particles: near-rim and outer ring
     const INFLOW_RATE      = 60;
@@ -424,7 +424,7 @@
        BACKGROUND + FX
     ======================= */
     function drawBackground(){
-      const progress = Math.max(0, Math.min(1, (performance.now() - gameStartMs) / GAME_COLOR_REVEAL_MS));
+      const progress = Math.max(0, Math.min(1, launchCount / COLOR_REVEAL_TARGET));
       const gray = 100 - (progress * 100);
       ctx.save();
       ctx.filter = `grayscale(${gray}%)`;


### PR DESCRIPTION
### Motivation
- Enable English and Japanese narration playback (in addition to French) for the Samurai eyegaze story, and provide a top-level About dialog in the menu for future copy and accessibility.
- Preload narration assets so spoken parts are available when scenes play to avoid playback hitches.

### Description
- Updated `eyegaze/samuraistory/index.html` to replace the French-only narration constant with `NARRATION_BASE_PATH` and compute a `narrationLangTag` (mapping `ja` -> `jp`) so `getNarrationSrc` returns `scene{n}p{part}{langTag}.mp3` for `fr`, `en`, and `jp` files.
- Extended the asset preloader (`gatherAssets`) to include narration clips for parts 1 and 2 for each scene and for each supported language tag so narration files are preloaded alongside images/videos/music.
- Added an `About this game` button (top-left), a stylized centered modal (`about-modal-backdrop` / `about-modal`) with localized placeholder title/body and a close button, and CSS for the button/modal styling.
- Wired JS handlers to open/close the modal (close via `Close` button or by clicking the backdrop), and added localized labels into the `i18n` structure and `updateModeUI` to refresh modal text when language changes.

### Testing
- Verified the updated file diff with `git diff -- eyegaze/samuraistory/index.html` and inspected the inserted modal/narration changes, which showed the expected additions (success).
- Searched the file for the new symbols with `rg -n "NARRATION_BASE_PATH|aboutModal|aboutButton|narrationEnabled"` to confirm references were added (success).
- Committed the change with `git add` + `git commit`, which completed successfully and recorded the change to `eyegaze/samuraistory/index.html` (success).
- No automated UI/browser tests were available in this environment, so runtime verification in a browser is recommended to confirm audio playback behavior and modal interactions in each language.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec02b6678c83259ee782fabe2b2444)