### PR TITLE
Refactor sensoriel session/theme and reinforcer flow into shared modules

### DIFF
--- a/sensoriel/base.html
+++ b/sensoriel/base.html
@@ -69,13 +69,15 @@
 
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      // Retrieve game selections and theme information from localStorage and themes.js
-      const selections = JSON.parse(localStorage.getItem('gameSelections')) || {};
-      const mediaOption = selections.mediaOption || "";
+      const flow = window.sessionHelpers && typeof window.sessionHelpers.runSessionFlow === 'function'
+        ? window.sessionHelpers.runSessionFlow()
+        : null;
+      if (!flow || !flow.session) {
+        return;
+      }
+      const selections = flow.session.selections || {};
       const reinforcerType = selections.reinforcerType || 'shortvideo';
-      const themeData = (window.themes && window.themes[mediaOption])
-                        ? window.themes[mediaOption]
-                        : window.themes["default"] || {};
+      const themeData = flow.themeData || {};
 
       // Set up audio element sources from theme data
       document.getElementById('error-sound').src = themeData.errorSound || "../sounds/error.mp3";
@@ -83,34 +85,14 @@
       document.getElementById('word-reward-sound').src = themeData.reinforcerSound || "../sounds/success3.mp3";
       document.getElementById('final-reward-sound').src = themeData.finalRewardSound || "../sounds/victory.mp3";
 
-      // Show the activity overlay with the game index
-      let overallGameIndex = parseInt(localStorage.getItem('currentGameIndex'), 10);
-      if (isNaN(overallGameIndex)) {
-        alert("Game selections not found. Redirecting to main page.");
-        window.location.href = "main.html";
-        return;
-      }
-      // (Optionally: check that the current game ID matches what you expect.)
-
-      const activityOverlay = document.getElementById('activityNumberOverlay');
-      const numberTextEl = activityOverlay.querySelector('.number-text');
-      numberTextEl.textContent = (overallGameIndex + 1).toString();
-      activityOverlay.style.display = 'flex';
-
-      // When the user clicks/touches the overlay, hide it and start the game.
       function hideOverlayAndStart() {
-        if (themeData.startSound) {
-          let sfx = new Audio(themeData.startSound);
-          sfx.play().catch(err => console.warn('Sound play error:', err));
-        }
-        activityOverlay.style.display = 'none';
-        document.removeEventListener('click', hideOverlayAndStart);
-        document.removeEventListener('touchend', hideOverlayAndStart);
-        // Call your game‐specific start function
         startGame();
       }
-      document.addEventListener('click', hideOverlayAndStart);
-      document.addEventListener('touchend', hideOverlayAndStart);
+      if (window.sessionHelpers && typeof window.sessionHelpers.showActivityOverlay === 'function') {
+        window.sessionHelpers.showActivityOverlay(hideOverlayAndStart, flow.session);
+      } else {
+        hideOverlayAndStart();
+      }
 
       const resolveGameFile = (gameId) => {
         if (!gameId) {
@@ -163,23 +145,7 @@
         }, 2000); // 2-second delay
       }
 
-      let reinforcerController = null;
-      if (window.sessionHelpers && typeof window.sessionHelpers.setupSharedReinforcer === 'function') {
-        const session = sessionHelpers.loadSession ? sessionHelpers.loadSession() : null;
-        if (session) {
-          reinforcerController = sessionHelpers.setupSharedReinforcer(session, {
-            reinforcerType,
-            onAdvance: navigateToNextGame
-          });
-        }
-      }
-      if (!reinforcerController && window.reinforcerOverlay && typeof window.reinforcerOverlay.init === 'function') {
-        reinforcerController = window.reinforcerOverlay.init({
-          reinforcerType,
-          themeData,
-          onAdvance: navigateToNextGame
-        });
-      }
+      const reinforcerController = flow.reinforcerController;
 
       // Generic function to show the final reinforcer overlay.
       function showFinalReinforcerVideo() {
@@ -187,8 +153,8 @@
         finalRewardSound.play().catch(error => {
           console.error('Error playing final reward sound:', error);
         });
-        if (reinforcerController && typeof reinforcerController.show === 'function') {
-          reinforcerController.show({ reinforcerType });
+        if (window.sessionHelpers && typeof window.sessionHelpers.startNextStep === 'function') {
+          window.sessionHelpers.startNextStep(reinforcerController, { reinforcerType });
         } else {
           navigateToNextGame();
         }

--- a/sensoriel/js/fullscreen.js
+++ b/sensoriel/js/fullscreen.js
@@ -121,6 +121,25 @@
     }
   }
 
+
+  function enforceKioskViewport() {
+    doc.documentElement.style.overflow = 'hidden';
+    if (doc.body) {
+      doc.body.style.overflow = 'hidden';
+      doc.body.style.overscrollBehavior = 'none';
+      doc.body.style.touchAction = 'none';
+    }
+    doc.documentElement.style.overscrollBehavior = 'none';
+
+    doc.addEventListener('touchmove', (event) => {
+      const target = event.target;
+      const allow = target && target.closest && target.closest('input, textarea, [contenteditable="true"], select');
+      if (!allow) {
+        event.preventDefault();
+      }
+    }, { passive: false });
+  }
+
   let iosZoomDisabled = false;
 
   function disableIOSZoom() {
@@ -168,6 +187,7 @@
 
   doc.addEventListener('visibilitychange', handleVisibilityReturn);
   doc.addEventListener('DOMContentLoaded', () => {
+    enforceKioskViewport();
     disableIOSZoom();
     if (shouldMaintainFullscreen()) {
       maintainFullscreen();

--- a/sensoriel/js/reinforcer-overlay.js
+++ b/sensoriel/js/reinforcer-overlay.js
@@ -642,7 +642,31 @@ const DEFAULT_IMAGE = '../images/default_reinforcer.png';
     };
   }
 
+  function bootstrapReinforcerPage(options) {
+    const opts = options || {};
+    if (global.SensorielFullscreen && typeof global.SensorielFullscreen.ensure === 'function') {
+      global.SensorielFullscreen.ensure();
+    }
+
+    const sessionFlow = global.sessionHelpers && typeof global.sessionHelpers.runSessionFlow === 'function'
+      ? global.sessionHelpers.runSessionFlow(opts)
+      : null;
+
+    if (!sessionFlow || !sessionFlow.session) {
+      return null;
+    }
+
+    if (global.sessionHelpers && typeof global.sessionHelpers.startNextStep === 'function') {
+      global.sessionHelpers.startNextStep(sessionFlow.reinforcerController, {
+        reinforcerType: sessionFlow.session.selections.reinforcerType || 'shortvideo'
+      });
+    }
+
+    return sessionFlow;
+  }
+
   global.reinforcerOverlay = {
-    init
+    init,
+    bootstrapReinforcerPage
   };
 })(window);

