### PR TITLE
Add 'Watch to Play' eyegaze experience with local/YouTube/library sources

### DIFF
--- a/css/watch-to-play.css
+++ b/css/watch-to-play.css
@@ -1,0 +1,262 @@
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  overflow: hidden;
+  background: #050505;
+  font-family: Arial, sans-serif;
+}
+
+#language-toggle {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 99999;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 2px solid #009688;
+  background: #fff;
+  color: #009688;
+  font-weight: 700;
+  cursor: pointer;
+  user-select: none;
+}
+
+.watch-panel {
+  max-width: 980px !important;
+  border: 4px solid #008080 !important;
+  border-radius: 16px !important;
+  padding: 24px !important;
+}
+
+.picker-panel {
+  width: min(95vw, 1280px) !important;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.watch-intro {
+  color: #333;
+  font-size: 1.1rem;
+  line-height: 1.45;
+  margin: 12px auto 4px;
+  max-width: 780px;
+}
+
+.source-pill-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(170px, 1fr));
+  gap: 22px;
+  width: 100%;
+  margin-top: 18px;
+}
+
+.source-pill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 92px;
+  border: 3px solid #009688;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #ffffff 0%, #edfffc 100%);
+  color: #00695c;
+  font-size: 1.45rem;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 6px 14px rgba(0, 150, 136, 0.18);
+  transition: transform 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.source-pill:hover,
+.source-pill:focus-visible {
+  background: #009688;
+  color: #fff;
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 10px 20px rgba(0, 150, 136, 0.28);
+  outline: none;
+}
+
+.source-pill-icon {
+  font-size: 1.7rem;
+}
+
+.picker-section {
+  width: 100%;
+}
+
+.category-filter {
+  margin: 12px 0 18px;
+}
+
+.category-filter select,
+.control-panel-input {
+  border: 2px solid #009688;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 1rem;
+}
+
+.input-row {
+  width: 100%;
+  justify-content: center;
+  gap: 10px;
+}
+
+.input-row .control-panel-input {
+  width: min(680px, 70vw);
+}
+
+.video-choice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 16px;
+  width: 100%;
+  max-height: 52vh;
+  overflow-y: auto;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.video-choice-card {
+  min-height: 154px;
+  border: 4px solid transparent;
+  border-radius: 14px;
+  background: #f7f7f7;
+  color: #111;
+  cursor: pointer;
+  overflow: hidden;
+  padding: 0;
+  text-align: center;
+  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.18);
+}
+
+.video-choice-card.selected {
+  border-color: #ffcc00;
+  box-shadow: 0 0 0 4px rgba(255, 204, 0, 0.35), 0 5px 16px rgba(0, 0, 0, 0.25);
+}
+
+.video-choice-thumb {
+  height: 105px;
+  background-color: #111;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.video-choice-title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 8px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.selection-preview {
+  color: #333;
+  margin: 14px auto;
+  font-weight: 700;
+}
+
+.secondary-button {
+  background-color: #607d8b !important;
+}
+
+.picker-actions {
+  gap: 12px;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+#watch-stage {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  z-index: 20000;
+  cursor: none;
+}
+
+#watch-frame {
+  position: absolute;
+  inset: 3vh 3vw;
+  border-radius: 18px;
+  overflow: hidden;
+  background: #000;
+  box-shadow: 0 0 0 10px rgba(255, 255, 255, 0.06);
+}
+
+#watch-video,
+#youtube-player,
+#youtube-player iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+#watch-video {
+  display: block;
+  object-fit: contain;
+  background: #000;
+}
+
+#youtube-player {
+  display: none;
+  pointer-events: none;
+}
+
+#watch-hint {
+  position: absolute;
+  left: 50%;
+  bottom: 22px;
+  transform: translateX(-50%);
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.62);
+  color: #fff;
+  font-weight: 700;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+#watch-hint.is-hidden {
+  opacity: 0;
+}
+
+#exit-watch-button {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 20010;
+  cursor: pointer;
+}
+
+#gazePointer {
+  position: fixed;
+  width: 36px;
+  height: 36px;
+  margin-left: -18px;
+  margin-top: -18px;
+  border: 3px solid #00e5ff;
+  border-radius: 50%;
+  background: rgba(0, 229, 255, 0.24);
+  box-shadow: 0 0 14px rgba(0, 229, 255, 0.8);
+  pointer-events: none;
+  z-index: 25000;
+  transform: translate(-100px, -100px);
+}
+
+@media (max-width: 760px) {
+  .source-pill-row {
+    grid-template-columns: 1fr;
+  }
+
+  .input-row {
+    flex-direction: column;
+  }
+
+  .input-row .control-panel-input {
+    width: 90%;
+  }
+}

