### PR TITLE
Add About modal, switch color-reveal to event counts, and improve narration/back-button logic

### DIFF
--- a/eyegaze/samuraistory/cherryblossom.js
+++ b/eyegaze/samuraistory/cherryblossom.js
@@ -9,7 +9,7 @@
     const SONG_SRC    = "../../songs/samurai/cherryblossomsong2.mp3"; // bg song
     const ENABLE_BG_SONG = false; // keep shared story music constant during games
     const KATANA_DRAW_SRC = "../../sounds/katana.mp3";               // sword drawing SFX
-    const GAME_COLOR_REVEAL_MS = 120000;
+    const COLOR_REVEAL_SLICES = 5;
 
     // Cursor limits and hotspot (in ORIGINAL image pixels)
     const CURSOR_MAX_PX = 124;
@@ -379,7 +379,7 @@
        BACKGROUND IMAGE (cover)
     ======================= */
     function drawBackgroundImage() {
-      const progress = Math.max(0, Math.min(1, (performance.now() - gameStartMs) / GAME_COLOR_REVEAL_MS));
+      const progress = Math.max(0, Math.min(1, sliceCount / COLOR_REVEAL_SLICES));
       const gray = 100 - (progress * 100);
       ctx.save();
       ctx.filter = `grayscale(${gray}%)`;

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -688,7 +688,7 @@
             <input id="dwellSlider" type="range" min="500" max="2000" step="100" value="1000" />
             <label class="dwell-toggle" for="largeCircleToggle">
               <input id="largeCircleToggle" type="checkbox" />
-              <span id="largeCircleLabel">Bigger green circle</span>
+              <span id="largeCircleLabel">Bigger dwell tiles</span>
             </label>
           </div>
           <div class="menu-footer">
@@ -867,7 +867,12 @@
       const chiCursor = document.getElementById('chiCursor');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
-      const STORY_LOOP_SRC = '../../songs/samurai/samuraisong4.mp3';
+      const STORY_LOOP_PLAYLIST = [
+        '../../songs/samurai/samuraisong4.mp3',
+        '../../songs/samurai/samuraisong5.mp3',
+        '../../songs/samurai/samuraisong6.mp3',
+        '../../songs/samurai/samuraisong7.mp3'
+      ];
       const MENU_LOOP_SRC = '../../songs/samurai/samuraisong2.mp3';
       const NARRATION_BASE_PATH = '../../narration/samurai/';
 
@@ -892,10 +897,11 @@
       let isJourneyStarted = false;
       let isTransitioning = false;
       const storyMusic = new Audio();
-      storyMusic.loop = true;
+      storyMusic.loop = false;
       storyMusic.preload = 'auto';
       storyMusic.volume = 0.64;
       let storyMusicSrc = '';
+      let storyMusicIndex = 0;
       const menuMusic = new Audio();
       menuMusic.loop = true;
       menuMusic.preload = 'auto';
@@ -940,7 +946,7 @@
             samurai: 'The strict path: you manually progress and must succeed in mini-game challenges to continue.'
           },
           dwellLabel: 'Dwell time',
-          largeCircleLabel: 'Bigger green circle',
+          largeCircleLabel: 'Bigger dwell tiles',
           aboutButton: 'About this game',
           aboutTitle: 'About this game',
           aboutBody: "This game is special because it is our first collaboration with an artist. All the background images were hand-drawn, and the story text was written together. Although AI can generate images and text, it is a great pleasure to work with real art to create a game. Hope you enjoy!",
@@ -991,7 +997,7 @@
             samurai: 'La voie stricte : progression manuelle et réussite des mini-jeux obligatoire pour continuer.'
           },
           dwellLabel: 'Temps de maintien',
-          largeCircleLabel: 'Cercle vert plus grand',
+          largeCircleLabel: 'Tuiles de maintien plus grandes',
           aboutButton: 'À propos du jeu',
           aboutTitle: 'À propos du jeu',
           aboutBody: "Ce jeu est spécial, car c’est notre première collaboration avec un artiste. Toutes les images de fond ont été dessinées à la main, et le texte de l’histoire a été écrit ensemble. Même s’il est agréable de pouvoir générer des images et des textes avec l’IA, c’est un grand plaisir de travailler avec de l’art réel pour créer un jeu. Nous espérons que vous apprécierez !",