--- a/sensoriel/js/session-helpers.js
+++ b/sensoriel/js/session-helpers.js
@@ -47,6 +47,13 @@
     return global.themes['default'] || {};
   }
 
+  function resolveThemeDataFromSession(sessionOrSelections) {
+    const selections = sessionOrSelections && sessionOrSelections.selections
+      ? sessionOrSelections.selections
+      : sessionOrSelections;
+    return getThemeData(selections || {});
+  }
+
   function loadSession() {
     let selections;
     try {
@@ -75,7 +82,7 @@
       selections.completionDestination = 'accessyoutube';
     }
 
-    const themeData = getThemeData(selections);
+    const themeData = resolveThemeDataFromSession(selections);
 
     return { selections, currentGameIndex, themeData };
   }
@@ -206,6 +213,19 @@
     }
   }
 
+  function ensureGameOrder(session) {
+    const activeSession = session || loadSession();
+    if (!activeSession) {
+      return null;
+    }
+    if (!Array.isArray(activeSession.selections.gameOrder) || activeSession.selections.gameOrder.length === 0) {
+      console.warn('Game order is missing from session.');
+      redirectToMain();
+      return null;
+    }
+    return activeSession;
+  }
+
   function setupReinforcerRedirect() {
     const button = document.getElementById('reinforcerButton');
     if (!button) {
@@ -241,15 +261,44 @@
     return global.reinforcerOverlay.init(config);
   }
 
+  function startNextStep(reinforcerController, options) {
+    const config = options || {};
+    const reinforcerType = config.reinforcerType || 'shortvideo';
+    if (reinforcerController && typeof reinforcerController.show === 'function') {
+      reinforcerController.show({ reinforcerType });
+      return;
+    }
+    advanceToNextGame();
+  }
+
+  function runSessionFlow(options) {
+    const config = options || {};
+    const session = ensureGameOrder(config.session || loadSession());
+    if (!session) {
+      return null;
+    }
+    const themeData = resolveThemeDataFromSession(session);
+    const reinforcerController = setupSharedReinforcer(session, Object.assign({}, config.reinforcerOptions, {
+      reinforcerType: config.reinforcerType || (session.selections && session.selections.reinforcerType) || 'shortvideo',
+      themeData,
+      onAdvance: config.onAdvance || advanceToNextGame
+    }));
+    return { session, themeData, reinforcerController };
+  }
+
   global.sessionHelpers = {
     getGameFileById,
     loadSession,
+    resolveThemeDataFromSession,
+    ensureGameOrder,
     ensureCurrentGame,
     getCurrentGameOptions,
     showActivityOverlay,
     updateActivityMarker,
     advanceToNextGame,
     setupReinforcerRedirect,
-    setupSharedReinforcer
+    setupSharedReinforcer,
+    startNextStep,
+    runSessionFlow
   };
 })(window);

--- a/sensoriel/main.html
+++ b/sensoriel/main.html
@@ -318,6 +318,9 @@
 
     let gameCount = 0;
 
