### PR TITLE
i18n: translate element attributes and migrate language storage key

### DIFF
--- a/pedagogique/cvi-field-mapper/index.html
+++ b/pedagogique/cvi-field-mapper/index.html
@@ -375,7 +375,7 @@
 <body>
   <div class="layout">
     <section class="panel controls">
-      <button id="language-toggle" type="button" title="Changer de langue / Change language / 言語を変更">EN</button>
+      <button id="language-toggle" type="button" class="translate-attr" data-attr="title" data-fr="Changer de langue" data-en="Change language" data-ja="言語を変更" title="Changer de langue">EN</button>
 
       <h1 class="translate" data-fr="Champ visuel" data-en="Field Mapper" data-ja="フィールドマッパー">Champ visuel</h1>
 
@@ -414,7 +414,7 @@
       <div class="panel test-zone" id="testZone">
         <div class="grid" id="grid"></div>
         <div class="target hidden" id="target" aria-hidden="true">
-          <canvas id="targetCanvas" aria-label="Cible CVI"></canvas>
+          <canvas id="targetCanvas" class="translate-attr" data-attr="aria-label" data-fr="Cible CVI" data-en="CVI target" data-ja="CVIターゲット" aria-label="Cible CVI"></canvas>
         </div>
       </div>
 
@@ -466,9 +466,10 @@
     const categories = [...new Set(allItems.map((item) => item.category))];
 
     const SUPPORTED_LANGUAGES = ["fr", "en", "ja"];
-    const LANGUAGE_STORAGE_KEY = "selectedLanguage";
+    const LANGUAGE_STORAGE_KEY = "siteLanguage";
+    const LEGACY_LANGUAGE_STORAGE_KEY = "selectedLanguage";
 
-    let currentLang = localStorage.getItem(LANGUAGE_STORAGE_KEY) || "fr";
+    let currentLang = localStorage.getItem(LANGUAGE_STORAGE_KEY) || localStorage.getItem(LEGACY_LANGUAGE_STORAGE_KEY) || "fr";
     if (!SUPPORTED_LANGUAGES.includes(currentLang)) currentLang = "fr";
 
     const state = {
@@ -532,6 +533,16 @@
           el.getAttribute("data-fr") ||
           "";
         if (translated) el.textContent = translated;
+      });
+
+      document.querySelectorAll(".translate-attr").forEach((el) => {
+        const translated =
+          el.getAttribute(`data-${currentLang}`) ||
+          el.getAttribute("data-en") ||
+          el.getAttribute("data-fr") ||
+          "";
+        const targetAttr = el.getAttribute("data-attr");
+        if (translated && targetAttr) el.setAttribute(targetAttr, translated);
       });
 
       const titleEl = document.querySelector("title.translate");
@@ -1031,6 +1042,7 @@
       const idx = SUPPORTED_LANGUAGES.indexOf(currentLang);
       currentLang = SUPPORTED_LANGUAGES[(idx + 1) % SUPPORTED_LANGUAGES.length];
       localStorage.setItem(LANGUAGE_STORAGE_KEY, currentLang);
+      localStorage.setItem(LEGACY_LANGUAGE_STORAGE_KEY, currentLang);
       refreshZoneNames();
       applyTranslations();
     });


### PR DESCRIPTION
### Motivation
- Improve internationalization so non-text attributes (like `title` and `aria-label`) can be localized in addition to element text.
- Migrate the persisted language setting to a clearer key while preserving compatibility with the previous key.

### Description
- Added a new `translate-attr` class and `data-attr` handling to set arbitrary attributes from `data-<lang>` values during translation by applying translated values via `setAttribute`.
- Switched the language storage key from `selectedLanguage` to `siteLanguage` and added a `LEGACY_LANGUAGE_STORAGE_KEY` fallback so existing stored preferences remain honored.
- Updated markup to include `class="translate-attr"` and `data-attr` on the language toggle button and the `targetCanvas` `aria-label`, and ensure the language toggle write updates both storage keys when changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26962fe8083259ec779ca8e88bbf1)