@@ -1042,7 +1048,7 @@
             samurai: '厳しい道：手動で進行し、ミニゲームを成功しないと先に進めません。'
           },
           dwellLabel: '滞留時間',
-          largeCircleLabel: '緑の円を大きくする',
+          largeCircleLabel: '滞留タイルを大きくする',
           aboutButton: 'このゲームについて',
           aboutTitle: 'このゲームについて',
           aboutBody: 'このゲームが特別なのは、アーティストとの初めてのコラボレーションだからです。背景画像はすべて手描きで、物語の文章も共同で作りました。AIで画像や文章を生成できる時代ですが、本物のアートと一緒にゲームを作ることには大きな喜びがあります。楽しんでいただけたらうれしいです！',
@@ -1329,12 +1335,28 @@
         return [words.slice(0, mid).join(' '), words.slice(mid).join(' ')];
       };
 
+      const setStoryMusicTrack = (index) => {
+        if (!STORY_LOOP_PLAYLIST.length) return;
+        storyMusicIndex = ((index % STORY_LOOP_PLAYLIST.length) + STORY_LOOP_PLAYLIST.length) % STORY_LOOP_PLAYLIST.length;
+        const nextSrc = STORY_LOOP_PLAYLIST[storyMusicIndex];
+        if (!nextSrc || storyMusicSrc === nextSrc) return;
+        storyMusicSrc = nextSrc;
+        storyMusic.src = nextSrc;
+        storyMusic.load();
+      };
+
+      const advanceStoryMusicTrack = () => {
+        if (!STORY_LOOP_PLAYLIST.length) return;
+        setStoryMusicTrack(storyMusicIndex + 1);
+        storyMusic.play().catch(() => {});
+      };
+
+      storyMusic.addEventListener('ended', advanceStoryMusicTrack);
+      storyMusic.addEventListener('error', advanceStoryMusicTrack);
+
       const playStoryMusic = () => {
-        if (storyMusicSrc !== STORY_LOOP_SRC) {
-          storyMusicSrc = STORY_LOOP_SRC;
-          storyMusic.src = STORY_LOOP_SRC;
-          storyMusic.load();
-        }
+        if (!STORY_LOOP_PLAYLIST.length) return;
+        setStoryMusicTrack(storyMusicIndex);
         storyMusic.play().catch(() => {});
       };
 
@@ -1860,9 +1882,10 @@
 
           installSamuraiChallenge(page, key, session.api);
 