+    const DEFAULT_THEME_ID = 'picto_animaux';
+    const DEFAULT_REINFORCER_TYPE = 'shortvideo';
+
     function populateGameSelect(selectElement) {
       if (!selectElement) {
         return;
@@ -410,6 +413,8 @@
 
       if (previousValue && seen.has(previousValue)) {
         themesDropdown.value = previousValue;
+      } else if (seen.has(DEFAULT_THEME_ID)) {
+        themesDropdown.value = DEFAULT_THEME_ID;
       }
     }
 
@@ -437,6 +442,14 @@
     function restoreGlobalPreferences() {
       const stored = getStoredSelections();
       if (!stored) {
+        const themesDropdownDefault = document.getElementById('mediaOption');
+        if (themesDropdownDefault && optionExists(themesDropdownDefault, DEFAULT_THEME_ID)) {
+          themesDropdownDefault.value = DEFAULT_THEME_ID;
+        }
+        const reinforcerTypeDefault = document.getElementById('reinforcerType');
+        if (reinforcerTypeDefault && optionExists(reinforcerTypeDefault, DEFAULT_REINFORCER_TYPE)) {
+          reinforcerTypeDefault.value = DEFAULT_REINFORCER_TYPE;
+        }
         return;
       }
 

--- a/sensoriel/reinforcer.html
+++ b/sensoriel/reinforcer.html
@@ -10,6 +10,8 @@
   <script src="../js/themes.js"></script>
   <script src="js/games-config.js"></script>
   <script src="js/session-helpers.js"></script>
+  <script src="js/reinforcer-overlay.js"></script>
+  <script src="js/fullscreen.js"></script>
   <link rel="stylesheet" href="../css/ipadteachh.css">
   <style>
     *, *::before, *::after {
@@ -179,186 +181,17 @@
 
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      // Attempt auto-fullscreen on page load
-      const docElm = document.documentElement;
-      if (docElm.requestFullscreen) {
-        docElm.requestFullscreen().catch(err => {
-          console.error('Auto-fullscreen failed:', err);
-        });
-      } else if (docElm.mozRequestFullScreen) { // Firefox
-        docElm.mozRequestFullScreen().catch(err => {
-          console.error('Auto-fullscreen failed:', err);
-        });
-      } else if (docElm.webkitRequestFullscreen) { // Chrome, Safari, Opera
-        docElm.webkitRequestFullscreen().catch(err => {
-          console.error('Auto-fullscreen failed:', err);
-        });
-      } else if (docElm.msRequestFullscreen) { // IE/Edge
-        docElm.msRequestFullscreen().catch(err => {
-          console.error('Auto-fullscreen failed:', err);
-        });
-      }
-
-      // Retrieve selections and theme data from localStorage and themes.js
-      const selections = JSON.parse(localStorage.getItem('gameSelections')) || {};
-      const mediaOption = selections.mediaOption || "default";
-      const themeData = (window.themes && window.themes[mediaOption]) ||
-                        (window.themes && window.themes["default"]) || {};
-
-      // Determine reinforcer type ("shortvideo" or "image")
-      const reinforcerType = selections.reinforcerType || "shortvideo";
-
-      // Get elements for video, play button, image, and interaction blocker overlay.
-      const reinforcerVideo = document.getElementById('reinforcerVideo');
-      const reinforcerSource = document.getElementById('reinforcerVideoSource');
-      const reinforcerImage = document.getElementById('reinforcerImage');
-      const playButton = document.getElementById('playButton');
-      const videoOverlayCover = document.getElementById('videoOverlayCover');
-      const socialContainer = document.getElementById('socialReinforcer');
-      const socialProgressFill = socialContainer ? socialContainer.querySelector('.progress-fill') : null;
-      const socialProgressRemaining = socialContainer ? socialContainer.querySelector('.progress-remaining') : null;
-
-      // Ensure the overlay is visible
-      document.getElementById('reinforcerOverlay').style.display = 'flex';
-
-      if (reinforcerType === "shortvideo") {
-        // Set the video source from the theme or use a fallback video.
-        if (themeData.reinforcerVideos && themeData.reinforcerVideos.length > 0) {
-          const randomIndex = Math.floor(Math.random() * themeData.reinforcerVideos.length);
-          reinforcerSource.src = themeData.reinforcerVideos[randomIndex];
-        } else {
-          reinforcerSource.src = "../videos/africa.mp4";
-        }
-        reinforcerVideo.load();
-        reinforcerVideo.controls = false;
-        // Hide video until the user clicks play.
-        reinforcerVideo.style.display = 'none';
-        // Show the play button.
-        playButton.style.display = 'block';
-
-        // On play button click, request fullscreen (fallback) and play the video.
-        playButton.addEventListener('click', function() {
-          // Request fullscreen as fallback (triggered by user gesture)
-          if (docElm.requestFullscreen) {
-            docElm.requestFullscreen().catch(err => {
-              console.error('Fullscreen request failed:', err);
-            });
-          } else if (docElm.mozRequestFullScreen) {
-            docElm.mozRequestFullScreen().catch(err => {
-              console.error('Fullscreen request failed:', err);
-            });
-          } else if (docElm.webkitRequestFullscreen) {
-            docElm.webkitRequestFullscreen().catch(err => {
-              console.error('Fullscreen request failed:', err);
-            });
-          } else if (docElm.msRequestFullscreen) {
-            docElm.msRequestFullscreen().catch(err => {
-              console.error('Fullscreen request failed:', err);
-            });
-          }
-          
-          reinforcerVideo.play().then(() => {
-            reinforcerVideo.style.display = 'block';
-            playButton.style.display = 'none';
-            // Show the overlay to block further user interaction with the video.
-            videoOverlayCover.style.display = 'block';
-          }).catch(err => {
-            console.error("Video play error:", err);
+      if (window.reinforcerOverlay && typeof window.reinforcerOverlay.bootstrapReinforcerPage === 'function') {
+        window.reinforcerOverlay.bootstrapReinforcerPage();
+      } else if (window.sessionHelpers && typeof window.sessionHelpers.runSessionFlow === 'function') {
+        const flow = window.sessionHelpers.runSessionFlow();
+        if (flow && typeof window.sessionHelpers.startNextStep === 'function') {
+          window.sessionHelpers.startNextStep(flow.reinforcerController, {
+            reinforcerType: flow.session && flow.session.selections
+              ? flow.session.selections.reinforcerType
+              : 'shortvideo'
           });
-        });
-
-        // Navigate to the next game when the video ends.
-        reinforcerVideo.addEventListener('ended', function() {
-          navigateToNextGame();
-        }, { once: true });
-      } else if (reinforcerType === "image") {
-        // If the reinforcer is an image, select a random image.
-        let imageSrc = "";
-        if (themeData.images && themeData.images.length > 0) {
-          const randomIndex = Math.floor(Math.random() * themeData.images.length);
-          imageSrc = themeData.images[randomIndex];
-        } else {
-          imageSrc = "../images/default_reinforcer.png";
         }
-        // Hide video and play button, then show the image.
-        reinforcerVideo.style.display = 'none';
-        playButton.style.display = 'none';
-        reinforcerImage.src = imageSrc;
-        reinforcerImage.style.display = 'block';
-        // After 10 seconds, navigate to the next game.
-        setTimeout(() => {
-          navigateToNextGame();
-        }, 10000);
-      } else if (reinforcerType === "social") {
-        reinforcerVideo.style.display = 'none';
-        playButton.style.display = 'none';
-        reinforcerImage.style.display = 'none';
-        if (socialContainer) {
-          socialContainer.style.display = 'flex';
-          const durationMs = 30000;
-          const startTime = Date.now();
-          let intervalId = null;
-          const updateProgress = () => {
-            const elapsed = Date.now() - startTime;
-            const remaining = Math.max(durationMs - elapsed, 0);
-            const progress = Math.min(elapsed / durationMs, 1);
-            if (socialProgressFill) {
-              socialProgressFill.style.width = `${progress * 100}%`;
-            }
-            if (socialProgressRemaining) {
-              socialProgressRemaining.textContent = String(Math.ceil(remaining / 1000));
-            }
-            if (remaining <= 0) {
-              if (intervalId !== null) {
-                clearInterval(intervalId);
-              }
-              navigateToNextGame();
-            }
-          };
-          updateProgress();
-          intervalId = setInterval(updateProgress, 200);
-        } else {
-          setTimeout(() => {
-            navigateToNextGame();
-          }, 30000);
-        }
-      }
-
-      const resolveGameFile = (gameId) => {
-        if (!gameId) {
-          return '';
-        }
-        if (window.sessionHelpers && typeof window.sessionHelpers.getGameFileById === 'function') {
-          return window.sessionHelpers.getGameFileById(gameId);
-        }
-        if (Array.isArray(window.gamesConfig)) {
-          const match = window.gamesConfig.find(game => game && game.id === gameId);
-          if (match && match.file) {
-            return match.file;
-          }
-        }
-        return `${gameId}.html`;
-      };
-
-      // Navigate to the next game.
-      function navigateToNextGame() {
-        if (window.sessionHelpers && typeof window.sessionHelpers.advanceToNextGame === 'function') {
-          sessionHelpers.advanceToNextGame();
-          return;
-        }
-        const selections = JSON.parse(localStorage.getItem('gameSelections')) || {};
-        let currentGameIndex = parseInt(localStorage.getItem('currentGameIndex'), 10);
-        currentGameIndex += 1;
-        localStorage.setItem('currentGameIndex', currentGameIndex);
-        if (Array.isArray(selections.gameOrder) && currentGameIndex < selections.gameOrder.length) {
-          const nextGameId = selections.gameOrder[currentGameIndex];
-          const nextGameFile = resolveGameFile(nextGameId);
-          if (nextGameFile) {
-            window.location.href = nextGameFile;
-            return;
-          }
-        }
-        window.location.href = "completion.html";
       }
     });
   </script>

--- a/sensoriel/shadow-match.html
+++ b/sensoriel/shadow-match.html
@@ -26,25 +26,43 @@
     }
     #activityNumberOverlay .number-text { font-weight: 700; }
 
+    .sensorial-header {
+      padding: clamp(8px, 1.5vh, 16px) clamp(16px, 3vw, 30px);
+      gap: 0;
+      max-height: clamp(72px, 10vh, 108px);
+    }
+
+    .sensorial-header-main {
+      min-height: clamp(52px, 8vh, 82px);
+    }
+
+    .sensorial-title {
+      font-size: clamp(1.45rem, 2.4vw, 2.1rem);
+    }
+
+    .sensorial-content {
+      padding: clamp(6px, 1.4vh, 14px) clamp(8px, 2vw, 18px);
+    }
+
     .game-container {
       display: none;
       width: 100%;
       height: 100%;
-      padding: clamp(20px, 4vh, 36px);
+      padding: clamp(10px, 2vh, 22px);
       background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(232, 242, 255, 0.9));
       border-radius: clamp(18px, 2.6vw, 28px);
       box-shadow: inset 0 0 0 1px rgba(15, 30, 60, 0.08);
-      display: flex;
       flex-direction: column;
-      gap: clamp(20px, 4vh, 32px);
+      gap: 0;
     }
 
     .shadow-layout {
       flex: 1 1 auto;
       min-height: 0;
       display: grid;
+      transform-origin: top center;
       grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
-      gap: clamp(20px, 4vw, 36px);
+      gap: clamp(10px, 2.4vw, 24px);
       align-items: stretch;
     }
 
@@ -52,22 +70,22 @@
     .shadow-pieces {
       background: rgba(255, 255, 255, 0.92);
       border-radius: clamp(16px, 3vw, 26px);
-      padding: clamp(18px, 3vh, 26px);
+      padding: clamp(8px, 1.6vh, 16px);
       box-shadow: inset 0 0 0 1px rgba(15, 30, 60, 0.07);
       display: grid;
-      gap: clamp(18px, 3vh, 26px);
+      gap: clamp(8px, 1.5vh, 16px);
       align-content: start;
       justify-items: center;
       overflow: hidden;
     }
 
     .shadow-pieces {
-      grid-template-columns: repeat(auto-fit, minmax(clamp(160px, 22vw, 220px), 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(clamp(88px, 13vw, 150px), 1fr));
       grid-auto-rows: minmax(clamp(120px, 18vh, 190px), auto);
     }
 
     .shadow-board {
-      grid-template-columns: repeat(auto-fit, minmax(clamp(200px, 24vw, 280px), 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(clamp(88px, 13vw, 150px), 1fr));
       grid-auto-rows: minmax(clamp(130px, 20vh, 210px), auto);
     }
 
@@ -81,7 +99,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: clamp(12px, 3vh, 24px);
+      padding: clamp(6px, 1.2vh, 14px);
       transition: border-color 0.2s ease, transform 0.2s ease;
       cursor: grab;
     }
@@ -89,7 +107,7 @@
     .shadow-slot::before {
       content: '';
       position: absolute;
-      inset: clamp(16px, 3vh, 26px);
+      inset: clamp(8px, 1.4vh, 16px);
       background: center / contain no-repeat var(--shadow-image);
       filter: brightness(0) contrast(1.35) opacity(0.9);
       transition: opacity 0.3s ease;
@@ -124,8 +142,9 @@
 
     .shadow-slot .placed-image {
       position: relative;
-      width: clamp(90px, 14vw, 180px);
-      max-height: clamp(120px, 18vh, 180px);
+      width: min(clamp(80px, 12vw, 160px), 100%);
+      max-width: 100%;
+      max-height: clamp(90px, 14vh, 150px);
       object-fit: contain;
       pointer-events: none;
       z-index: 2;
@@ -141,7 +160,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: clamp(12px, 2.4vh, 20px);
+      padding: clamp(6px, 1.2vh, 12px);
       cursor: grab;
       transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
       touch-action: none;
@@ -157,8 +176,9 @@
     }
 
     .shadow-token img {
-      width: clamp(80px, 12vw, 160px);
-      max-height: clamp(110px, 16vh, 170px);
+      width: min(clamp(72px, 11vw, 150px), 100%);
+      max-width: 100%;
+      max-height: clamp(80px, 13vh, 140px);
       object-fit: contain;
       pointer-events: none;
     }
@@ -193,13 +213,7 @@
       border-color: #16a34a;
     }
 
-    .shadow-status {
-      min-height: clamp(28px, 4vh, 36px);
-      font-size: clamp(1.05rem, 2vw, 1.3rem);
-      font-weight: 600;
-      color: #0f172a;
-      text-align: center;
-    }
+    .shadow-status { display: none; }
 
     @keyframes shake {
       0%, 100% { transform: translateX(0); }
@@ -209,11 +223,13 @@
 
     @media (max-width: 980px) {
       .shadow-layout {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+        gap: clamp(8px, 2vw, 18px);
       }
       .shadow-board,
       .shadow-pieces {
-        grid-template-columns: repeat(auto-fit, minmax(clamp(160px, 48vw, 240px), 1fr));
+        padding: clamp(6px, 1.2vh, 12px);
+        gap: clamp(6px, 1.1vh, 12px);
       }
     }
 
@@ -243,7 +259,6 @@
           <span class="sensorial-activity-number">–</span>
         </div>
       </div>
-      <p class="sensorial-subtitle">Glisse chaque image vers la silhouette identique.</p>
     </header>
     <main class="sensorial-content">
       <div class="game-container" id="shadowGame" aria-live="polite">
@@ -290,7 +305,7 @@
       const statusEl = document.getElementById('shadowStatus');
       const gameContainer = document.getElementById('shadowGame');
 
-      window.addEventListener('resize', adjustLayoutScale);
+      window.addEventListener('resize', fitShadowGame);
 
       document.addEventListener('DOMContentLoaded', () => {
         session = sessionHelpers.ensureCurrentGame('shadow-match');
@@ -323,21 +338,71 @@
       });
 
 
-      function adjustLayoutScale() {
+      function getCssPixels(value) {
+        const parsed = parseFloat(value);
+        return Number.isFinite(parsed) ? parsed : 0;
+      }
+
+      function getGridColumnCount(panel) {
+        if (!panel) { return 1; }
+        const template = getComputedStyle(panel).gridTemplateColumns;
+        if (!template || template === 'none') { return 1; }
+        return Math.max(template.split(' ').filter(Boolean).length, 1);
+      }
+
+      function calculateCellHeight(panel, itemCount) {
+        if (!panel || itemCount <= 0) { return 90; }
+        const styles = getComputedStyle(panel);
+        const columns = getGridColumnCount(panel);
+        const rows = Math.max(Math.ceil(itemCount / columns), 1);
+        const verticalPadding = getCssPixels(styles.paddingTop) + getCssPixels(styles.paddingBottom);
+        const totalGap = getCssPixels(styles.rowGap) * Math.max(rows - 1, 0);
+        const availableHeight = panel.clientHeight - verticalPadding - totalGap;
+        return Math.max(Math.floor(availableHeight / rows), 62);
+      }
+
+      function setPanelCellHeight(panel, selector, cellHeight) {
+        if (!panel || !Number.isFinite(cellHeight)) { return; }
+        panel.style.gridAutoRows = `${cellHeight}px`;
+        panel.querySelectorAll(selector).forEach((element) => {
+          element.style.height = `${cellHeight}px`;
+          element.style.minHeight = `${cellHeight}px`;
+        });
+      }
+
+      function fitPanelImages(panel, imageSelector, cellHeight) {
+        if (!panel || !Number.isFinite(cellHeight)) { return; }
+        const imageMaxHeight = Math.max(cellHeight - 18, 42);
+        panel.querySelectorAll(imageSelector).forEach((image) => {
+          image.style.maxHeight = `${imageMaxHeight}px`;
+        });
+      }
+
+      function fitShadowGame() {
         const layout = document.querySelector('.shadow-layout');
         if (!layout || !gameContainer) {
           return;
         }
+
         layout.style.transform = 'scale(1)';
-        const availableHeight = gameContainer.clientHeight;
-        const availableWidth = gameContainer.clientWidth;
+        const slots = boardEl.querySelectorAll('.shadow-slot');
+        const tokens = piecesEl.querySelectorAll('.shadow-token');
+        const itemCount = Math.max(slots.length, tokens.length, targetCount);
+        const boardCellHeight = calculateCellHeight(boardEl, itemCount);
+        const piecesCellHeight = calculateCellHeight(piecesEl, itemCount);
+
+        setPanelCellHeight(boardEl, '.shadow-slot', boardCellHeight);
+        setPanelCellHeight(piecesEl, '.shadow-token, .shadow-token-placeholder', piecesCellHeight);
+        fitPanelImages(boardEl, '.placed-image', boardCellHeight);
+        fitPanelImages(piecesEl, '.shadow-token img', piecesCellHeight);
+
         const requiredHeight = layout.scrollHeight;
         const requiredWidth = layout.scrollWidth;
-        const heightRatio = availableHeight > 0 ? availableHeight / requiredHeight : 1;
-        const widthRatio = availableWidth > 0 ? availableWidth / requiredWidth : 1;
+        const heightRatio = gameContainer.clientHeight > 0 ? gameContainer.clientHeight / requiredHeight : 1;
+        const widthRatio = gameContainer.clientWidth > 0 ? gameContainer.clientWidth / requiredWidth : 1;
         const ratio = Math.min(1, heightRatio, widthRatio);
         if (Number.isFinite(ratio) && ratio < 1) {
-          layout.style.transform = `scale(${Math.max(ratio, 0.65)})`;
+          layout.style.transform = `scale(${Math.max(ratio, 0.72)})`;
         }
       }
 
@@ -347,7 +412,7 @@
         statusEl.textContent = '';
         renderBoard(images);
         renderPieces(images);
-        requestAnimationFrame(adjustLayoutScale);
+        requestAnimationFrame(fitShadowGame);
       }
 
       function pickImages(count) {
@@ -447,7 +512,7 @@
         window.addEventListener('touchmove', handleDragMove, { passive: false });
         window.addEventListener('touchend', endDrag, { passive: false });
         window.addEventListener('touchcancel', cancelDrag, { passive: false });
-        statusEl.textContent = 'Dépose l’image sur la bonne ombre.';
+        statusEl.textContent = '';
       }
 
       function handleDragMove(event) {
@@ -499,11 +564,7 @@
         if (slot && slot.dataset.filled !== 'true') {
           completeAttempt(slot);
         } else {
-          if (slot && slot.dataset.filled === 'true') {
-            statusEl.textContent = 'Cette ombre est déjà remplie.';
-          } else {
-            statusEl.textContent = 'Essaie encore.';
-          }
+          statusEl.textContent = '';
           resetToken();
         }
       }
@@ -548,9 +609,7 @@
 
           playSound('word-reward-sound');
           remainingMatches -= 1;
-          statusEl.textContent = remainingMatches === 0
-            ? 'Bravo ! Toutes les ombres sont complétées.'
-            : 'Super ! Continue avec les autres ombres.';
+          statusEl.textContent = '';
 
           cleanupToken(token, placeholder, true);
 
@@ -561,7 +620,7 @@
           slot.classList.add('is-incorrect');
           token.classList.add('is-incorrect');
           playSound('error-sound');
-          statusEl.textContent = 'Ce n’est pas la bonne ombre.';
+          statusEl.textContent = '';
           setTimeout(() => {
             slot.classList.remove('is-incorrect');
             token.classList.remove('is-incorrect');

--- a/sensoriel/shadow-match.html
+++ b/sensoriel/shadow-match.html
@@ -107,7 +107,11 @@
     .shadow-slot::before {
       content: '';
       position: absolute;
-      inset: clamp(8px, 1.4vh, 16px);
+      top: 50%;
+      left: 50%;
+      width: var(--shadow-visual-size, min(clamp(72px, 11vw, 150px), calc(100% - 16px)));
+      height: var(--shadow-visual-size, min(clamp(72px, 11vw, 150px), calc(100% - 16px)));
+      transform: translate(-50%, -50%);
       background: center / contain no-repeat var(--shadow-image);
       filter: brightness(0) contrast(1.35) opacity(0.9);
       transition: opacity 0.3s ease;
@@ -378,9 +382,18 @@
 
       function fitPanelImages(panel, imageSelector, cellHeight) {
         if (!panel || !Number.isFinite(cellHeight)) { return; }
-        const imageMaxHeight = Math.max(cellHeight - 18, 42);
+        const imageMaxSize = Math.max(cellHeight - 18, 42);
         panel.querySelectorAll(imageSelector).forEach((image) => {
-          image.style.maxHeight = `${imageMaxHeight}px`;
+          image.style.width = `${imageMaxSize}px`;
+          image.style.maxWidth = '100%';
+          image.style.maxHeight = `${imageMaxSize}px`;
+        });
+      }
+
+      function fitShadowSilhouettes(cellHeight) {
+        const imageMaxSize = Math.max(cellHeight - 18, 42);
+        boardEl.querySelectorAll('.shadow-slot').forEach((slot) => {
+          slot.style.setProperty('--shadow-visual-size', `${imageMaxSize}px`);
         });
       }
 
@@ -406,6 +419,7 @@
         setPanelCellHeight(piecesEl, '.shadow-token, .shadow-token-placeholder', sharedCellHeight);
         fitPanelImages(boardEl, '.placed-image', sharedCellHeight);
         fitPanelImages(piecesEl, '.shadow-token img', sharedCellHeight);
+        fitShadowSilhouettes(sharedCellHeight);
 
         const requiredHeight = layout.scrollHeight;
         const requiredWidth = layout.scrollWidth;

--- a/sensoriel/shadow-match.html
+++ b/sensoriel/shadow-match.html
@@ -350,10 +350,10 @@
         return Math.max(template.split(' ').filter(Boolean).length, 1);
       }
 
-      function calculateCellHeight(panel, itemCount) {
+      function calculateCellHeight(panel, itemCount, forcedColumns) {
         if (!panel || itemCount <= 0) { return 90; }
         const styles = getComputedStyle(panel);
-        const columns = getGridColumnCount(panel);
+        const columns = forcedColumns || getGridColumnCount(panel);
         const rows = Math.max(Math.ceil(itemCount / columns), 1);
         const verticalPadding = getCssPixels(styles.paddingTop) + getCssPixels(styles.paddingBottom);
         const horizontalPadding = getCssPixels(styles.paddingLeft) + getCssPixels(styles.paddingRight);
@@ -394,10 +394,14 @@
         const slots = boardEl.querySelectorAll('.shadow-slot');
         const tokens = piecesEl.querySelectorAll('.shadow-token');
         const itemCount = Math.max(slots.length, tokens.length, targetCount);
-        const boardCellHeight = calculateCellHeight(boardEl, itemCount);
-        const piecesCellHeight = calculateCellHeight(piecesEl, itemCount);
+        const sharedColumnCount = Math.max(getGridColumnCount(boardEl), getGridColumnCount(piecesEl), 1);
+        const boardCellHeight = calculateCellHeight(boardEl, itemCount, sharedColumnCount);
+        const piecesCellHeight = calculateCellHeight(piecesEl, itemCount, sharedColumnCount);
         const sharedCellHeight = Math.min(boardCellHeight, piecesCellHeight);
+        const sharedColumns = `repeat(${sharedColumnCount}, ${sharedCellHeight}px)`;
 
+        boardEl.style.gridTemplateColumns = sharedColumns;
+        piecesEl.style.gridTemplateColumns = sharedColumns;
         setPanelCellHeight(boardEl, '.shadow-slot', sharedCellHeight);
         setPanelCellHeight(piecesEl, '.shadow-token, .shadow-token-placeholder', sharedCellHeight);
         fitPanelImages(boardEl, '.placed-image', sharedCellHeight);
@@ -669,6 +673,7 @@
         }
         placeholder.remove();
         dragState = null;
+        requestAnimationFrame(fitShadowGame);
       }
 
       function playSound(id) {

--- a/sensoriel/shadow-match.html
+++ b/sensoriel/shadow-match.html
@@ -61,7 +61,7 @@
       min-height: 0;
       display: grid;
       transform-origin: top center;
-      grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: clamp(10px, 2.4vw, 24px);
       align-items: stretch;
     }
@@ -223,7 +223,7 @@
 
     @media (max-width: 980px) {
       .shadow-layout {
-        grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+        grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: clamp(8px, 2vw, 18px);
       }
       .shadow-board,
@@ -396,11 +396,12 @@
         const itemCount = Math.max(slots.length, tokens.length, targetCount);
         const boardCellHeight = calculateCellHeight(boardEl, itemCount);
         const piecesCellHeight = calculateCellHeight(piecesEl, itemCount);
+        const sharedCellHeight = Math.min(boardCellHeight, piecesCellHeight);
 
-        setPanelCellHeight(boardEl, '.shadow-slot', boardCellHeight);
-        setPanelCellHeight(piecesEl, '.shadow-token, .shadow-token-placeholder', piecesCellHeight);
-        fitPanelImages(boardEl, '.placed-image', boardCellHeight);
-        fitPanelImages(piecesEl, '.shadow-token img', piecesCellHeight);
+        setPanelCellHeight(boardEl, '.shadow-slot', sharedCellHeight);
+        setPanelCellHeight(piecesEl, '.shadow-token, .shadow-token-placeholder', sharedCellHeight);
+        fitPanelImages(boardEl, '.placed-image', sharedCellHeight);
+        fitPanelImages(piecesEl, '.shadow-token img', sharedCellHeight);
 
         const requiredHeight = layout.scrollHeight;
         const requiredWidth = layout.scrollWidth;

--- a/sensoriel/shadow-match.html
+++ b/sensoriel/shadow-match.html
@@ -58,7 +58,7 @@
       gap: clamp(18px, 3vh, 26px);
       align-content: start;
       justify-items: center;
-      overflow-y: auto;
+      overflow: hidden;
     }
 
     .shadow-pieces {
@@ -298,6 +298,8 @@
       const statusEl = document.getElementById('shadowStatus');
       const gameContainer = document.getElementById('shadowGame');
 
+      window.addEventListener('resize', adjustLayoutScale);
+
       document.addEventListener('DOMContentLoaded', () => {
         session = sessionHelpers.ensureCurrentGame('shadow-match');
         if (!session) { return; }
@@ -328,12 +330,28 @@
         }, session);
       });
 
+
+      function adjustLayoutScale() {
+        const layout = document.querySelector('.shadow-layout');
+        if (!layout || !gameContainer) {
+          return;
+        }
+        layout.style.transform = 'scale(1)';
+        const availableHeight = gameContainer.clientHeight;
+        const requiredHeight = layout.scrollHeight;
+        if (availableHeight > 0 && requiredHeight > availableHeight) {
+          const ratio = Math.max(availableHeight / requiredHeight, 0.7);
+          layout.style.transform = `scale(${ratio})`;
+        }
+      }
+
       function startGame() {
         const images = pickImages(targetCount);
         remainingMatches = images.length;
         statusEl.textContent = '';
         renderBoard(images);
         renderPieces(images);
+        requestAnimationFrame(adjustLayoutScale);
       }
 
       function pickImages(count) {

--- a/sensoriel/shadow-match.html
+++ b/sensoriel/shadow-match.html
@@ -63,18 +63,18 @@
 
     .shadow-pieces {
       grid-template-columns: repeat(auto-fit, minmax(clamp(160px, 22vw, 220px), 1fr));
-      grid-auto-rows: minmax(clamp(160px, 24vh, 230px), auto);
+      grid-auto-rows: minmax(clamp(120px, 18vh, 190px), auto);
     }
 
     .shadow-board {
       grid-template-columns: repeat(auto-fit, minmax(clamp(200px, 24vw, 280px), 1fr));
-      grid-auto-rows: minmax(clamp(190px, 28vh, 260px), auto);
+      grid-auto-rows: minmax(clamp(130px, 20vh, 210px), auto);
     }
 
     .shadow-slot {
       position: relative;
       width: 100%;
-      min-height: clamp(170px, 28vh, 260px);
+      min-height: clamp(130px, 20vh, 210px);
       border-radius: clamp(18px, 3vw, 26px);
       border: 3px dashed rgba(30, 64, 175, 0.38);
       background: rgba(148, 163, 184, 0.18);
@@ -124,8 +124,8 @@
 
     .shadow-slot .placed-image {
       position: relative;
-      width: clamp(120px, 20vw, 220px);
-      max-height: clamp(160px, 24vh, 220px);
+      width: clamp(90px, 14vw, 180px);
+      max-height: clamp(120px, 18vh, 180px);
       object-fit: contain;
       pointer-events: none;
       z-index: 2;
@@ -133,7 +133,7 @@
 
     .shadow-token {
       width: 100%;
-      min-height: clamp(150px, 24vh, 220px);
+      min-height: clamp(120px, 18vh, 190px);
       border-radius: clamp(16px, 3vw, 24px);
       border: 3px solid transparent;
       background: #fff;
@@ -151,14 +151,14 @@
 
     .shadow-token-placeholder {
       width: 100%;
-      min-height: clamp(150px, 24vh, 220px);
+      min-height: clamp(120px, 18vh, 190px);
       border-radius: clamp(16px, 3vw, 24px);
       border: 2px dashed transparent;
     }
 
     .shadow-token img {
-      width: clamp(110px, 18vw, 200px);
-      max-height: clamp(140px, 22vh, 210px);
+      width: clamp(80px, 12vw, 160px);
+      max-height: clamp(110px, 16vh, 170px);
       object-fit: contain;
       pointer-events: none;
     }
@@ -193,13 +193,6 @@
       border-color: #16a34a;
     }
 
-    .shadow-instruction {
-      font-size: clamp(1rem, 1.8vw, 1.25rem);
-      color: #475569;
-      text-align: center;
-      margin: 0;
-    }
-
     .shadow-status {
       min-height: clamp(28px, 4vh, 36px);
       font-size: clamp(1.05rem, 2vw, 1.3rem);
@@ -226,13 +219,13 @@
 
     @media (max-height: 820px) {
       .shadow-slot {
-        min-height: clamp(150px, 26vh, 220px);
+        min-height: clamp(120px, 18vh, 180px);
       }
       .shadow-token {
-        min-height: clamp(140px, 22vh, 200px);
+        min-height: clamp(110px, 16vh, 170px);
       }
       .shadow-token img {
-        max-height: clamp(120px, 20vh, 190px);
+        max-height: clamp(95px, 14vh, 150px);
       }
     }
   </style>
@@ -258,7 +251,6 @@
           <section class="shadow-pieces" id="shadowPieces" aria-label="Images à glisser"></section>
           <section class="shadow-board" id="shadowBoard" aria-label="Ombres à compléter"></section>
         </div>
-        <p class="shadow-instruction">Glisse chaque image vers son ombre. Quand toutes les silhouettes sont remplies, la récompense apparaît.</p>
         <p class="shadow-status" id="shadowStatus" aria-live="assertive"></p>
       </div>
     </main>
@@ -338,10 +330,14 @@
         }
         layout.style.transform = 'scale(1)';
         const availableHeight = gameContainer.clientHeight;
+        const availableWidth = gameContainer.clientWidth;
         const requiredHeight = layout.scrollHeight;
-        if (availableHeight > 0 && requiredHeight > availableHeight) {
-          const ratio = Math.max(availableHeight / requiredHeight, 0.7);
-          layout.style.transform = `scale(${ratio})`;
+        const requiredWidth = layout.scrollWidth;
+        const heightRatio = availableHeight > 0 ? availableHeight / requiredHeight : 1;
+        const widthRatio = availableWidth > 0 ? availableWidth / requiredWidth : 1;
+        const ratio = Math.min(1, heightRatio, widthRatio);
+        if (Number.isFinite(ratio) && ratio < 1) {
+          layout.style.transform = `scale(${Math.max(ratio, 0.65)})`;
         }
       }
 

--- a/sensoriel/shadow-match.html
+++ b/sensoriel/shadow-match.html
@@ -356,9 +356,15 @@
         const columns = getGridColumnCount(panel);
         const rows = Math.max(Math.ceil(itemCount / columns), 1);
         const verticalPadding = getCssPixels(styles.paddingTop) + getCssPixels(styles.paddingBottom);
-        const totalGap = getCssPixels(styles.rowGap) * Math.max(rows - 1, 0);
-        const availableHeight = panel.clientHeight - verticalPadding - totalGap;
-        return Math.max(Math.floor(availableHeight / rows), 62);
+        const horizontalPadding = getCssPixels(styles.paddingLeft) + getCssPixels(styles.paddingRight);
+        const totalRowGap = getCssPixels(styles.rowGap) * Math.max(rows - 1, 0);
+        const totalColumnGap = getCssPixels(styles.columnGap) * Math.max(columns - 1, 0);
+        const availableHeight = panel.clientHeight - verticalPadding - totalRowGap;
+        const availableWidth = panel.clientWidth - horizontalPadding - totalColumnGap;
+        const heightPerRow = availableHeight / rows;
+        const widthPerColumn = availableWidth / columns;
+        const squareSize = Math.min(heightPerRow, widthPerColumn);
+        return Math.max(Math.floor(squareSize), 62);
       }
 
       function setPanelCellHeight(panel, selector, cellHeight) {

--- a/sensoriel/shadow-match.html
+++ b/sensoriel/shadow-match.html
@@ -144,7 +144,7 @@
       padding: clamp(12px, 2.4vh, 20px);
       cursor: grab;
       transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-      touch-action: manipulation;
+      touch-action: none;
       user-select: none;
       position: relative;
     }

--- a/sensoriel/shadow-match.html
+++ b/sensoriel/shadow-match.html
@@ -283,6 +283,16 @@
       let remainingMatches = 0;
       let dragState = null;
 
+      function getPoint(event) {
+        if (event.touches && event.touches.length > 0) {
+          return event.touches[0];
+        }
+        if (event.changedTouches && event.changedTouches.length > 0) {
+          return event.changedTouches[0];
+        }
+        return event;
+      }
+
       const boardEl = document.getElementById('shadowBoard');
       const piecesEl = document.getElementById('shadowPieces');
       const statusEl = document.getElementById('shadowStatus');
@@ -372,6 +382,7 @@
           token.appendChild(img);
 
           token.addEventListener('pointerdown', (event) => beginDrag(event, token));
+          token.addEventListener('touchstart', (event) => beginDrag(event, token), { passive: false });
 
           piecesEl.appendChild(token);
         });
@@ -382,6 +393,7 @@
           return;
         }
         event.preventDefault();
+        const point = getPoint(event);
 
         const rect = token.getBoundingClientRect();
         const placeholder = document.createElement('div');
@@ -393,9 +405,9 @@
         dragState = {
           token,
           placeholder,
-          pointerId: event.pointerId,
-          offsetX: event.clientX - rect.left,
-          offsetY: event.clientY - rect.top,
+          pointerId: typeof event.pointerId === 'number' ? event.pointerId : null,
+          offsetX: point.clientX - rect.left,
+          offsetY: point.clientY - rect.top,
           currentSlot: null
         };
 
@@ -408,23 +420,33 @@
         token.style.margin = '0';
         token.style.zIndex = '2000';
 
-        token.setPointerCapture(event.pointerId);
+        if (typeof event.pointerId === 'number' && token.setPointerCapture) {
+          token.setPointerCapture(event.pointerId);
+        }
         document.body.appendChild(token);
 
-        moveToken(event.clientX, event.clientY);
+        moveToken(point.clientX, point.clientY);
 
-        token.addEventListener('pointermove', handleDragMove);
-        token.addEventListener('pointerup', endDrag);
-        token.addEventListener('pointercancel', cancelDrag);
+        window.addEventListener('pointermove', handleDragMove, { passive: false });
+        window.addEventListener('pointerup', endDrag, { passive: false });
+        window.addEventListener('pointercancel', cancelDrag, { passive: false });
+        window.addEventListener('touchmove', handleDragMove, { passive: false });
+        window.addEventListener('touchend', endDrag, { passive: false });
+        window.addEventListener('touchcancel', cancelDrag, { passive: false });
         statusEl.textContent = 'Dépose l’image sur la bonne ombre.';
       }
 
       function handleDragMove(event) {
-        if (!dragState || event.pointerId !== dragState.pointerId) {
+        if (!dragState) {
           return;
         }
-        moveToken(event.clientX, event.clientY);
-        highlightSlot(event.clientX, event.clientY);
+        if (dragState.pointerId !== null && typeof event.pointerId === 'number' && event.pointerId !== dragState.pointerId) {
+          return;
+        }
+        event.preventDefault();
+        const point = getPoint(event);
+        moveToken(point.clientX, point.clientY);
+        highlightSlot(point.clientX, point.clientY);
       }
 
       function moveToken(clientX, clientY) {
@@ -446,14 +468,20 @@
       }
 
       function endDrag(event) {
-        if (!dragState || event.pointerId !== dragState.pointerId) {
+        if (!dragState) {
+          return;
+        }
+        if (dragState.pointerId !== null && typeof event.pointerId === 'number' && event.pointerId !== dragState.pointerId) {
           return;
         }
 
         const { token } = dragState;
-        token.releasePointerCapture(event.pointerId);
+        if (typeof event.pointerId === 'number' && token.releasePointerCapture) {
+          token.releasePointerCapture(event.pointerId);
+        }
 
-        const slot = findSlotAtPoint(event.clientX, event.clientY);
+        const point = getPoint(event);
+        const slot = findSlotAtPoint(point.clientX, point.clientY);
         if (slot && slot.dataset.filled !== 'true') {
           completeAttempt(slot);
         } else {
@@ -467,7 +495,10 @@
       }
 
       function cancelDrag(event) {
-        if (!dragState || event.pointerId !== dragState.pointerId) {
+        if (!dragState) {
+          return;
+        }
+        if (dragState.pointerId !== null && typeof event.pointerId === 'number' && event.pointerId !== dragState.pointerId) {
           return;
         }
         resetToken();
@@ -544,9 +575,12 @@
         token.style.width = '';
         token.style.height = '';
 
-        token.removeEventListener('pointermove', handleDragMove);
-        token.removeEventListener('pointerup', endDrag);
-        token.removeEventListener('pointercancel', cancelDrag);
+        window.removeEventListener('pointermove', handleDragMove);
+        window.removeEventListener('pointerup', endDrag);
+        window.removeEventListener('pointercancel', cancelDrag);
+        window.removeEventListener('touchmove', handleDragMove);
+        window.removeEventListener('touchend', endDrag);
+        window.removeEventListener('touchcancel', cancelDrag);
 
         if (lockInPlace) {
           token.remove();


### PR DESCRIPTION
### Motivation
- Consolidate repeated session, theme resolution, and reinforcer/fullscreen setup logic into shared JS helpers so pages stop re-implementing the same flow and the reinforcer progression is centralized.
- Define a single canonical flow (load session → resolve theme → ensure game order → run overlay/reinforcer → advance) and expose clear function boundaries to make page bootstrap and transitions simpler and consistent.

### Description
- Added helpers to `sensoriel/js/session-helpers.js`: `resolveThemeDataFromSession`, `ensureGameOrder`, `runSessionFlow`, and `startNextStep`, and exported them on `window.sessionHelpers` for reuse.
- Extended `sensoriel/js/reinforcer-overlay.js` with `bootstrapReinforcerPage` which ensures fullscreen preference and boots the canonical session/reinforcer flow via the shared helpers.
- Updated `sensoriel/reinforcer.html` to load the shared overlay and fullscreen modules and call the new bootstrap API instead of inlining session/theme/fullscreen/reinforcer logic.
- Updated `sensoriel/base.html` (representative game page) to use `runSessionFlow`, `showActivityOverlay`, and `startNextStep` from the shared helpers and to consume the returned `reinforcerController` rather than re-creating reinforcer flow inline.

### Testing
- Applied and committed the patches successfully (`apply_patch` and `git commit` completed and reported changed files). 
- Verified repository state after the change with `git status --short` which returned a clean working tree after the commit.
- Performed file inspections (`sed`/`rg`) to confirm the new functions and updated pages are present and wired; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d251b54483258a4cbeb14dd82a8c)