### PR TITLE
Add Jiao Switch Heroes to Pedagogy resources

### DIFF
--- a/ressources/index.html
+++ b/ressources/index.html
@@ -136,6 +136,21 @@
             <a class="resource-link" href="https://talksense.weebly.com/" target="_blank" rel="noopener" data-fr="Visiter" data-en="Visit" data-ja="見る">Visiter <span>↗</span></a>
           </div>
         </li>
+
+        <li class="resource-item">
+          <div class="resource-body">
+            <div class="resource-header">
+              <span class="resource-tag" data-fr="Anglais" data-en="English" data-ja="英語">Switchs</span>
+              <h3 class="resource-title">
+                <a href="https://jiao.life/switch-heroes/" target="_blank" rel="noopener">Switch Heroes (Jiao)</a>
+              </h3>
+            </div>
+            <p class="resource-description" data-fr="Ressource de Jiao présentant les Seven Stages of Switch Development, un cadre de progression pour les utilisateurs de switchs, leurs familles et les intervenants qui les accompagnent. Les personnages et histoires rendent les étapes plus accessibles, tout en offrant des repères souples pour observer les progrès et adapter les objectifs d’apprentissage."
+               data-en="A Jiao resource presenting the Seven Stages of Switch Development, a progression framework for switch users, their families, and the professionals who support them. The characters and stories make the stages easier to understand while offering flexible reference points for observing progress and adapting learning goals."
+               data-ja="Jiao による、スイッチ利用者、その家族、支援者のための「Seven Stages of Switch Development」を紹介するリソースです。親しみやすいキャラクターと物語を通して各段階を理解しやすくし、進歩の観察や学習目標の調整に使える柔軟な目安を提供します。"></p>
+            <a class="resource-link" href="https://jiao.life/switch-heroes/" target="_blank" rel="noopener" data-fr="Visiter" data-en="Visit" data-ja="見る">Visiter <span>↗</span></a>
+          </div>
+        </li>
        
       </ul>
     </section>

--- a/ressources/index.html
+++ b/ressources/index.html
@@ -145,9 +145,9 @@
                 <a href="https://jiao.life/switch-heroes/" target="_blank" rel="noopener">Switch Heroes (Jiao)</a>
               </h3>
             </div>
-            <p class="resource-description" data-fr="Ressource de Jiao présentant les Seven Stages of Switch Development, un cadre de progression pour les utilisateurs de switchs, leurs familles et les intervenants qui les accompagnent. Les personnages et histoires rendent les étapes plus accessibles, tout en offrant des repères souples pour observer les progrès et adapter les objectifs d’apprentissage."
-               data-en="A Jiao resource presenting the Seven Stages of Switch Development, a progression framework for switch users, their families, and the professionals who support them. The characters and stories make the stages easier to understand while offering flexible reference points for observing progress and adapting learning goals."
-               data-ja="Jiao による、スイッチ利用者、その家族、支援者のための「Seven Stages of Switch Development」を紹介するリソースです。親しみやすいキャラクターと物語を通して各段階を理解しやすくし、進歩の観察や学習目標の調整に使える柔軟な目安を提供します。"></p>
+            <p class="resource-description" data-fr="Une ressource de Jiao autour des Seven Stages of Switch Development. L’idée est simple et bien présentée : suivre, étape par étape, comment une personne apprend à utiliser une switch. Les personnages et les petites histoires rendent le tout plus concret, autant pour les familles que pour les intervenants."
+               data-en="A Jiao resource about the Seven Stages of Switch Development. The idea is simple and clearly presented: follow, step by step, how someone learns to use a switch. The characters and short stories make it feel more concrete and approachable for families and support teams."
+               data-ja="Jiao による「Seven Stages of Switch Development」のリソースです。スイッチの使い方を身につけていく流れを、段階ごとにわかりやすく見られます。キャラクターや短いストーリーがあるので、家族や支援者にもイメージしやすい内容です。"></p>
             <a class="resource-link" href="https://jiao.life/switch-heroes/" target="_blank" rel="noopener" data-fr="Visiter" data-en="Visit" data-ja="見る">Visiter <span>↗</span></a>
           </div>
         </li>


### PR DESCRIPTION
### Motivation
- Provide a direct link and short, localized description for Jiao’s Switch Heroes so educators and therapists can discover the Seven Stages of Switch Development framework from the pedagogy resources list.

### Description
- Added a new resource entry in `ressources/index.html` under the “Pédagogie” section linking to `https://jiao.life/switch-heroes/` with French, English and Japanese localized descriptions and a "Visiter" link.

### Testing
- Verified the modified HTML parses with `python - <<'PY' ... HTMLParser ...` which completed successfully and checked the file with `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7e7e6fb48325b147e7f5afa68194)