-          if (currentMode === 'story') {
+          if (currentMode === 'story' || currentMode === 'autonomous') {
+            const modeSnapshot = currentMode;
             setTimeout(() => {
-              if (pages[currentIndex] !== page || currentMode !== 'story') return;
+              if (pages[currentIndex] !== page || currentMode !== modeSnapshot) return;
               nextPage();
             }, storyGameDurationMs);
           }
@@ -1899,12 +1922,19 @@
       };
 
       const getInstructionConstraintNote = (lang, gameKey) => {
-        if (currentMode !== 'samurai') return '';
         const goal = samuraiTargets[gameKey] || 1;
-        const seconds = Math.round(Math.max(samuraiTimeoutMs, 120000) / 1000);
-        if (lang === 'fr') return `Mode Samouraï : réussite obligatoire (${goal}) en ${seconds}s.`;
-        if (lang === 'ja') return `サムライモード：${seconds}秒以内に${goal}回達成が必要です。`;
-        return `Samurai mode: required to reach ${goal} within ${seconds}s.`;
+        const seconds = Math.round(Math.max(samuraiTimeoutMs, storyGameDurationMs) / 1000);
+        if (currentMode === 'samurai') {
+          if (lang === 'fr') return `Mode Samouraï : réussite obligatoire (${goal}) en ${seconds}s.`;
+          if (lang === 'ja') return `サムライモード：${seconds}秒以内に${goal}回達成が必要です。`;
+          return `Samurai mode: required to reach ${goal} within ${seconds}s.`;
+        }
+        if (currentMode === 'story' || currentMode === 'autonomous') {
+          if (lang === 'fr') return `Condition : atteindre ${goal} réussites ou attendre ${seconds}s.`;
+          if (lang === 'ja') return `条件：${goal}回達成、または${seconds}秒経過で次に進みます。`;
+          return `Condition: reach ${goal} successes, or continue after ${seconds}s.`;
+        }
+        return '';
       };
 
       const renderConclusionStats = (page) => {
@@ -2116,6 +2146,7 @@
       const gatherAssets = () => {
         const set = new Set();
         set.add(MENU_LOOP_SRC);
+        STORY_LOOP_PLAYLIST.forEach((track) => set.add(track));
         Object.values(modeConfig).forEach((m) => set.add(m.previewImage));
         storyPages.forEach((page) => {
           const img = page.dataset.image;

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -1258,8 +1258,8 @@
       };
 
       const getTargetPosition = () => isLargeGazeTarget
-        ? { left: '84%', top: '74%' }
-        : { left: '86%', top: '78%' };
+        ? { left: '83%', top: '73%' }
+        : { left: '85%', top: '77%' };
 
       const applyTargetSettings = (target) => {
         if (!target) return;

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -89,6 +89,79 @@
       outline: none;
     }
 
+    .about-button {
+      position: relative;
+      z-index: 2;
+      width: 100%;
+      border: 1px solid rgba(248, 213, 150, .18);
+      border-radius: 12px;
+      background: rgba(17, 12, 18, .42);
+      color: #f9efe1;
+      padding: 6px 8px;
+      text-align: center;
+      min-height: 36px;
+      font-family: Georgia, serif;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      font-size: clamp(.65rem, .95vw, .95rem);
+      cursor: pointer;
+      transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+      backdrop-filter: blur(2px);
+      margin-bottom: 14px;
+    }
+    .about-button:hover,
+    .about-button:focus-visible {
+      background: rgba(148, 83, 38, .72);
+      border-color: rgba(252, 216, 147, .82);
+      outline: none;
+    }
+
+    .about-modal-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 40;
+      display: grid;
+      place-items: center;
+      background: rgba(2, 2, 7, .72);
+      backdrop-filter: blur(3px);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .2s ease;
+    }
+    .about-modal-backdrop.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+    .about-modal {
+      width: min(92vw, 720px);
+      max-height: min(80vh, 560px);
+      overflow: auto;
+      border: 1px solid rgba(252, 216, 147, .42);
+      border-radius: 20px;
+      background:
+        linear-gradient(160deg, rgba(8, 10, 16, .95), rgba(18, 12, 16, .95)),
+        url('../../images/samurai/cherryblossombg.png') center/cover no-repeat;
+      padding: clamp(16px, 2.4vw, 30px);
+      box-shadow: 0 22px 48px rgba(0, 0, 0, .5);
+    }
+    .about-modal h3 {
+      margin: 0 0 10px;
+      font-family: Georgia, serif;
+      color: var(--gold);
+      text-transform: uppercase;
+      letter-spacing: .05em;
+    }
+    .about-modal p {
+      margin: 0;
+      line-height: 1.5;
+      color: rgba(255, 245, 230, .94);
+    }
+    .about-modal-footer {
+      margin-top: 14px;
+      display: flex;
+      justify-content: flex-end;
+    }
+
     .menu-blossoms {
       position: absolute;
       inset: 0;
@@ -593,6 +666,16 @@
           <div id="languageSwitcher" class="language-switcher">
             <button id="language-toggle" class="lang-toggle" type="button" title="Changer de langue / Change language / 言語を変更">FR</button>
           </div>
+          <button id="aboutButton" class="about-button" type="button">About this game</button>
+          <div id="aboutModalBackdrop" class="about-modal-backdrop" aria-hidden="true">
+            <div class="about-modal" role="dialog" aria-modal="true" aria-labelledby="aboutModalTitle">
+              <h3 id="aboutModalTitle">About this game</h3>
+              <p id="aboutModalText">This game is special because it is our first collaboration with an artist. All the background images were hand-drawn, and the story text was written together. Although AI can generate images and text, it is a great pleasure to work with real art to create a game. Hope you enjoy!</p>
+              <div class="about-modal-footer">
+                <button id="aboutModalClose" class="start-button" type="button">Close</button>
+              </div>
+            </div>
+          </div>
           <div id="menuBlossoms" class="menu-blossoms" aria-hidden="true"></div>
           <div class="menu-row">
             <button class="mode-button active" data-mode="story" type="button"><strong>Story</strong></button>
@@ -754,7 +837,7 @@
 
   <div id="chiCursor" aria-hidden="true"></div>
   <div id="transitionOverlay" class="transition-overlay" aria-hidden="true"></div>
-  <button id="backButton" class="gaze-target back-target" aria-label="Go to previous stage" type="button" hidden></button>
+  <button id="backButton" class="gaze-target back-target" aria-label="Go to previous stage" type="button"></button>
 
   <script>
     window.addEventListener('DOMContentLoaded', () => {
@@ -776,12 +859,17 @@
       const languageToggleButton = document.getElementById('language-toggle');
       const menuTitleLocalized = document.getElementById('menuTitleLocalized');
       const menuBlossoms = document.getElementById('menuBlossoms');
+      const aboutButton = document.getElementById('aboutButton');
+      const aboutModalBackdrop = document.getElementById('aboutModalBackdrop');
+      const aboutModalClose = document.getElementById('aboutModalClose');
+      const aboutModalTitle = document.getElementById('aboutModalTitle');
+      const aboutModalText = document.getElementById('aboutModalText');
       const chiCursor = document.getElementById('chiCursor');
       const imageBasePath = '../../images/samuraikata/';
       const videoBasePath = '../../animations/samurai/';
       const STORY_LOOP_SRC = '../../songs/samurai/samuraisong4.mp3';
       const MENU_LOOP_SRC = '../../songs/samurai/samuraisong2.mp3';
-      const FRENCH_NARRATION_BASE_PATH = '../../narration/samurai/';
+      const NARRATION_BASE_PATH = '../../narration/samurai/';
 
       const gameTemplates = { cherry: 'tpl-cherryblossom', meditation: 'tpl-meditation', lamp: 'tpl-lamp' };
       const templateCache = {};
@@ -853,6 +941,10 @@
           },
           dwellLabel: 'Dwell time',
           largeCircleLabel: 'Bigger green circle',
+          aboutButton: 'About this game',
+          aboutTitle: 'About this game',
+          aboutBody: "This game is special because it is our first collaboration with an artist. All the background images were hand-drawn, and the story text was written together. Although AI can generate images and text, it is a great pleasure to work with real art to create a game. Hope you enjoy!",
+          close: 'Close',
           colorPrompt: 'Color it',
           thanks: 'Thanks for playing',
           stats: {
@@ -900,6 +992,10 @@
           },
           dwellLabel: 'Temps de maintien',
           largeCircleLabel: 'Cercle vert plus grand',
+          aboutButton: 'À propos du jeu',
+          aboutTitle: 'À propos du jeu',
+          aboutBody: "Ce jeu est spécial, car c’est notre première collaboration avec un artiste. Toutes les images de fond ont été dessinées à la main, et le texte de l’histoire a été écrit ensemble. Même s’il est agréable de pouvoir générer des images et des textes avec l’IA, c’est un grand plaisir de travailler avec de l’art réel pour créer un jeu. Nous espérons que vous apprécierez !",
+          close: 'Fermer',
           colorPrompt: 'Colorie-la',
           thanks: 'Merci d’avoir joué',
           stats: {
@@ -947,6 +1043,10 @@
           },
           dwellLabel: '滞留時間',
           largeCircleLabel: '緑の円を大きくする',
+          aboutButton: 'このゲームについて',
+          aboutTitle: 'このゲームについて',
+          aboutBody: 'このゲームが特別なのは、アーティストとの初めてのコラボレーションだからです。背景画像はすべて手描きで、物語の文章も共同で作りました。AIで画像や文章を生成できる時代ですが、本物のアートと一緒にゲームを作ることには大きな喜びがあります。楽しんでいただけたらうれしいです！',
+          close: '閉じる',
           colorPrompt: '色をつけよう',
           thanks: 'プレイしてくれてありがとう',
           stats: {
@@ -1191,13 +1291,11 @@
         if (!backButton) return;
         const canGoBack = isJourneyStarted && currentIndex > 1;
         if (!canGoBack || !target) {
-          backButton.hidden = true;
           backButton.classList.remove('visible', 'active', 'inactive', 'dwell', 'dwell-complete');
           return;
         }
         applyBackButtonSettings(target);
         const visible = target.classList.contains('visible');
-        backButton.hidden = !visible;
         backButton.classList.toggle('visible', visible);
         backButton.classList.toggle('active', target.classList.contains('active'));
         backButton.classList.toggle('inactive', target.classList.contains('inactive'));
@@ -1430,11 +1528,13 @@
         const [textA, textB] = Array.isArray(explicitParts) && explicitParts.length === 2
           ? explicitParts
           : splitText(fullText);
-        const narrationEnabled = uiLang === 'fr' && ['scene1', 'scene2', 'scene3', 'scene5', 'scene6', 'scene7', 'scene9', 'scene10', 'scene11'].includes(sceneKey);
+        const narratableScenes = ['scene1', 'scene2', 'scene3', 'scene5', 'scene6', 'scene7', 'scene9', 'scene10', 'scene11'];
+        const narrationLangTag = uiLang === 'ja' ? 'jp' : uiLang;
+        const narrationEnabled = narratableScenes.includes(sceneKey) && ['fr', 'en', 'jp'].includes(narrationLangTag);
         const sceneNumber = sceneKey.replace('scene', '');
         const getNarrationSrc = (part) => {
-          const fileName = `scene${sceneNumber}p${part}fr.mp3`;
-          return `${FRENCH_NARRATION_BASE_PATH}${fileName}`;
+          const fileName = `scene${sceneNumber}p${part}${narrationLangTag}.mp3`;
+          return `${NARRATION_BASE_PATH}${fileName}`;
         };
         playStoryMusic();
 
@@ -1789,14 +1889,22 @@
         }
         const canGoBack = isJourneyStarted && currentIndex > 1;
         if (!canGoBack) {
-          backButton.hidden = true;
-          backButton.classList.remove('visible', 'active', 'dwell', 'dwell-complete');
+          backButton.classList.remove('visible', 'active', 'inactive', 'dwell', 'dwell-complete');
           return;
         }
         const page = pages[currentIndex];
         const primaryTarget = page?.querySelector('[data-gaze-target], [data-instruction-target], [data-conclusion-target]') || null;
         syncBackButtonStateFrom(primaryTarget);
         backButtonCleanup = createDwellGate(backButton, () => prevPage(), 0);
+      };
+
+      const getInstructionConstraintNote = (lang, gameKey) => {
+        if (currentMode !== 'samurai') return '';
+        const goal = samuraiTargets[gameKey] || 1;
+        const seconds = Math.round(Math.max(samuraiTimeoutMs, 120000) / 1000);
+        if (lang === 'fr') return `Mode Samouraï : réussite obligatoire (${goal}) en ${seconds}s.`;
+        if (lang === 'ja') return `サムライモード：${seconds}秒以内に${goal}回達成が必要です。`;
+        return `Samurai mode: required to reach ${goal} within ${seconds}s.`;
       };
 
       const renderConclusionStats = (page) => {
@@ -1859,7 +1967,8 @@
         syncBackButtonStateFrom(target);
         captionEl.classList.add('visible', 'advanceable');
         captionEl.classList.remove('dwell');
-        captionEl.innerHTML = `<span class="instruction-caption-title">${instruction?.title || 'Instruction'}</span>${instruction?.text || ''}`;
+        const constraintNote = getInstructionConstraintNote(lang, gameKey);
+        captionEl.innerHTML = `<span class="instruction-caption-title">${instruction?.title || 'Instruction'}</span>${instruction?.text || ''}${constraintNote ? `<br><br><strong>${constraintNote}</strong>` : ''}`;
 
         if (instructionCleanup) instructionCleanup();
         const autoActivateMs = currentMode === 'story' ? 30000 : 0;
@@ -2015,6 +2124,12 @@
             if (page.dataset.novideo !== 'true') {
               set.add(`${videoBasePath}${img.replace(/\.(jpg|jpeg|png)$/i, '.mp4')}`);
             }
+            const sceneNumber = img.replace(/\.(jpg|jpeg|png)$/i, '').replace('scene', '');
+            ['fr', 'en', 'jp'].forEach((langTag) => {
+              [1, 2].forEach((part) => {
+                set.add(`${NARRATION_BASE_PATH}scene${sceneNumber}p${part}${langTag}.mp3`);
+              });
+            });
           }
           if (page.dataset.audio) set.add(page.dataset.audio);
         });
@@ -2047,6 +2162,10 @@
           const nextLang = getNextLanguage(lang);
           languageToggleButton.textContent = languageLabels[nextLang] || nextLang.toUpperCase();
         }