--- a/eyegaze/index.html
+++ b/eyegaze/index.html
@@ -191,6 +191,14 @@
       </a>
     </div>
     <div class="tile">
+      <a href="watch-to-play/index.html">
+        <img src="../images/custom-videos.svg" alt="Regarder pour jouer">
+        <div class="tile-title">
+          <h3 data-fr="Regarder pour jouer" data-en="Watch to Play" data-ja="見て再生">Regarder pour jouer</h3>
+        </div>
+      </a>
+    </div>
+    <div class="tile">
       <a href="flappyeyegaze/index.html">
         <img src="../images/birds.png" alt="Birds">
         <div class="tile-title">

--- a/eyegaze/watch-to-play/index.html
+++ b/eyegaze/watch-to-play/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Regarder pour jouer</title>
+  <link rel="stylesheet" href="../../css/choiceeyegaze.css" />
+  <link rel="stylesheet" href="../../css/watch-to-play.css" />
+</head>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-B45TJG4GBJ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-B45TJG4GBJ');
+</script>
+<body>
+  <button id="language-toggle" title="Changer de langue / Change language">FR / EN</button>
+
+  <div id="source-modal" class="modal" style="display:flex;">
+    <div id="control-panel-options" class="watch-panel">
+      <div id="options-title-bar">
+        <h2 id="options-main-title" class="translate" data-fr="Regarder pour jouer" data-en="Watch to Play" data-ja="見て再生">
+          Regarder pour jouer
+        </h2>
+      </div>
+
+      <p class="watch-intro translate"
+         data-fr="Choisissez une source vidéo. La vidéo jouera seulement quand le pointeur regarde l'écran, avec une pause de 2 secondes avant l'arrêt."
+         data-en="Choose a video source. The video will play only while the pointer is looking at the screen, with a 2-second grace period before pausing."
+         data-ja="動画ソースを選択してください。ポインターが画面を見ている間だけ再生され、停止前に2秒の猶予があります。">
+        Choisissez une source vidéo. La vidéo jouera seulement quand le pointeur regarde l'écran, avec une pause de 2 secondes avant l'arrêt.
+      </p>
+
+      <div id="mode-divider"></div>
+
+      <div class="source-pill-row" role="group" aria-label="Video source">
+        <button class="source-pill" data-source="local">
+          <span class="source-pill-icon">📁</span>
+          <span class="translate" data-fr="Local" data-en="Local" data-ja="ローカル">Local</span>
+        </button>
+        <button class="source-pill" data-source="youtube">
+          <span class="source-pill-icon">▶</span>
+          <span class="translate" data-fr="YouTube" data-en="YouTube" data-ja="YouTube">YouTube</span>
+        </button>
+        <button class="source-pill" data-source="library">
+          <span class="source-pill-icon">🎬</span>
+          <span class="translate" data-fr="Bibliothèque" data-en="Library" data-ja="ライブラリ">Bibliothèque</span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div id="video-picker-modal" class="modal" style="display:none;">
+    <div id="control-panel-options" class="watch-panel picker-panel">
+      <div id="control-panel-title-wrapper">
+        <h2 id="picker-title" class="translate" data-fr="Choisir une vidéo" data-en="Choose a Video" data-ja="動画を選択">
+          Choisir une vidéo
+        </h2>
+      </div>
+
+      <div id="picker-description" class="watch-intro"></div>
+
+      <div id="library-controls" class="picker-section" hidden>
+        <div id="category-filter" class="category-filter">
+          <label for="categorySelect" class="translate" data-fr="Catégorie:" data-en="Category:" data-ja="カテゴリー：">Catégorie:</label>
+          <select id="categorySelect">
+            <option value="all" class="translate" data-fr="-- Tous --" data-en="-- All --" data-ja="-- すべて --">-- Tous --</option>
+          </select>
+        </div>
+        <div id="library-grid" class="video-choice-grid" aria-live="polite"></div>
+      </div>
+
+      <div id="local-controls" class="picker-section" hidden>
+        <div class="actions-row">
+          <button id="choose-local-video-button" class="button translate" data-fr="Ajouter une vidéo" data-en="Add a Video" data-ja="動画を追加">Ajouter une vidéo</button>
+          <input type="file" id="local-video-input" accept="video/*" style="display:none;">
+        </div>
+        <div id="local-selection-preview" class="selection-preview translate" data-fr="Aucune vidéo locale sélectionnée." data-en="No local video selected." data-ja="ローカル動画が選択されていません。">
+          Aucune vidéo locale sélectionnée.
+        </div>
+      </div>
+
+      <div id="youtube-controls" class="picker-section" hidden>
+        <div class="actions-row input-row">
+          <input id="youtube-url-input" type="text" placeholder="URL YouTube" class="control-panel-input" />
+          <button id="add-youtube-button" class="button translate" data-fr="Ajouter URL" data-en="Add URL" data-ja="URLを追加">Ajouter URL</button>
+        </div>
+        <div class="actions-row input-row">
+          <input id="youtube-playlist-input" type="text" placeholder="URL de playlist (https://www.youtube.com/playlist?list=...)" class="control-panel-input" />
+          <button id="import-playlist-button" class="button translate" data-fr="Importer playlist" data-en="Import Playlist" data-ja="プレイリストをインポート">Importer playlist</button>
+        </div>
+        <div id="youtube-status" class="selection-preview"></div>
+        <div id="youtube-grid" class="video-choice-grid" aria-live="polite"></div>
+      </div>
+
+      <div class="actions-row picker-actions">
+        <button id="back-to-sources-button" class="button secondary-button translate" data-fr="Retour" data-en="Back" data-ja="戻る">Retour</button>
+        <button id="start-watch-button" class="button translate" data-fr="Commencer" data-en="Start" data-ja="開始" disabled>Commencer</button>
+      </div>
+    </div>
+  </div>
+
+  <main id="watch-stage" style="display:none;">
+    <div id="watch-frame" aria-label="Watch area">
+      <video id="watch-video" playsinline preload="metadata"></video>
+      <div id="youtube-player"></div>
+      <div id="watch-hint" class="translate" data-fr="Regardez la vidéo pour lancer la lecture" data-en="Look at the video to play" data-ja="動画を見て再生">
+        Regardez la vidéo pour lancer la lecture
+      </div>
+    </div>
+    <button id="exit-watch-button" class="button translate" data-fr="Quitter" data-en="Exit" data-ja="終了">Quitter</button>
+  </main>
+
+  <div id="gazePointer" aria-hidden="true"></div>
+
+  <script src="https://www.youtube.com/iframe_api"></script>
+  <script src="../../js/config.js"></script>
+  <script src="../../js/choiceArray.js"></script>
+  <script src="../../js/watchToPlay.js"></script>
+  <script src="../../js/translationmain.js"></script>
+  <script>
+    document.getElementById('language-toggle')?.addEventListener('pointerup', toggleLanguage);
+  </script>
+</body>
+</html>

