### PR TITLE
Hide red back gaze-circle during Samurai story video playback

### DIFF
--- a/eyegaze/samuraistory/index.html
+++ b/eyegaze/samuraistory/index.html
@@ -1459,6 +1459,7 @@
           return;
         }
         media.classList.add('video-playing');
+        syncBackButtonStateFrom(null);
         video.currentTime = 0;
         const p = video.play();
         if (p && typeof p.catch === 'function') p.catch(() => {});


### PR DESCRIPTION
### Motivation
- During Samurai story scenes the forward (green) gaze target is hidden when videos play via `.story-media.video-playing .gaze-target`, but the red back gaze-circle (`#backButton`) lives outside `.story-media` and remained visible during video playback.

### Description
- Added a single-line change in `eyegaze/samuraistory/index.html` inside `playVideoThenAdvance` to call `syncBackButtonStateFrom(null)` immediately after `media.classList.add('video-playing')` to clear the back-button state and hide the red circle while the video is playing.
- This matches the existing hide behavior applied to the green forward circle and avoids visual overlap during cinematic playback.

### Testing
- Searched and inspected relevant files with `rg` to confirm the root cause and targets, which returned expected matches (success).
- Verified the change via `git diff` and `nl -ba` to confirm the insertion at the intended location in `eyegaze/samuraistory/index.html` (success).
- Committed the change with `git commit` and validated the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3ed6431c83258ef8ba27808d57ca)