+        if (aboutButton) aboutButton.textContent = text.aboutButton || 'About this game';
+        if (aboutModalTitle) aboutModalTitle.textContent = text.aboutTitle || 'About this game';
+        if (aboutModalText) aboutModalText.textContent = text.aboutBody || "This game is special because it is our first collaboration with an artist. All the background images were hand-drawn, and the story text was written together. Although AI can generate images and text, it is a great pleasure to work with real art to create a game. Hope you enjoy!";
+        if (aboutModalClose) aboutModalClose.textContent = text.close || 'Close';
         updateDwellUI();
       };
 
@@ -2091,6 +2210,24 @@
           renderConclusionStats(currentPage);
           setupConclusionPage(currentPage);
         }
+      });
+
+      const closeAboutModal = () => {
+        if (!aboutModalBackdrop) return;
+        aboutModalBackdrop.classList.remove('open');
+        aboutModalBackdrop.setAttribute('aria-hidden', 'true');
+      };
+
+      const openAboutModal = () => {
+        if (!aboutModalBackdrop) return;
+        aboutModalBackdrop.classList.add('open');
+        aboutModalBackdrop.setAttribute('aria-hidden', 'false');
+      };
+
+      aboutButton?.addEventListener('click', openAboutModal);
+      aboutModalClose?.addEventListener('click', closeAboutModal);
+      aboutModalBackdrop?.addEventListener('click', (event) => {
+        if (event.target === aboutModalBackdrop) closeAboutModal();
       });
 
       dwellSlider?.addEventListener('input', () => {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -641,7 +641,7 @@
       background: #050505;
       opacity: 0;
       pointer-events: none;
-      z-index: 30;
+      z-index: 90;
     }
     .transition-overlay.active { animation: sceneFade var(--scene-transition-total) linear forwards; }
     @keyframes sceneFade {

--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -92,22 +92,24 @@
     .about-button {
       position: relative;
       z-index: 2;
-      width: 100%;
+      width: 92%;
+      align-self: center;
       border: 1px solid rgba(248, 213, 150, .18);
       border-radius: 12px;
       background: rgba(17, 12, 18, .42);
       color: #f9efe1;
-      padding: 6px 8px;
+      padding: 5px 8px;
       text-align: center;
-      min-height: 36px;
+      min-height: 32px;
       font-family: Georgia, serif;
       letter-spacing: .05em;
       text-transform: uppercase;
-      font-size: clamp(.65rem, .95vw, .95rem);
+      font-size: clamp(.62rem, .9vw, .88rem);
       cursor: pointer;
       transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
       backdrop-filter: blur(2px);
       margin-bottom: 14px;
+      margin-top: -4px;
     }
     .about-button:hover,
     .about-button:focus-visible {

--- a/eyegaze/samuraistory/lamp.js
+++ b/eyegaze/samuraistory/lamp.js
@@ -110,7 +110,7 @@
     const CHI_POINTER_MAX = 118;
     const CHI_POINTER_BREATH = 0.05;
     const CHI_POINTER_BREATH_FREQ = 0.8;
-    const GAME_COLOR_REVEAL_MS = 120000;
+    const COLOR_REVEAL_RELEASES = 5;
 
     /* =======================
        SETUP
@@ -933,7 +933,7 @@ function drawRopes(t) {
     let gameStartMs = 0;
 
     function drawBackgroundImage() {
-      const progress = Math.max(0, Math.min(1, (performance.now() - gameStartMs) / GAME_COLOR_REVEAL_MS));
+      const progress = Math.max(0, Math.min(1, releasedCount / COLOR_REVEAL_RELEASES));
       const gray = 100 - (progress * 100);
       ctx.save();
       ctx.filter = `grayscale(${gray}%)`;

--- a/eyegaze/samuraistory/meditation.js
+++ b/eyegaze/samuraistory/meditation.js
@@ -92,7 +92,7 @@
     const RING_COUNT      = 3;
     const RING_ALPHA      = 0.18;
     const RING_PULSE_HZ   = 1.8;
-    const GAME_COLOR_REVEAL_MS = 120000;
+    const COLOR_REVEAL_LAUNCHES = 3;
 
     // Inflow particles: near-rim and outer ring
     const INFLOW_RATE      = 60;
@@ -424,7 +424,7 @@
        BACKGROUND + FX
     ======================= */
     function drawBackground(){
-      const progress = Math.max(0, Math.min(1, (performance.now() - gameStartMs) / GAME_COLOR_REVEAL_MS));
+      const progress = Math.max(0, Math.min(1, launchCount / COLOR_REVEAL_LAUNCHES));
       const gray = 100 - (progress * 100);
       ctx.save();
       ctx.filter = `grayscale(${gray}%)`;


### PR DESCRIPTION
### Motivation
- Replace time-based background color reveal with event-count triggers so scene colorization depends on in-game milestones rather than elapsed time.
- Surface an ‘About this game’ modal to credit the artist and provide localized copy for players.
- Unify narration/audio path handling and improve back-button and instruction caption behavior for clearer localized narration and Samurai-mode constraints.

### Description
- Replaced `GAME_COLOR_REVEAL_MS` time-based constants with event-count constants (`COLOR_REVEAL_SLICES`, `COLOR_REVEAL_RELEASES`, `COLOR_REVEAL_LAUNCHES`) and updated background draw logic in `cherryblossom.js`, `lamp.js`, and `meditation.js` to compute grayscale progress from event counters (`sliceCount`, `releasedCount`, `launchCount`).
- Added an About modal UI in `index.html` including styles, markup (`#aboutButton`, `#aboutModalBackdrop`, modal content) and localized copy for English, French and Japanese in the `i18n` table.
- Wire up modal behavior with open/close handlers and backdrop click-to-close logic in the main script, and localized the modal strings from `i18n` in `updateModeUI`.
- Renamed `FRENCH_NARRATION_BASE_PATH` to `NARRATION_BASE_PATH` and extended narration support to multiple languages by selecting files like `scene{n}p{part}{langTag}.mp3` (supports `fr`, `en`, `jp`), changed narration enable logic to check allowed languages, and added those assets to the preload list in `gatherAssets`.
- Adjusted back-button visibility/behavior: removed use of the `hidden` attribute and rely on classes for visible/active/inactive states so the gaze-target is styled consistently; updated sync/update functions accordingly.
- Added `getInstructionConstraintNote` to surface Samurai-mode constraint text in instruction captions and appended it to the instruction caption in `setupInstructionPage`.

### Testing
- Ran the repository's automated checks including linting and the project test suite via `npm test` and `npm run lint`, and they completed successfully.
- Verified asset preloading includes the new narration files by exercising the `gatherAssets` path (preload routine ran without errors).
- Confirmed modal open/close handlers and backdrop click behavior run without throwing errors during the app initialization sequence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec02b6678c83259ee782fabe2b2444)