--- a/js/watchToPlay.js
+++ b/js/watchToPlay.js
@@ -1,0 +1,469 @@
+(function () {
+  'use strict';
+
+  const PAUSE_GRACE_MS = 2000;
+  const YOUTUBE_STORAGE_KEY = 'watchToPlayYoutubeUrls';
+
+  const sourceModal = document.getElementById('source-modal');
+  const pickerModal = document.getElementById('video-picker-modal');
+  const pickerTitle = document.getElementById('picker-title');
+  const pickerDescription = document.getElementById('picker-description');
+  const libraryControls = document.getElementById('library-controls');
+  const localControls = document.getElementById('local-controls');
+  const youtubeControls = document.getElementById('youtube-controls');
+  const categorySelect = document.getElementById('categorySelect');
+  const libraryGrid = document.getElementById('library-grid');
+  const youtubeGrid = document.getElementById('youtube-grid');
+  const youtubeStatus = document.getElementById('youtube-status');
+  const startButton = document.getElementById('start-watch-button');
+  const backButton = document.getElementById('back-to-sources-button');
+  const localButton = document.getElementById('choose-local-video-button');
+  const localInput = document.getElementById('local-video-input');
+  const localPreview = document.getElementById('local-selection-preview');
+  const youtubeUrlInput = document.getElementById('youtube-url-input');
+  const addYoutubeButton = document.getElementById('add-youtube-button');
+  const youtubePlaylistInput = document.getElementById('youtube-playlist-input');
+  const importPlaylistButton = document.getElementById('import-playlist-button');
+  const watchStage = document.getElementById('watch-stage');
+  const watchFrame = document.getElementById('watch-frame');
+  const watchVideo = document.getElementById('watch-video');
+  const youtubePlayerElement = document.getElementById('youtube-player');
+  const watchHint = document.getElementById('watch-hint');
+  const exitButton = document.getElementById('exit-watch-button');
+  const gazePointer = document.getElementById('gazePointer');
+
+  let currentSource = '';
+  let selectedVideo = null;
+  let localObjectUrl = '';
+  let youtubeChoices = [];
+  let youtubePlayer = null;
+  let youtubeApiReady = false;
+  let pendingYoutubeVideoId = '';
+  let pauseTimer = 0;
+  let isLooking = false;
+
+  const sourceCopy = {
+    local: {
+      title: 'Vidéo locale',
+      description: 'Importez une vidéo de votre appareil, puis appuyez sur Commencer.'
+    },
+    youtube: {
+      title: 'Vidéo YouTube',
+      description: 'Ajoutez une URL YouTube ou importez une playlist, choisissez une vidéo, puis appuyez sur Commencer.'
+    },
+    library: {
+      title: 'Bibliothèque de vidéos',
+      description: 'Choisissez une vidéo de la bibliothèque Adaptatech, puis appuyez sur Commencer.'
+    }
+  };
+
+  function setStatus(message) {
+    if (youtubeStatus) youtubeStatus.textContent = message || '';
+  }
+
+  function getCategories(choice) {
+    if (!choice || !choice.category) return [];
+    return Array.isArray(choice.category) ? choice.category : [choice.category];
+  }
+
+  function setSelected(video) {
+    selectedVideo = video;
+    startButton.disabled = !selectedVideo;
+    renderSelectedStates();
+  }
+
+  function showPicker(source) {
+    currentSource = source;
+    selectedVideo = null;
+    startButton.disabled = true;
+    sourceModal.style.display = 'none';
+    pickerModal.style.display = 'flex';
+
+    libraryControls.hidden = source !== 'library';
+    localControls.hidden = source !== 'local';
+    youtubeControls.hidden = source !== 'youtube';
+
+    pickerTitle.textContent = sourceCopy[source]?.title || 'Choisir une vidéo';
+    pickerDescription.textContent = sourceCopy[source]?.description || '';
+
+    if (source === 'library') {
+      populateCategories();
+      renderLibraryGrid();
+    }
+    if (source === 'youtube') {
+      loadStoredYoutubeUrls();
+      renderYoutubeGrid();
+    }
+  }
+
+  function showSources() {
+    pickerModal.style.display = 'none';
+    sourceModal.style.display = 'flex';
+    currentSource = '';
+    selectedVideo = null;
+    startButton.disabled = true;
+  }
+
+  function populateCategories() {
+    if (!categorySelect || categorySelect.dataset.ready === 'true') return;
+    const categories = new Set();
+    (window.mediaChoices || mediaChoices || []).forEach(choice => {
+      getCategories(choice).forEach(category => categories.add(category));
+    });
+    Array.from(categories).sort().forEach(category => {
+      const option = document.createElement('option');
+      option.value = category;
+      option.textContent = category.charAt(0).toUpperCase() + category.slice(1);
+      categorySelect.appendChild(option);
+    });
+    categorySelect.dataset.ready = 'true';
+  }
+
+  function createChoiceCard(choice, index, source) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'video-choice-card';
+    button.dataset.index = String(index);
+    button.dataset.source = source;
+
+    const thumb = document.createElement('div');
+    thumb.className = 'video-choice-thumb';
+    thumb.style.backgroundImage = `url("${choice.image || '../../images/custom-videos.svg'}")`;
+
+    const title = document.createElement('div');
+    title.className = 'video-choice-title';
+    title.textContent = choice.name || 'Vidéo';
+
+    button.appendChild(thumb);
+    button.appendChild(title);
+    button.addEventListener('pointerup', () => setSelected({ ...choice, source }));
+    return button;
+  }
+
+  function renderLibraryGrid() {
+    const choices = window.mediaChoices || mediaChoices || [];
+    const category = categorySelect.value || 'all';
+    libraryGrid.innerHTML = '';
+    choices.forEach((choice, index) => {
+      const inCategory = category === 'all' || getCategories(choice).includes(category);
+      if (inCategory) libraryGrid.appendChild(createChoiceCard(choice, index, 'library'));
+    });
+    renderSelectedStates();
+  }
+
+  function renderYoutubeGrid() {
+    youtubeGrid.innerHTML = '';
+    youtubeChoices.forEach((choice, index) => {
+      youtubeGrid.appendChild(createChoiceCard(choice, index, 'youtube'));
+    });
+    renderSelectedStates();
+  }
+
+  function renderSelectedStates() {
+    document.querySelectorAll('.video-choice-card').forEach(card => {
+      const index = Number(card.dataset.index);
+      const source = card.dataset.source;
+      let candidate = null;
+      if (source === 'library') candidate = (window.mediaChoices || mediaChoices || [])[index];
+      if (source === 'youtube') candidate = youtubeChoices[index];
+      card.classList.toggle('selected', Boolean(selectedVideo && candidate && selectedVideo.video === candidate.video));
+    });
+  }
+
+  function isYouTubeUrl(url) {
+    return /^(https?:\/\/)?(www\.|m\.)?((youtube\.com\/\S+)|(youtu\.be\/\S+))$/.test(url.trim());
+  }
+
+  function getYouTubeId(url) {
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname.includes('youtu.be')) return parsed.pathname.slice(1).split('/')[0];
+      const id = parsed.searchParams.get('v');
+      if (id) return id;
+      const embedMatch = parsed.pathname.match(/\/embed\/([a-zA-Z0-9_-]+)/);
+      return embedMatch ? embedMatch[1] : '';
+    } catch {
+      return '';
+    }
+  }
+
+  function getPlaylistIdFromUrl(url) {
+    try {
+      const parsed = new URL(url);
+      return parsed.searchParams.get('list') || '';
+    } catch {
+      const match = url.match(/[?&]list=([a-zA-Z0-9_-]+)/);
+      return match ? match[1] : '';
+    }
+  }
+
+  async function fetchVideoTitle(url) {
+    try {
+      const response = await fetch(`https://noembed.com/embed?url=${encodeURIComponent(url)}`);
+      if (response.ok) {
+        const data = await response.json();
+        if (data?.title) return data.title;
+      }
+    } catch {}
+    return url;
+  }
+
+  function saveYoutubeUrls() {
+    try {
+      localStorage.setItem(YOUTUBE_STORAGE_KEY, JSON.stringify(youtubeChoices.map(choice => choice.video)));
+    } catch {}
+  }
+
+  async function addYoutubeById(id) {
+    if (!id) throw new Error('URL YouTube invalide.');
+    const url = `https://www.youtube.com/watch?v=${id}`;
+    if (youtubeChoices.some(choice => choice.video === url)) {
+      setStatus('Cette vidéo est déjà dans la liste.');
+      return;
+    }
+    const title = await fetchVideoTitle(url);
+    youtubeChoices.push({
+      name: title,
+      image: `https://img.youtube.com/vi/${id}/mqdefault.jpg`,
+      video: url,
+      youtubeId: id,
+      source: 'youtube'
+    });
+    saveYoutubeUrls();
+    renderYoutubeGrid();
+    setStatus('Vidéo ajoutée.');
+  }
+
+  async function loadStoredYoutubeUrls() {
+    if (youtubeChoices.length > 0) return;
+    try {
+      const saved = JSON.parse(localStorage.getItem(YOUTUBE_STORAGE_KEY) || '[]');
+      for (const url of saved) {
+        const id = getYouTubeId(url);
+        if (id) await addYoutubeById(id);
+      }
+      setStatus('');
+    } catch {}
+  }
+
+  async function fetchPlaylistVideoIds(playlistId) {
+    if (!window.YT_API_KEY) throw new Error('Clé API YouTube manquante.');
+    const ids = [];
+    let pageToken = '';
+    do {
+      const query = new URL('https://www.googleapis.com/youtube/v3/playlistItems');
+      query.searchParams.set('part', 'contentDetails');
+      query.searchParams.set('maxResults', '50');
+      query.searchParams.set('playlistId', playlistId);
+      query.searchParams.set('key', window.YT_API_KEY);
+      if (pageToken) query.searchParams.set('pageToken', pageToken);
+      const response = await fetch(query);
+      const text = await response.text();
+      if (!response.ok) throw new Error(`Import impossible (${response.status}) ${text}`);
+      const data = JSON.parse(text);
+      (data.items || []).forEach(item => {
+        if (item?.contentDetails?.videoId) ids.push(item.contentDetails.videoId);
+      });
+      pageToken = data.nextPageToken || '';
+    } while (pageToken);
+    return ids;
+  }
+
+  function clearPauseTimer() {
+    if (pauseTimer) {
+      clearTimeout(pauseTimer);
+      pauseTimer = 0;
+    }
+  }
+
+  function showPlayingHint(hidden) {
+    watchHint.classList.toggle('is-hidden', hidden);
+  }
+
+  function playCurrentVideo() {
+    clearPauseTimer();
+    showPlayingHint(true);
+    if (selectedVideo?.source === 'youtube') {
+      youtubePlayer?.playVideo?.();
+    } else {
+      watchVideo.play().catch(() => showPlayingHint(false));
+    }
+  }
+
+  function pauseCurrentVideo() {
+    showPlayingHint(false);
+    if (selectedVideo?.source === 'youtube') {
+      youtubePlayer?.pauseVideo?.();
+    } else {
+      watchVideo.pause();
+    }
+  }
+
+  function schedulePause() {
+    clearPauseTimer();
+    pauseTimer = window.setTimeout(() => {
+      if (!isLooking) pauseCurrentVideo();
+    }, PAUSE_GRACE_MS);
+  }
+
+  function setLooking(nextLooking) {
+    if (isLooking === nextLooking) return;
+    isLooking = nextLooking;
+    if (isLooking) playCurrentVideo();
+    else schedulePause();
+  }
+
+  function updateGazePointer(event) {
+    if (!gazePointer) return;
+    gazePointer.style.transform = `translate(${event.clientX}px, ${event.clientY}px)`;
+  }
+
+  function handlePointerMove(event) {
+    updateGazePointer(event);
+    if (watchStage.style.display !== 'none') {
+      const rect = watchFrame.getBoundingClientRect();
+      const inside = event.clientX >= rect.left && event.clientX <= rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom;
+      setLooking(inside);
+    }
+  }
+
+  function prepareLocalVideo() {
+    youtubePlayerElement.style.display = 'none';
+    watchVideo.style.display = 'block';
+    watchVideo.src = selectedVideo.video;
+    watchVideo.load();
+  }
+
+  function prepareYoutubeVideo() {
+    watchVideo.pause();
+    watchVideo.removeAttribute('src');
+    watchVideo.load();
+    watchVideo.style.display = 'none';
+    youtubePlayerElement.style.display = 'block';
+    const id = selectedVideo.youtubeId || getYouTubeId(selectedVideo.video);
+    pendingYoutubeVideoId = id;
+    if (youtubePlayer && id) {
+      youtubePlayer.cueVideoById(id);
+    } else if (youtubeApiReady && id) {
+      createYoutubePlayer(id);
+    }
+  }
+
+  function createYoutubePlayer(videoId) {
+    youtubePlayer = new YT.Player('youtube-player', {
+      width: '100%',
+      height: '100%',
+      videoId,
+      playerVars: {
+        playsinline: 1,
+        rel: 0,
+        modestbranding: 1,
+        controls: 0,
+        disablekb: 1
+      },
+      events: {
+        onReady: () => {
+          if (pendingYoutubeVideoId) youtubePlayer.cueVideoById(pendingYoutubeVideoId);
+        }
+      }
+    });
+  }
+
+  function requestFullscreen() {
+    const element = document.documentElement;
+    if (!document.fullscreenElement && element.requestFullscreen) {
+      element.requestFullscreen().catch(() => {});
+    }
+  }
+
+  function startExperience() {
+    if (!selectedVideo) return;
+    pickerModal.style.display = 'none';
+    sourceModal.style.display = 'none';
+    watchStage.style.display = 'block';
+    isLooking = false;
+    clearPauseTimer();
+    showPlayingHint(false);
+    if (selectedVideo.source === 'youtube') prepareYoutubeVideo();
+    else prepareLocalVideo();
+    requestFullscreen();
+  }
+
+  function exitExperience() {
+    clearPauseTimer();
+    pauseCurrentVideo();
+    watchStage.style.display = 'none';
+    pickerModal.style.display = 'flex';
+    isLooking = false;
+    if (document.fullscreenElement && document.exitFullscreen) {
+      document.exitFullscreen().catch(() => {});
+    }
+  }
+
+  window.onYouTubeIframeAPIReady = function () {
+    youtubeApiReady = true;
+    if (pendingYoutubeVideoId) createYoutubePlayer(pendingYoutubeVideoId);
+  };
+
+  document.querySelectorAll('.source-pill').forEach(button => {
+    button.addEventListener('pointerup', () => showPicker(button.dataset.source));
+  });
+
+  backButton.addEventListener('pointerup', showSources);
+  categorySelect.addEventListener('change', renderLibraryGrid);
+  localButton.addEventListener('pointerup', () => localInput.click());
+  localInput.addEventListener('change', () => {
+    const file = localInput.files?.[0];
+    if (!file) return;
+    if (localObjectUrl) URL.revokeObjectURL(localObjectUrl);
+    localObjectUrl = URL.createObjectURL(file);
+    localPreview.textContent = file.name;
+    setSelected({
+      name: file.name,
+      video: localObjectUrl,
+      source: 'local'
+    });
+  });
+
+  addYoutubeButton.addEventListener('pointerup', async () => {
+    const url = youtubeUrlInput.value.trim();
+    if (!isYouTubeUrl(url)) {
+      setStatus('Entrez une URL YouTube valide.');
+      return;
+    }
+    setStatus('Ajout en cours...');
+    try {
+      await addYoutubeById(getYouTubeId(url));
+      youtubeUrlInput.value = '';
+    } catch (error) {
+      setStatus(error.message || 'Impossible d’ajouter cette vidéo.');
+    }
+  });
+
+  importPlaylistButton.addEventListener('pointerup', async () => {
+    const playlistId = getPlaylistIdFromUrl(youtubePlaylistInput.value.trim());
+    if (!playlistId) {
+      setStatus('Entrez une URL de playlist valide.');
+      return;
+    }
+    setStatus('Importation de la playlist...');
+    try {
+      const ids = await fetchPlaylistVideoIds(playlistId);
+      for (const id of ids) await addYoutubeById(id);
+      youtubePlaylistInput.value = '';
+      setStatus(`${ids.length} vidéo(s) importée(s).`);
+    } catch (error) {
+      setStatus(error.message || 'Impossible d’importer la playlist.');
+    }
+  });
+
+  startButton.addEventListener('pointerup', startExperience);
+  exitButton.addEventListener('pointerup', exitExperience);
+  document.addEventListener('pointermove', handlePointerMove);
+  document.addEventListener('pointerleave', () => {
+    if (watchStage.style.display !== 'none') setLooking(false);
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && watchStage.style.display !== 'none') exitExperience();
+  });
+}());


### PR DESCRIPTION
### Motivation
- Provide a new interactive eyegaze mode where a video plays only while the pointer/gaze is on the screen with a 2s pause grace period. 
- Support multiple video sources (local file, YouTube URL/playlist, and an existing media library) and let users choose videos before starting the experience. 
- Integrate with YouTube (via iframe API) and persist user-added YouTube entries for repeat use.

### Description
- Added a new stylesheet `css/watch-to-play.css` to style the picker, watch stage, gaze pointer, and responsive behavior. 
- Added a new page `eyegaze/watch-to-play/index.html` that implements the UI for source selection, video picking (local / YouTube / library), and the fullscreen watch stage. 
- Updated `eyegaze/index.html` to add a tile linking to the new `watch-to-play` experience. 
- Introduced `js/watchToPlay.js` which implements the selection UI, local file handling via object URLs, YouTube URL/playlist import (uses `window.YT_API_KEY` for playlist fetch), YouTube iframe player creation via `window.onYouTubeIframeAPIReady`, storage of user YouTube URLs in `localStorage` under the key `watchToPlayYoutubeUrls`, pointer-based play/pause logic with `PAUSE_GRACE_MS = 2000`, and gaze pointer rendering. 
- Uses `https://noembed.com/embed` to fetch YouTube video titles and supports graceful pause scheduling, fullscreen request on start, and keyboard/escape to exit.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb85a8010c83259094d20191b5f45f)