### PR TITLE
Add Look-to-Play gaze-controlled video experience

### DIFF
--- a/eyegaze/index.html
+++ b/eyegaze/index.html
@@ -167,6 +167,15 @@
     </div>
 
     <div class="tile">
+      <a href="regarder-video/index.html">
+        <img src="../images/eyegazeyoutube.png" alt="Vidéo au regard">
+        <div class="tile-title">
+          <h3 data-fr="Vidéo au regard" data-en="Look-to-Play Video" data-ja="視線で再生する動画">Vidéo au regard</h3>
+        </div>
+      </a>
+    </div>
+
+    <div class="tile">
       <a href="choixeyegaze-videos-local/index.html">
         <img src="../images/localvideosmultiplechoices.png" alt="Choix vidéos locales">
         <div class="tile-title">

--- a/eyegaze/regarder-video/index.html
+++ b/eyegaze/regarder-video/index.html
@@ -113,8 +113,10 @@
     }
 
     #look-video-frame {
-      width: 100%;
-      height: 100%;
+      width: min(66vw, calc(100vh * 16 / 9));
+      height: min(calc(66vw * 9 / 16), 72vh);
+      max-width: calc(100vw - 2 * clamp(12px, 2vw, 28px));
+      max-height: calc(100vh - 2 * clamp(12px, 2vw, 28px));
       position: relative;
       background: #000;
       border: 3px solid rgba(0, 150, 136, 0.75);
@@ -123,6 +125,13 @@
       display: flex;
       align-items: center;
       justify-content: center;
+    }
+
+    @media (max-width: 900px) {
+      #look-video-frame {
+        width: min(88vw, calc(100vh * 16 / 9));
+        height: min(calc(88vw * 9 / 16), 72vh);
+      }
     }
 
     #video-container.look-to-play-mode #video-player,

--- a/eyegaze/regarder-video/index.html
+++ b/eyegaze/regarder-video/index.html
@@ -6,172 +6,132 @@
   <title class="translate" data-fr="Vidéo au regard" data-en="Look-to-Play Video" data-ja="視線で再生する動画">Vidéo au regard</title>
   <link rel="stylesheet" href="../../css/choiceeyegaze.css" />
   <style>
-    :root {
-      --look-teal: #009688;
-      --look-teal-dark: #00796b;
-      --look-bg: #021013;
-    }
-
     #language-toggle{
       position:fixed; top:10px; right:10px; z-index:99999;
-      padding:6px 10px; border-radius:10px; border:2px solid var(--look-teal);
-      background:#fff; color:var(--look-teal); font-weight:700; cursor:pointer;
+      padding:6px 10px; border-radius:10px; border:2px solid #009688;
+      background:#fff; color:#009688; font-weight:700; cursor:pointer;
       user-select:none;
     }
 
-    .source-pill-row {
+    /* Same segmented pill style used on the pedagogical choice page. */
+    #mode-segmented-control {
       display: flex;
-      justify-content: center;
-      flex-wrap: wrap;
-      gap: 18px;
-      width: 100%;
-      margin: 16px 0 6px;
-    }
-
-    .source-pill {
-      border: 3px solid var(--look-teal);
-      border-radius: 999px;
-      background: #fff;
-      color: var(--look-teal-dark);
-      cursor: pointer;
-      font-size: clamp(1.15rem, 2vw, 1.6rem);
-      font-weight: 800;
-      min-width: min(260px, 82vw);
-      padding: 18px 28px;
-      transition: transform .18s ease, box-shadow .18s ease, background .18s ease, color .18s ease;
-    }
-
-    .source-pill:hover,
-    .source-pill.selected {
-      background: var(--look-teal);
-      color: #fff;
-      box-shadow: 0 10px 24px rgba(0, 150, 136, .25);
-      transform: translateY(-2px);
-    }
-
-    .source-help {
-      color: #345;
-      font-size: 1.05rem;
-      line-height: 1.45;
-      margin: 8px auto 0;
-      max-width: 760px;
-    }
-
-    .chooser-toolbar,
-    .actions-row {
+      justify-content: space-around;
       align-items: center;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-      justify-content: center;
-      margin: 12px auto;
+      max-width: 700px;
       width: 100%;
-    }
-
-    .styled-input,
-    .styled-select,
-    .control-panel-input {
-      border: 2px solid var(--look-teal);
-      border-radius: 12px;
-      box-sizing: border-box;
-      font-size: 1rem;
-      padding: 12px 14px;
-      min-width: min(420px, 88vw);
-    }
-
-    #single-video-grid {
-      display: grid;
-      gap: 18px;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      margin: 16px auto;
-      max-height: 52vh;
-      overflow-y: auto;
-      padding: 10px;
-      width: 100%;
-    }
-
-    #single-video-grid .tile {
-      aspect-ratio: 16 / 10;
-      background-color: #17383d;
-      background-position: center;
-      background-size: cover;
-      border: 4px solid transparent;
-      border-radius: 18px;
-      box-shadow: 0 6px 18px rgba(0,0,0,.18);
-      cursor: pointer;
-      min-height: 150px;
+      margin: 20px auto;
+      border: 4px solid #000000;
+      border-radius: 50px;
+      background-color: #e6e6e6;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.15);
       overflow: hidden;
-      position: relative;
-      transition: border-color .15s ease, transform .15s ease;
     }
 
-    #single-video-grid .tile:hover,
-    #single-video-grid .tile.selected {
-      border-color: var(--look-teal);
-      transform: translateY(-2px);
-    }
-
-    #single-video-grid .caption {
-      background: linear-gradient(transparent, rgba(0,0,0,.86));
-      bottom: 0;
-      box-sizing: border-box;
-      color: #fff;
+    .mode-btn {
+      flex: 1;
+      padding: 10px 15px;
+      font-size: 18px;
       font-weight: 800;
-      left: 0;
-      padding: 34px 12px 12px;
-      position: absolute;
-      right: 0;
-      text-shadow: 0 1px 3px rgba(0,0,0,.9);
+      background: transparent;
+      border: none;
+      outline: none;
+      cursor: pointer;
+      color: #000000;
+      transition: all 0.3s ease;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
     }
 
-    .status-note {
-      color: #345;
+    .mode-btn:hover {
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    .mode-btn.selected {
+      background: linear-gradient(135deg, #009688, #00796B);
+      color: #fff;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+    }
+
+    .mode-btn:not(:last-child) {
+      border-right: 4px solid #000000;
+    }
+
+    #source-instructions {
+      max-width: 680px;
+      margin: 0 auto;
+      font-size: 18px;
+      line-height: 1.45;
+    }
+
+    #source-summary {
+      margin-top: 10px;
       font-weight: 700;
+      color: #00796B;
       min-height: 1.4em;
     }
 
-    #video-stage {
+    #library-controls,
+    #local-import-controls,
+    #yt-import-controls {
+      width: 100%;
+      margin-top: 10px;
+    }
+
+    #library-controls {
+      display: flex;
       align-items: center;
-      background: radial-gradient(circle at center, #052126 0%, #000 72%);
-      display: none;
-      height: 100vh;
       justify-content: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .actions-row {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      flex-wrap: wrap;
+      width: 100%;
+      margin: 10px 0;
+    }
+
+    #video-container.look-to-play-mode {
+      box-sizing: border-box;
       padding: clamp(12px, 2vw, 28px);
       position: fixed;
       inset: 0;
-      width: 100vw;
       z-index: 1000;
-      box-sizing: border-box;
     }
 
     #look-video-frame {
-      align-items: center;
-      background: #000;
-      border: 3px solid rgba(0, 150, 136, .75);
-      border-radius: clamp(14px, 2vw, 28px);
-      box-shadow: 0 0 0 8px rgba(0, 150, 136, .12), 0 18px 50px rgba(0,0,0,.55);
-      display: flex;
+      width: 100%;
       height: 100%;
-      justify-content: center;
-      overflow: hidden;
       position: relative;
-      width: 100%;
-    }
-
-    #look-video,
-    #youtube-player {
       background: #000;
-      height: 100%;
-      width: 100%;
+      border: 3px solid rgba(0, 150, 136, 0.75);
+      border-radius: 8px;
+      overflow: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
-    #look-video {
-      object-fit: contain;
-    }
-
+    #video-container.look-to-play-mode #video-player,
+    #youtube-player,
     #youtube-player iframe {
-      height: 100% !important;
       width: 100% !important;
+      height: 100% !important;
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+      background: #000;
+    }
+
+    #youtube-player {
+      pointer-events: none;
     }
 
     #look-zone {
@@ -181,37 +141,21 @@
     }
 
     #look-status {
-      background: rgba(0,0,0,.58);
-      border: 2px solid rgba(255,255,255,.22);
-      border-radius: 999px;
-      color: #fff;
-      font-weight: 800;
-      left: 50%;
-      padding: 10px 18px;
-      pointer-events: none;
       position: absolute;
+      left: 50%;
       top: 18px;
       transform: translateX(-50%);
       z-index: 4;
-    }
-
-    #gazePointer {
-      position: fixed;
-      width: 36px;
-      height: 36px;
-      margin-left: -18px;
-      margin-top: -18px;
-      border: 3px solid #fff;
-      border-radius: 50%;
-      box-shadow: 0 0 0 4px rgba(0,150,136,.75), 0 0 18px rgba(0,150,136,.95);
+      background: rgba(0,0,0,0.65);
+      color: #fff;
+      border-radius: 20px;
+      padding: 8px 16px;
+      font-weight: 700;
       pointer-events: none;
-      transform: translate(-100px, -100px);
-      z-index: 2147483647;
     }
 
-    @media (max-width: 760px) {
-      #control-panel-options { width: 94vw; }
-      .source-pill { width: 100%; }
+    #gazePointer.look-visible {
+      opacity: 1;
     }
   </style>
 </head>
@@ -225,29 +169,39 @@
 <body>
   <button id="language-toggle" title="Changer de langue / Change language">FR / EN</button>
 
-  <div id="source-modal" class="modal" style="display: flex;">
+  <!-- Main Options Modal (Step 1), matching the EyeGaze choice games. -->
+  <div id="game-options" class="modal" style="display: flex;">
     <div id="control-panel-options">
       <div id="options-title-bar">
         <h2 id="options-main-title" class="translate" data-fr="Vidéo au regard" data-en="Look-to-Play Video" data-ja="視線で再生する動画">Vidéo au regard</h2>
       </div>
+
       <div id="mode-divider"></div>
-      <p class="source-help translate" data-fr="Choisissez une source vidéo. La vidéo jouera ensuite seulement pendant que le pointeur de regard reste sur l'écran vidéo." data-en="Choose a video source. The video will then play only while the gaze pointer stays over the video screen." data-ja="動画ソースを選んでください。視線ポインターが動画画面上にある間だけ動画が再生されます。">Choisissez une source vidéo. La vidéo jouera ensuite seulement pendant que le pointeur de regard reste sur l'écran vidéo.</p>
-      <div class="source-pill-row" role="group" aria-label="Video source">
-        <button class="source-pill translate" data-source="local" data-fr="Local" data-en="Local" data-ja="ローカル">Local</button>
-        <button class="source-pill translate" data-source="youtube" data-fr="YouTube" data-en="YouTube" data-ja="YouTube">YouTube</button>
-        <button class="source-pill translate" data-source="library" data-fr="Bibliothèque" data-en="Library" data-ja="ライブラリ">Bibliothèque</button>
+
+      <p id="source-instructions" class="translate" data-fr="Choisissez une source. La vidéo s'affichera ensuite presque en plein écran et jouera quand le pointeur de regard est sur la vidéo." data-en="Choose a source. The video will then appear nearly fullscreen and play when the gaze pointer is on the video." data-ja="ソースを選びます。動画はほぼ全画面で表示され、視線ポインターが動画上にある時に再生されます。">Choisissez une source. La vidéo s'affichera ensuite presque en plein écran et jouera quand le pointeur de regard est sur la vidéo.</p>
+
+      <div id="mode-segmented-control" role="group" aria-label="Video source">
+        <button id="source-local-button" class="mode-btn translate" data-source="local" data-fr="Local" data-en="Local" data-ja="ローカル">Local</button>
+        <button id="source-youtube-button" class="mode-btn translate" data-source="youtube" data-fr="YouTube" data-en="YouTube" data-ja="YouTube">YouTube</button>
+        <button id="source-library-button" class="mode-btn selected translate" data-source="library" data-fr="Bibliothèque" data-en="Library" data-ja="ライブラリ">Bibliothèque</button>
       </div>
+
+      <div id="source-summary" class="translate" data-fr="Source: Bibliothèque" data-en="Source: Library" data-ja="ソース：ライブラリ">Source: Bibliothèque</div>
+
+      <div id="mode-divider"></div>
+
+      <button id="choose-source-button" class="button translate" data-fr="Choisir la vidéo" data-en="Choose Video" data-ja="動画を選ぶ">Choisir la vidéo</button>
     </div>
   </div>
 
-  <div id="picker-modal" class="modal" style="display: none;">
+  <!-- Tile Picker Modal (Step 2), using the same picker structure as choixeyegaze. -->
+  <div id="tile-picker-modal" class="modal" style="display: none;">
     <div id="control-panel-options">
       <div id="control-panel-title-wrapper">
-        <h2 id="picker-title" class="translate" data-fr="Choisir une vidéo" data-en="Choose one video" data-ja="動画を1つ選ぶ">Choisir une vidéo</h2>
+        <h2 id="control-panel-title" class="translate" data-fr="Choisir une vidéo" data-en="Choose a Video" data-ja="動画を選ぶ">Choisir une vidéo</h2>
       </div>
-      <div id="mode-divider"></div>
 
-      <div id="library-controls" class="chooser-toolbar" style="display:none;">
+      <div id="library-controls">
         <label for="categorySelect" class="translate" data-fr="Catégorie:" data-en="Category:" data-ja="カテゴリー：">Catégorie:</label>
         <select id="categorySelect" class="styled-select">
           <option value="all" class="translate" data-fr="-- Tous --" data-en="-- All --" data-ja="-- すべて --">-- Tous --</option>
@@ -262,34 +216,47 @@
         </select>
       </div>
 
-      <div id="local-controls" class="chooser-toolbar" style="display:none;">
-        <input id="local-video-input" class="styled-input" type="file" accept="video/*" />
-      </div>
-
-      <div id="youtube-controls" style="display:none;">
+      <div id="local-import-controls" style="display:none;">
         <div class="actions-row">
-          <input id="youtube-url-input" class="control-panel-input" type="text" placeholder="https://www.youtube.com/watch?v=..." />
-          <button id="add-youtube-button" class="button translate" data-fr="Ajouter URL" data-en="Add URL" data-ja="URLを追加">Ajouter URL</button>
-        </div>
-        <div class="actions-row">
-          <input id="youtube-playlist-input" class="control-panel-input" type="text" placeholder="URL de playlist (optionnel)" />
-          <button id="import-playlist-button" class="button translate" data-fr="Importer playlist" data-en="Import playlist" data-ja="プレイリストをインポート">Importer playlist</button>
+          <button id="add-video-file-button" class="button translate" data-fr="Ajouter vidéo" data-en="Add Video" data-ja="動画を追加">Ajouter vidéo</button>
+          <input type="file" id="add-video-input" accept="video/*" style="display:none;">
         </div>
       </div>
 
-      <div id="picker-status" class="status-note" aria-live="polite"></div>
-      <div id="single-video-grid" aria-live="polite"></div>
+      <div id="yt-import-controls" style="display:none;">
+        <div id="yt-input-row">
+          <div class="actions-row">
+            <input id="add-video-url-input" type="text" placeholder="URL" class="control-panel-input">
+            <button id="add-video-url-button" class="button translate" data-fr="Ajouter URL" data-en="Add URL" data-ja="URLを追加">Ajouter URL</button>
+          </div>
+          <div class="actions-row">
+            <input id="yt-playlist-url-input" type="text" placeholder="URL de playlist (ex. https://www.youtube.com/playlist?list=...)" class="control-panel-input">
+            <button id="yt-playlist-import-button" class="button translate" data-fr="Importer" data-en="Import" data-ja="インポート">Importer</button>
+          </div>
+        </div>
+      </div>
+
+      <div id="control-panel-instructions" style="margin-top:10px;">
+        <span class="translate" data-fr="Choisir une vidéo." data-en="Choose one video." data-ja="動画を1つ選んでください。">Choisir une vidéo.</span>
+      </div>
+
+      <div id="tile-picker-grid"></div>
 
       <div class="actions-row">
         <button id="back-to-source-button" class="button translate" data-fr="Retour" data-en="Back" data-ja="戻る">Retour</button>
-        <button id="start-look-video-button" class="button translate" data-fr="Commencer" data-en="Start" data-ja="開始" disabled>Commencer</button>
+        <button id="clear-videos-button" class="button translate" data-fr="Tout effacer" data-en="Clear All" data-ja="すべてクリア" style="display:none;">Tout effacer</button>
+        <button id="start-game-button" class="button translate" data-fr="Commencer" data-en="Start" data-ja="開始" disabled>Commencer</button>
       </div>
     </div>
   </div>
 
-  <div id="video-stage" aria-live="polite">
+  <!-- Same video-container base as the EyeGaze video games; the frame adds the small buffer. -->
+  <div id="video-container" class="look-to-play-mode" style="display: none;">
     <div id="look-video-frame">
-      <video id="look-video" playsinline preload="metadata"></video>
+      <video id="video-player" playsinline preload="metadata">
+        <source id="video-source" type="video/mp4" />
+        Your browser does not support video.
+      </video>
       <div id="youtube-player" style="display:none;"></div>
       <div id="look-zone" aria-label="Look here to play video"></div>
       <div id="look-status" class="translate" data-fr="Regardez la vidéo pour jouer" data-en="Look at the video to play" data-ja="動画を見ると再生します">Regardez la vidéo pour jouer</div>
@@ -298,6 +265,7 @@
 
   <div id="gazePointer" aria-hidden="true"></div>
 
+  <script src="../../js/eyegaze-menu.js"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
   <script src="../../js/config.js"></script>
   <script src="../../js/choiceArray.js"></script>

--- a/eyegaze/regarder-video/index.html
+++ b/eyegaze/regarder-video/index.html
@@ -100,10 +100,16 @@
 
     #video-container.look-to-play-mode {
       box-sizing: border-box;
+      cursor: none;
       padding: clamp(12px, 2vw, 28px);
       position: fixed;
       inset: 0;
       z-index: 1000;
+    }
+
+    body.look-video-active,
+    body.look-video-active * {
+      cursor: none !important;
     }
 
     #look-video-frame {
@@ -155,7 +161,8 @@
     }
 
     #gazePointer.look-visible {
-      opacity: 1;
+      --gp-size: 22px;
+      opacity: 0.42;
     }
   </style>
 </head>

--- a/eyegaze/regarder-video/index.html
+++ b/eyegaze/regarder-video/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title class="translate" data-fr="Vidéo au regard" data-en="Look-to-Play Video" data-ja="視線で再生する動画">Vidéo au regard</title>
+  <link rel="stylesheet" href="../../css/choiceeyegaze.css" />
+  <style>
+    :root {
+      --look-teal: #009688;
+      --look-teal-dark: #00796b;
+      --look-bg: #021013;
+    }
+
+    #language-toggle{
+      position:fixed; top:10px; right:10px; z-index:99999;
+      padding:6px 10px; border-radius:10px; border:2px solid var(--look-teal);
+      background:#fff; color:var(--look-teal); font-weight:700; cursor:pointer;
+      user-select:none;
+    }
+
+    .source-pill-row {
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 18px;
+      width: 100%;
+      margin: 16px 0 6px;
+    }
+
+    .source-pill {
+      border: 3px solid var(--look-teal);
+      border-radius: 999px;
+      background: #fff;
+      color: var(--look-teal-dark);
+      cursor: pointer;
+      font-size: clamp(1.15rem, 2vw, 1.6rem);
+      font-weight: 800;
+      min-width: min(260px, 82vw);
+      padding: 18px 28px;
+      transition: transform .18s ease, box-shadow .18s ease, background .18s ease, color .18s ease;
+    }
+
+    .source-pill:hover,
+    .source-pill.selected {
+      background: var(--look-teal);
+      color: #fff;
+      box-shadow: 0 10px 24px rgba(0, 150, 136, .25);
+      transform: translateY(-2px);
+    }
+
+    .source-help {
+      color: #345;
+      font-size: 1.05rem;
+      line-height: 1.45;
+      margin: 8px auto 0;
+      max-width: 760px;
+    }
+
+    .chooser-toolbar,
+    .actions-row {
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: center;
+      margin: 12px auto;
+      width: 100%;
+    }
+
+    .styled-input,
+    .styled-select,
+    .control-panel-input {
+      border: 2px solid var(--look-teal);
+      border-radius: 12px;
+      box-sizing: border-box;
+      font-size: 1rem;
+      padding: 12px 14px;
+      min-width: min(420px, 88vw);
+    }
+
+    #single-video-grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      margin: 16px auto;
+      max-height: 52vh;
+      overflow-y: auto;
+      padding: 10px;
+      width: 100%;
+    }
+
+    #single-video-grid .tile {
+      aspect-ratio: 16 / 10;
+      background-color: #17383d;
+      background-position: center;
+      background-size: cover;
+      border: 4px solid transparent;
+      border-radius: 18px;
+      box-shadow: 0 6px 18px rgba(0,0,0,.18);
+      cursor: pointer;
+      min-height: 150px;
+      overflow: hidden;
+      position: relative;
+      transition: border-color .15s ease, transform .15s ease;
+    }
+
+    #single-video-grid .tile:hover,
+    #single-video-grid .tile.selected {
+      border-color: var(--look-teal);
+      transform: translateY(-2px);
+    }
+
+    #single-video-grid .caption {
+      background: linear-gradient(transparent, rgba(0,0,0,.86));
+      bottom: 0;
+      box-sizing: border-box;
+      color: #fff;
+      font-weight: 800;
+      left: 0;
+      padding: 34px 12px 12px;
+      position: absolute;
+      right: 0;
+      text-shadow: 0 1px 3px rgba(0,0,0,.9);
+    }
+
+    .status-note {
+      color: #345;
+      font-weight: 700;
+      min-height: 1.4em;
+    }
+
+    #video-stage {
+      align-items: center;
+      background: radial-gradient(circle at center, #052126 0%, #000 72%);
+      display: none;
+      height: 100vh;
+      justify-content: center;
+      padding: clamp(12px, 2vw, 28px);
+      position: fixed;
+      inset: 0;
+      width: 100vw;
+      z-index: 1000;
+      box-sizing: border-box;
+    }
+
+    #look-video-frame {
+      align-items: center;
+      background: #000;
+      border: 3px solid rgba(0, 150, 136, .75);
+      border-radius: clamp(14px, 2vw, 28px);
+      box-shadow: 0 0 0 8px rgba(0, 150, 136, .12), 0 18px 50px rgba(0,0,0,.55);
+      display: flex;
+      height: 100%;
+      justify-content: center;
+      overflow: hidden;
+      position: relative;
+      width: 100%;
+    }
+
+    #look-video,
+    #youtube-player {
+      background: #000;
+      height: 100%;
+      width: 100%;
+    }
+
+    #look-video {
+      object-fit: contain;
+    }
+
+    #youtube-player iframe {
+      height: 100% !important;
+      width: 100% !important;
+    }
+
+    #look-zone {
+      position: absolute;
+      inset: 0;
+      z-index: 3;
+    }
+
+    #look-status {
+      background: rgba(0,0,0,.58);
+      border: 2px solid rgba(255,255,255,.22);
+      border-radius: 999px;
+      color: #fff;
+      font-weight: 800;
+      left: 50%;
+      padding: 10px 18px;
+      pointer-events: none;
+      position: absolute;
+      top: 18px;
+      transform: translateX(-50%);
+      z-index: 4;
+    }
+
+    #gazePointer {
+      position: fixed;
+      width: 36px;
+      height: 36px;
+      margin-left: -18px;
+      margin-top: -18px;
+      border: 3px solid #fff;
+      border-radius: 50%;
+      box-shadow: 0 0 0 4px rgba(0,150,136,.75), 0 0 18px rgba(0,150,136,.95);
+      pointer-events: none;
+      transform: translate(-100px, -100px);
+      z-index: 2147483647;
+    }
+
+    @media (max-width: 760px) {
+      #control-panel-options { width: 94vw; }
+      .source-pill { width: 100%; }
+    }
+  </style>
+</head>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-B45TJG4GBJ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-B45TJG4GBJ');
+</script>
+<body>
+  <button id="language-toggle" title="Changer de langue / Change language">FR / EN</button>
+
+  <div id="source-modal" class="modal" style="display: flex;">
+    <div id="control-panel-options">
+      <div id="options-title-bar">
+        <h2 id="options-main-title" class="translate" data-fr="Vidéo au regard" data-en="Look-to-Play Video" data-ja="視線で再生する動画">Vidéo au regard</h2>
+      </div>
+      <div id="mode-divider"></div>
+      <p class="source-help translate" data-fr="Choisissez une source vidéo. La vidéo jouera ensuite seulement pendant que le pointeur de regard reste sur l'écran vidéo." data-en="Choose a video source. The video will then play only while the gaze pointer stays over the video screen." data-ja="動画ソースを選んでください。視線ポインターが動画画面上にある間だけ動画が再生されます。">Choisissez une source vidéo. La vidéo jouera ensuite seulement pendant que le pointeur de regard reste sur l'écran vidéo.</p>
+      <div class="source-pill-row" role="group" aria-label="Video source">
+        <button class="source-pill translate" data-source="local" data-fr="Local" data-en="Local" data-ja="ローカル">Local</button>
+        <button class="source-pill translate" data-source="youtube" data-fr="YouTube" data-en="YouTube" data-ja="YouTube">YouTube</button>
+        <button class="source-pill translate" data-source="library" data-fr="Bibliothèque" data-en="Library" data-ja="ライブラリ">Bibliothèque</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="picker-modal" class="modal" style="display: none;">
+    <div id="control-panel-options">
+      <div id="control-panel-title-wrapper">
+        <h2 id="picker-title" class="translate" data-fr="Choisir une vidéo" data-en="Choose one video" data-ja="動画を1つ選ぶ">Choisir une vidéo</h2>
+      </div>
+      <div id="mode-divider"></div>
+
+      <div id="library-controls" class="chooser-toolbar" style="display:none;">
+        <label for="categorySelect" class="translate" data-fr="Catégorie:" data-en="Category:" data-ja="カテゴリー：">Catégorie:</label>
+        <select id="categorySelect" class="styled-select">
+          <option value="all" class="translate" data-fr="-- Tous --" data-en="-- All --" data-ja="-- すべて --">-- Tous --</option>
+          <option value="pop">Pop</option>
+          <option value="disney">Disney</option>
+          <option value="enfant" class="translate" data-fr="Enfants" data-en="Children" data-ja="子ども向け">Enfants</option>
+          <option value="hip hop">Hip Hop</option>
+          <option value="rock">Rock</option>
+          <option value="bonjour" class="translate" data-fr="Bonjour" data-en="Hello" data-ja="こんにちは">Bonjour</option>
+          <option value="parc" class="translate" data-fr="Parc" data-en="Park" data-ja="公園">Parc</option>
+          <option value="manège" class="translate" data-fr="Manège" data-en="Ride" data-ja="乗り物">Manège</option>
+        </select>
+      </div>
+
+      <div id="local-controls" class="chooser-toolbar" style="display:none;">
+        <input id="local-video-input" class="styled-input" type="file" accept="video/*" />
+      </div>
+
+      <div id="youtube-controls" style="display:none;">
+        <div class="actions-row">
+          <input id="youtube-url-input" class="control-panel-input" type="text" placeholder="https://www.youtube.com/watch?v=..." />
+          <button id="add-youtube-button" class="button translate" data-fr="Ajouter URL" data-en="Add URL" data-ja="URLを追加">Ajouter URL</button>
+        </div>
+        <div class="actions-row">
+          <input id="youtube-playlist-input" class="control-panel-input" type="text" placeholder="URL de playlist (optionnel)" />
+          <button id="import-playlist-button" class="button translate" data-fr="Importer playlist" data-en="Import playlist" data-ja="プレイリストをインポート">Importer playlist</button>
+        </div>
+      </div>
+
+      <div id="picker-status" class="status-note" aria-live="polite"></div>
+      <div id="single-video-grid" aria-live="polite"></div>
+
+      <div class="actions-row">
+        <button id="back-to-source-button" class="button translate" data-fr="Retour" data-en="Back" data-ja="戻る">Retour</button>
+        <button id="start-look-video-button" class="button translate" data-fr="Commencer" data-en="Start" data-ja="開始" disabled>Commencer</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="video-stage" aria-live="polite">
+    <div id="look-video-frame">
+      <video id="look-video" playsinline preload="metadata"></video>
+      <div id="youtube-player" style="display:none;"></div>
+      <div id="look-zone" aria-label="Look here to play video"></div>
+      <div id="look-status" class="translate" data-fr="Regardez la vidéo pour jouer" data-en="Look at the video to play" data-ja="動画を見ると再生します">Regardez la vidéo pour jouer</div>
+    </div>
+  </div>
+
+  <div id="gazePointer" aria-hidden="true"></div>
+
+  <script src="https://www.youtube.com/iframe_api"></script>
+  <script src="../../js/config.js"></script>
+  <script src="../../js/choiceArray.js"></script>
+  <script src="../../js/lookToPlayVideo.js"></script>
+  <script src="../../js/translationmain.js"></script>
+  <script>
+    document.getElementById('language-toggle')?.addEventListener('pointerup', toggleLanguage);
+  </script>
+</body>
+</html>

--- a/js/lookToPlayVideo.js
+++ b/js/lookToPlayVideo.js
@@ -1,23 +1,26 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const sourceModal = document.getElementById('source-modal');
-  const pickerModal = document.getElementById('picker-modal');
-  const sourceButtons = Array.from(document.querySelectorAll('.source-pill'));
+  const gameOptionsModal = document.getElementById('game-options');
+  const tilePickerModal = document.getElementById('tile-picker-modal');
+  const sourceButtons = Array.from(document.querySelectorAll('#mode-segmented-control .mode-btn'));
+  const chooseSourceButton = document.getElementById('choose-source-button');
+  const sourceSummary = document.getElementById('source-summary');
   const libraryControls = document.getElementById('library-controls');
-  const localControls = document.getElementById('local-controls');
-  const youtubeControls = document.getElementById('youtube-controls');
+  const localImportControls = document.getElementById('local-import-controls');
+  const youtubeImportControls = document.getElementById('yt-import-controls');
   const categorySelect = document.getElementById('categorySelect');
-  const localVideoInput = document.getElementById('local-video-input');
-  const youtubeUrlInput = document.getElementById('youtube-url-input');
-  const youtubePlaylistInput = document.getElementById('youtube-playlist-input');
-  const addYoutubeButton = document.getElementById('add-youtube-button');
-  const importPlaylistButton = document.getElementById('import-playlist-button');
-  const pickerStatus = document.getElementById('picker-status');
-  const grid = document.getElementById('single-video-grid');
+  const addVideoButton = document.getElementById('add-video-file-button');
+  const addVideoInput = document.getElementById('add-video-input');
+  const addYoutubeButton = document.getElementById('add-video-url-button');
+  const addYoutubeInput = document.getElementById('add-video-url-input');
+  const playlistButton = document.getElementById('yt-playlist-import-button');
+  const playlistInput = document.getElementById('yt-playlist-url-input');
+  const clearButton = document.getElementById('clear-videos-button');
   const backButton = document.getElementById('back-to-source-button');
-  const startButton = document.getElementById('start-look-video-button');
-  const videoStage = document.getElementById('video-stage');
-  const videoFrame = document.getElementById('look-video-frame');
-  const video = document.getElementById('look-video');
+  const tilePickerGrid = document.getElementById('tile-picker-grid');
+  const startGameButton = document.getElementById('start-game-button');
+  const videoContainer = document.getElementById('video-container');
+  const videoPlayer = document.getElementById('video-player');
+  const videoSource = document.getElementById('video-source');
   const youtubeDiv = document.getElementById('youtube-player');
   const lookZone = document.getElementById('look-zone');
   const lookStatus = document.getElementById('look-status');
@@ -25,13 +28,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const languageToggle = document.getElementById('language-toggle');
 
   const LOOK_AWAY_GRACE_MS = 2000;
-  const STORAGE_KEY = 'lookToPlayYoutubeChoices';
-  const supportedSources = ['local', 'youtube', 'library'];
+  const YOUTUBE_STORAGE_KEY = 'lookToPlayYoutubeUrls';
+  const VIDEO_RX = /\.(mp4|webm|ogg|ogv|mov|m4v)$/i;
+  const sourceLabels = {
+    local: { fr: 'Source: Local', en: 'Source: Local', ja: 'ソース：ローカル' },
+    youtube: { fr: 'Source: YouTube', en: 'Source: YouTube', ja: 'ソース：YouTube' },
+    library: { fr: 'Source: Bibliothèque', en: 'Source: Library', ja: 'ソース：ライブラリ' },
+  };
 
-  let currentSource = null;
+  let currentSource = 'library';
   let currentCategory = 'all';
   let selectedChoice = null;
-  let localObjectUrl = null;
+  let localChoices = [];
   let youtubeChoices = [];
   let youtubePlayer = null;
   let youtubeApiReady = Boolean(window.YT && window.YT.Player);
@@ -47,15 +55,21 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
-  function setStatus(message = '') {
-    pickerStatus.textContent = message;
+  function getLanguage() {
+    const stored = localStorage.getItem('siteLanguage');
+    return ['fr', 'en', 'ja'].includes(stored) ? stored : 'fr';
   }
 
-  function setLookStatus(fr, en = fr, ja = en) {
-    lookStatus.textContent = fr;
-    lookStatus.dataset.fr = fr;
-    lookStatus.dataset.en = en;
-    lookStatus.dataset.ja = ja;
+  function setTranslatedText(element, strings) {
+    if (!element || !strings) return;
+    element.textContent = strings[getLanguage()] || strings.fr || strings.en || '';
+    Object.entries(strings).forEach(([lang, value]) => {
+      element.dataset[lang] = value;
+    });
+  }
+
+  function setLookStatus(strings) {
+    setTranslatedText(lookStatus, strings);
   }
 
   function ensureFullscreen() {
@@ -65,15 +79,37 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function updatePointer(event) {
+  function ensurePointerOverlay() {
     if (!gazePointer) return;
-    gazePointer.style.transform = `translate(${event.clientX}px, ${event.clientY}px)`;
+    let overlay = document.getElementById('gazePointerOverlay');
+    if (!overlay) {
+      overlay = document.createElement('div');
+      overlay.id = 'gazePointerOverlay';
+      overlay.setAttribute('aria-hidden', 'true');
+      document.body.appendChild(overlay);
+    }
+    if (gazePointer.parentElement !== overlay) {
+      overlay.appendChild(gazePointer);
+    }
   }
 
-  function categoriesInclude(choice, category) {
-    if (category === 'all') return true;
-    const categories = Array.isArray(choice.category) ? choice.category : [choice.category];
-    return categories.includes(category);
+  function setPointerPos(x, y) {
+    if (!gazePointer) return;
+    gazePointer.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)`;
+  }
+
+  function setSource(source) {
+    currentSource = source;
+    selectedChoice = null;
+    currentCategory = 'all';
+    if (categorySelect) categorySelect.value = 'all';
+
+    sourceButtons.forEach(button => {
+      button.classList.toggle('selected', button.dataset.source === source);
+    });
+
+    setTranslatedText(sourceSummary, sourceLabels[source]);
+    updateStartButtonState();
   }
 
   function isYouTubeUrl(url) {
@@ -83,7 +119,9 @@ document.addEventListener('DOMContentLoaded', () => {
   function getYouTubeId(url) {
     try {
       const parsed = new URL(url);
-      if (parsed.hostname.includes('youtu.be')) return parsed.pathname.slice(1).split(/[?&]/)[0];
+      if (parsed.hostname.includes('youtu.be')) {
+        return parsed.pathname.slice(1).split(/[?&]/)[0];
+      }
       const id = parsed.searchParams.get('v');
       if (id) return id;
       const shorts = parsed.pathname.match(/\/shorts\/([a-zA-Z0-9_-]+)/);
@@ -116,53 +154,115 @@ document.addEventListener('DOMContentLoaded', () => {
     return url;
   }
 
-  function saveYoutubeChoices() {
+  function categoriesInclude(choice, category) {
+    if (category === 'all') return true;
+    const categories = Array.isArray(choice.category) ? choice.category : [choice.category];
+    return categories.includes(category);
+  }
+
+  function choicesForCurrentSource() {
+    if (currentSource === 'library') {
+      return mediaChoices
+        .filter(choice => categoriesInclude(choice, currentCategory))
+        .map(choice => ({ ...choice, sourceType: 'native' }));
+    }
+    if (currentSource === 'local') return localChoices;
+    if (currentSource === 'youtube') return youtubeChoices;
+    return [];
+  }
+
+  function updateStartButtonState() {
+    startGameButton.disabled = !selectedChoice?.video;
+  }
+
+  function populateTilePickerGrid() {
+    tilePickerGrid.innerHTML = '';
+    const choices = choicesForCurrentSource();
+
+    choices.forEach((choice, index) => {
+      const tileOption = document.createElement('div');
+      tileOption.classList.add('tile');
+      tileOption.setAttribute('data-index', index);
+      tileOption.style.backgroundImage = choice.image ? `url(${choice.image})` : 'none';
+      if (selectedChoice?.video === choice.video) {
+        tileOption.classList.add('selected');
+      }
+
+      const caption = document.createElement('div');
+      caption.classList.add('caption');
+      caption.textContent = choice.name || 'Vidéo';
+      tileOption.appendChild(caption);
+
+      tileOption.addEventListener('click', () => {
+        selectedChoice = choice;
+        updateStartButtonState();
+        populateTilePickerGrid();
+      });
+
+      tilePickerGrid.appendChild(tileOption);
+    });
+  }
+
+  window.populateTilePickerGrid = populateTilePickerGrid;
+
+  function showPicker() {
+    selectedChoice = null;
+    gameOptionsModal.style.display = 'none';
+    tilePickerModal.style.display = 'flex';
+    libraryControls.style.display = currentSource === 'library' ? 'flex' : 'none';
+    localImportControls.style.display = currentSource === 'local' ? 'block' : 'none';
+    youtubeImportControls.style.display = currentSource === 'youtube' ? 'block' : 'none';
+    clearButton.style.display = currentSource === 'youtube' ? '' : 'none';
+    populateTilePickerGrid();
+    updateStartButtonState();
+    ensureFullscreen();
+  }
+
+  function showSourceOptions() {
+    tilePickerModal.style.display = 'none';
+    gameOptionsModal.style.display = 'flex';
+  }
+
+  function saveYoutubeUrls() {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(youtubeChoices.map(choice => choice.video)));
+      localStorage.setItem(YOUTUBE_STORAGE_KEY, JSON.stringify(youtubeChoices.map(choice => choice.video)));
     } catch {}
   }
 
-  async function loadYoutubeChoices() {
+  async function loadYoutubeUrls() {
     try {
-      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
-      for (const url of saved) {
+      const urls = JSON.parse(localStorage.getItem(YOUTUBE_STORAGE_KEY) || '[]');
+      for (const url of urls) {
         const id = getYouTubeId(url);
         if (!id || youtubeChoices.some(choice => choice.video === url)) continue;
         youtubeChoices.push({
           name: await fetchVideoTitle(url),
           image: `https://img.youtube.com/vi/${id}/mqdefault.jpg`,
           video: url,
-          type: 'youtube',
+          sourceType: 'youtube',
         });
       }
     } catch {}
   }
 
-  async function addYoutubeUrl(url) {
-    const cleanUrl = url.trim();
-    const id = getYouTubeId(cleanUrl);
-    if (!id || !isYouTubeUrl(cleanUrl)) {
-      setStatus('URL YouTube invalide / Invalid YouTube URL');
-      return;
-    }
+  async function addYoutubeByUrl(url) {
+    const id = getYouTubeId(url.trim());
+    if (!id || !isYouTubeUrl(url.trim())) return;
 
     const canonicalUrl = `https://www.youtube.com/watch?v=${id}`;
-    let choice = youtubeChoices.find(item => item.video === canonicalUrl);
-    if (!choice) {
-      choice = {
+    if (!youtubeChoices.some(choice => choice.video === canonicalUrl)) {
+      youtubeChoices.push({
         name: await fetchVideoTitle(canonicalUrl),
         image: `https://img.youtube.com/vi/${id}/mqdefault.jpg`,
         video: canonicalUrl,
-        type: 'youtube',
-      };
-      youtubeChoices.push(choice);
-      saveYoutubeChoices();
+        sourceType: 'youtube',
+      });
+      saveYoutubeUrls();
     }
 
-    selectedChoice = choice;
-    setStatus('Vidéo YouTube ajoutée. / YouTube video added.');
-    renderGrid();
-    updateStartButton();
+    selectedChoice = youtubeChoices.find(choice => choice.video === canonicalUrl) || null;
+    populateTilePickerGrid();
+    updateStartButtonState();
   }
 
   async function fetchPlaylistVideoIds(apiKey, playlistId) {
@@ -176,9 +276,17 @@ document.addEventListener('DOMContentLoaded', () => {
       url.searchParams.set('key', apiKey);
       if (pageToken) url.searchParams.set('pageToken', pageToken);
       const response = await fetch(url);
-      const data = await response.json();
-      if (!response.ok) throw new Error(data?.error?.message || `HTTP ${response.status}`);
-      data.items?.forEach(item => {
+      const text = await response.text();
+      if (!response.ok) {
+        let message = `HTTP ${response.status}`;
+        try {
+          const data = JSON.parse(text);
+          if (data.error?.message) message += ` – ${data.error.message}`;
+        } catch {}
+        throw new Error(message);
+      }
+      const data = JSON.parse(text);
+      (data.items || []).forEach(item => {
         if (item?.contentDetails?.videoId) ids.push(item.contentDetails.videoId);
       });
       pageToken = data.nextPageToken || '';
@@ -187,106 +295,91 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function importPlaylist() {
-    const playlistId = getPlaylistIdFromUrl(youtubePlaylistInput.value.trim());
+    const playlistId = getPlaylistIdFromUrl(playlistInput.value.trim());
     const apiKey = window.YT_API_KEY;
-    if (!playlistId) {
-      setStatus("URL de playlist invalide. / Invalid playlist URL.");
-      return;
-    }
-    if (!apiKey) {
-      setStatus('Clé API YouTube absente. / Missing YouTube API key.');
-      return;
-    }
+    if (!playlistId || !apiKey) return;
 
-    importPlaylistButton.disabled = true;
-    setStatus('Importation de la playlist... / Importing playlist...');
+    playlistButton.disabled = true;
     try {
       const ids = await fetchPlaylistVideoIds(apiKey, playlistId);
       for (const id of ids) {
-        const url = `https://www.youtube.com/watch?v=${id}`;
-        if (!youtubeChoices.some(choice => choice.video === url)) {
-          youtubeChoices.push({
-            name: await fetchVideoTitle(url),
-            image: `https://img.youtube.com/vi/${id}/mqdefault.jpg`,
-            video: url,
-            type: 'youtube',
-          });
-        }
+        await addYoutubeByUrl(`https://www.youtube.com/watch?v=${id}`);
       }
-      saveYoutubeChoices();
-      setStatus(`${ids.length} vidéos importées. / ${ids.length} videos imported.`);
-      renderGrid();
-    } catch (error) {
-      setStatus(`Import échoué: ${error.message}`);
+    } catch (err) {
+      console.error(err);
     } finally {
-      importPlaylistButton.disabled = false;
+      playlistButton.disabled = false;
+      populateTilePickerGrid();
     }
   }
 
-  function choicesForCurrentSource() {
-    if (currentSource === 'library') {
-      return (Array.isArray(window.mediaChoices) ? window.mediaChoices : mediaChoices)
-        .filter(choice => categoriesInclude(choice, currentCategory))
-        .map(choice => ({ ...choice, type: 'file' }));
-    }
-    if (currentSource === 'youtube') return youtubeChoices;
-    if (currentSource === 'local' && selectedChoice) return [selectedChoice];
-    return [];
+  async function makeThumbnailFromVideo(file) {
+    return new Promise(resolve => {
+      const url = URL.createObjectURL(file);
+      const video = document.createElement('video');
+      video.preload = 'metadata';
+      video.muted = true;
+      video.playsInline = true;
+      video.src = url;
+
+      const cleanup = () => { try { URL.revokeObjectURL(url); } catch {} };
+
+      video.addEventListener('loadedmetadata', () => {
+        try {
+          video.currentTime = Math.min(10, Math.max(0, (video.duration || 0) - 0.1));
+        } catch {}
+      }, { once: true });
+
+      video.addEventListener('seeked', () => {
+        try {
+          const canvas = document.createElement('canvas');
+          canvas.width = 640;
+          canvas.height = 360;
+          const context = canvas.getContext('2d');
+          const scale = Math.min(canvas.width / video.videoWidth, canvas.height / video.videoHeight);
+          const width = video.videoWidth * scale;
+          const height = video.videoHeight * scale;
+          context.drawImage(video, (canvas.width - width) / 2, (canvas.height - height) / 2, width, height);
+          resolve(canvas.toDataURL('image/jpeg', 0.85));
+        } catch {
+          resolve('../../images/localvideosmultiplechoices.png');
+        }
+        cleanup();
+      }, { once: true });
+
+      video.addEventListener('error', () => {
+        cleanup();
+        resolve('../../images/localvideosmultiplechoices.png');
+      }, { once: true });
+
+      setTimeout(() => {
+        cleanup();
+        resolve('../../images/localvideosmultiplechoices.png');
+      }, 3000);
+    });
   }
 
-  function renderGrid() {
-    grid.innerHTML = '';
-    const choices = choicesForCurrentSource();
+  function revokeLocalChoices() {
+    localChoices.forEach(choice => {
+      try { URL.revokeObjectURL(choice.video); } catch {}
+    });
+  }
 
-    choices.forEach(choice => {
-      const tile = document.createElement('button');
-      tile.type = 'button';
-      tile.className = 'tile';
-      if (selectedChoice?.video === choice.video) tile.classList.add('selected');
-      if (choice.image) tile.style.backgroundImage = `url(${choice.image})`;
-      tile.innerHTML = `<span class="caption"></span>`;
-      tile.querySelector('.caption').textContent = choice.name || 'Vidéo';
-      tile.addEventListener('click', () => {
-        selectedChoice = choice;
-        renderGrid();
-        updateStartButton();
+  async function addLocalFiles(files) {
+    revokeLocalChoices();
+    localChoices = [];
+    for (const file of files) {
+      if (!VIDEO_RX.test(file.name)) continue;
+      localChoices.push({
+        name: file.name,
+        image: await makeThumbnailFromVideo(file),
+        video: URL.createObjectURL(file),
+        sourceType: 'native',
       });
-      grid.appendChild(tile);
-    });
-
-    if (!choices.length) {
-      const empty = document.createElement('p');
-      empty.className = 'status-note';
-      empty.textContent = currentSource === 'local'
-        ? 'Choisissez un fichier vidéo. / Choose a video file.'
-        : 'Aucune vidéo à afficher. / No videos to show.';
-      grid.appendChild(empty);
     }
-  }
-
-  function updateStartButton() {
-    startButton.disabled = !selectedChoice?.video;
-  }
-
-  function resetPickerForSource(source) {
-    currentSource = source;
-    selectedChoice = null;
-    currentCategory = 'all';
-    if (categorySelect) categorySelect.value = 'all';
-    setStatus('');
-
-    libraryControls.style.display = source === 'library' ? 'flex' : 'none';
-    localControls.style.display = source === 'local' ? 'flex' : 'none';
-    youtubeControls.style.display = source === 'youtube' ? 'block' : 'none';
-
-    sourceButtons.forEach(button => {
-      button.classList.toggle('selected', button.dataset.source === source);
-    });
-
-    sourceModal.style.display = 'none';
-    pickerModal.style.display = 'flex';
-    renderGrid();
-    updateStartButton();
+    selectedChoice = localChoices[0] || null;
+    populateTilePickerGrid();
+    updateStartButtonState();
   }
 
   function clearPauseTimer() {
@@ -296,66 +389,71 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function playSelectedMedia() {
+  function playCurrentVideo() {
     clearPauseTimer();
     if (!selectedChoice) return;
-    setLookStatus('Lecture...', 'Playing...', '再生中...');
-    if (selectedChoice.type === 'youtube') {
-      try { youtubePlayer?.playVideo(); isPlaying = true; } catch {}
+    setLookStatus({ fr: 'Lecture...', en: 'Playing...', ja: '再生中...' });
+
+    if (selectedChoice.sourceType === 'youtube') {
+      try {
+        youtubePlayer?.playVideo();
+        isPlaying = true;
+      } catch {}
     } else {
-      video.play().then(() => { isPlaying = true; }).catch(() => {
-        setLookStatus('Cliquez ou regardez de nouveau pour jouer', 'Click or look again to play', 'クリックするか、もう一度見て再生します');
+      videoPlayer.play().then(() => {
+        isPlaying = true;
+      }).catch(err => {
+        console.error(err);
       });
     }
   }
 
-  function pauseSelectedMedia() {
+  function pauseCurrentVideo() {
     clearPauseTimer();
-    if (selectedChoice?.type === 'youtube') {
+    if (selectedChoice?.sourceType === 'youtube') {
       try { youtubePlayer?.pauseVideo(); } catch {}
     } else {
-      video.pause();
+      videoPlayer.pause();
     }
     isPlaying = false;
-    setLookStatus('Regardez la vidéo pour jouer', 'Look at the video to play', '動画を見ると再生します');
+    setLookStatus({ fr: 'Regardez la vidéo pour jouer', en: 'Look at the video to play', ja: '動画を見ると再生します' });
   }
 
-  function scheduleGracePause() {
+  function schedulePauseAfterGrace() {
     clearPauseTimer();
-    setLookStatus('Pause dans 2 secondes...', 'Pausing in 2 seconds...', '2秒後に一時停止...');
+    setLookStatus({ fr: 'Pause dans 2 secondes...', en: 'Pausing in 2 seconds...', ja: '2秒後に一時停止...' });
     pauseTimer = setTimeout(() => {
-      if (!isLooking) pauseSelectedMedia();
+      if (!isLooking) pauseCurrentVideo();
     }, LOOK_AWAY_GRACE_MS);
   }
 
   function handleLookStart() {
     isLooking = true;
-    playSelectedMedia();
+    playCurrentVideo();
   }
 
   function handleLookEnd() {
     isLooking = false;
-    if (isPlaying) scheduleGracePause();
+    if (isPlaying) schedulePauseAfterGrace();
   }
 
-  function resetPlayers() {
+  function resetPlayback() {
     clearPauseTimer();
     isLooking = false;
     isPlaying = false;
     try { youtubePlayer?.stopVideo(); } catch {}
-    video.pause();
-    video.removeAttribute('src');
-    video.load();
-    youtubeDiv.style.display = 'none';
-    video.style.display = 'block';
+    videoPlayer.pause();
+    videoPlayer.currentTime = 0;
   }
 
   function loadYoutubeVideo(videoId) {
     pendingYoutubeVideoId = videoId;
     if (!youtubeApiReady) return;
+
     pendingYoutubeVideoId = null;
-    video.style.display = 'none';
+    videoPlayer.style.display = 'none';
     youtubeDiv.style.display = 'block';
+
     if (!youtubePlayer) {
       youtubePlayer = new YT.Player('youtube-player', {
         host: 'https://www.youtube-nocookie.com',
@@ -363,120 +461,116 @@ document.addEventListener('DOMContentLoaded', () => {
         playerVars: { controls: 0, disablekb: 1, modestbranding: 1, rel: 0, playsinline: 1 },
         events: {
           onReady: () => {
-            if (isLooking) playSelectedMedia();
+            try { youtubePlayer.pauseVideo(); } catch {}
+            if (isLooking) playCurrentVideo();
           },
           onStateChange: event => {
             if (event.data === YT.PlayerState.ENDED) {
               isPlaying = false;
-              setLookStatus('Vidéo terminée', 'Video ended', '動画が終了しました');
+              setLookStatus({ fr: 'Vidéo terminée', en: 'Video ended', ja: '動画が終了しました' });
             }
           },
         },
       });
     } else {
       youtubePlayer.loadVideoById(videoId);
-      youtubePlayer.pauseVideo();
+      try { youtubePlayer.pauseVideo(); } catch {}
     }
   }
 
-  function startExperience() {
+  function startLookToPlay() {
     if (!selectedChoice?.video) return;
-    pickerModal.style.display = 'none';
-    sourceModal.style.display = 'none';
-    if (languageToggle) languageToggle.style.display = 'none';
-    resetPlayers();
 
-    if (selectedChoice.type === 'youtube') {
-      const videoId = getYouTubeId(selectedChoice.video);
-      loadYoutubeVideo(videoId);
+    resetPlayback();
+    tilePickerModal.style.display = 'none';
+    gameOptionsModal.style.display = 'none';
+    videoContainer.style.display = 'flex';
+    if (languageToggle) languageToggle.style.display = 'none';
+    gazePointer?.classList.add('look-visible', 'gp-dwell');
+
+    if (selectedChoice.sourceType === 'youtube') {
+      videoSource.removeAttribute('src');
+      videoPlayer.removeAttribute('src');
+      loadYoutubeVideo(getYouTubeId(selectedChoice.video));
     } else {
-      video.src = selectedChoice.video;
-      video.load();
+      youtubeDiv.style.display = 'none';
+      videoPlayer.style.display = 'block';
+      videoSource.src = selectedChoice.video;
+      videoPlayer.load();
     }
 
-    videoStage.style.display = 'flex';
-    setLookStatus('Regardez la vidéo pour jouer', 'Look at the video to play', '動画を見ると再生します');
+    setLookStatus({ fr: 'Regardez la vidéo pour jouer', en: 'Look at the video to play', ja: '動画を見ると再生します' });
     ensureFullscreen();
   }
 
   function returnToPicker() {
-    resetPlayers();
-    videoStage.style.display = 'none';
-    pickerModal.style.display = 'flex';
+    resetPlayback();
+    videoContainer.style.display = 'none';
+    tilePickerModal.style.display = 'flex';
     if (languageToggle) languageToggle.style.display = '';
+    gazePointer?.classList.remove('look-visible', 'gp-dwell');
   }
 
   sourceButtons.forEach(button => {
-    button.addEventListener('click', async () => {
-      const source = button.dataset.source;
-      if (!supportedSources.includes(source)) return;
-      if (source === 'youtube' && youtubeChoices.length === 0) {
-        await loadYoutubeChoices();
-      }
-      resetPickerForSource(source);
-    });
+    button.addEventListener('click', () => setSource(button.dataset.source));
   });
 
-  backButton.addEventListener('click', () => {
-    pickerModal.style.display = 'none';
-    sourceModal.style.display = 'flex';
-  });
+  chooseSourceButton.addEventListener('click', showPicker);
+  backButton.addEventListener('click', showSourceOptions);
+  startGameButton.addEventListener('click', startLookToPlay);
 
   categorySelect.addEventListener('change', event => {
     currentCategory = event.target.value;
     selectedChoice = null;
-    renderGrid();
-    updateStartButton();
+    populateTilePickerGrid();
+    updateStartButtonState();
   });
 
-  localVideoInput.addEventListener('change', event => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-    if (localObjectUrl) URL.revokeObjectURL(localObjectUrl);
-    localObjectUrl = URL.createObjectURL(file);
-    selectedChoice = {
-      name: file.name,
-      image: '../../images/localvideosmultiplechoices.png',
-      video: localObjectUrl,
-      type: 'file',
-    };
-    setStatus('Vidéo locale prête. / Local video ready.');
-    renderGrid();
-    updateStartButton();
+  addVideoButton.addEventListener('click', () => addVideoInput.click());
+  addVideoInput.addEventListener('change', async () => {
+    await addLocalFiles(addVideoInput.files || []);
+    addVideoInput.value = '';
   });
 
-  addYoutubeButton.addEventListener('click', () => addYoutubeUrl(youtubeUrlInput.value));
-  youtubeUrlInput.addEventListener('keydown', event => {
-    if (event.key === 'Enter') addYoutubeUrl(youtubeUrlInput.value);
+  addYoutubeButton.addEventListener('click', () => addYoutubeByUrl(addYoutubeInput.value));
+  addYoutubeInput.addEventListener('keydown', event => {
+    if (event.key === 'Enter') addYoutubeByUrl(addYoutubeInput.value);
   });
-  importPlaylistButton.addEventListener('click', importPlaylist);
-  startButton.addEventListener('click', startExperience);
+  playlistButton.addEventListener('click', importPlaylist);
+  clearButton.addEventListener('click', () => {
+    youtubeChoices = [];
+    selectedChoice = null;
+    try { localStorage.removeItem(YOUTUBE_STORAGE_KEY); } catch {}
+    populateTilePickerGrid();
+    updateStartButtonState();
+  });
 
   lookZone.addEventListener('pointerenter', handleLookStart);
   lookZone.addEventListener('pointermove', event => {
-    updatePointer(event);
+    setPointerPos(event.clientX, event.clientY);
     if (!isLooking) handleLookStart();
   });
   lookZone.addEventListener('pointerleave', handleLookEnd);
-  videoFrame.addEventListener('click', () => {
-    isLooking = true;
-    playSelectedMedia();
+
+  document.addEventListener('pointermove', event => {
+    setPointerPos(event.clientX, event.clientY);
   });
 
-  document.addEventListener('pointermove', updatePointer);
   document.addEventListener('keydown', event => {
-    if (videoStage.style.display === 'flex' && (event.key === 'Escape' || event.key === 'Backspace')) {
+    if (videoContainer.style.display === 'flex' && (event.key === 'Escape' || event.key === 'Backspace')) {
       event.preventDefault();
       returnToPicker();
     }
   });
 
-  video.addEventListener('ended', () => {
+  videoPlayer.addEventListener('ended', () => {
     isPlaying = false;
-    setLookStatus('Vidéo terminée', 'Video ended', '動画が終了しました');
+    setLookStatus({ fr: 'Vidéo terminée', en: 'Video ended', ja: '動画が終了しました' });
   });
 
-  window.addEventListener('beforeunload', () => {
-    if (localObjectUrl) URL.revokeObjectURL(localObjectUrl);
-  });
+  window.addEventListener('beforeunload', revokeLocalChoices);
+
+  ensurePointerOverlay();
+  setSource('library');
+  loadYoutubeUrls();
 });

--- a/js/lookToPlayVideo.js
+++ b/js/lookToPlayVideo.js
@@ -1,0 +1,482 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const sourceModal = document.getElementById('source-modal');
+  const pickerModal = document.getElementById('picker-modal');
+  const sourceButtons = Array.from(document.querySelectorAll('.source-pill'));
+  const libraryControls = document.getElementById('library-controls');
+  const localControls = document.getElementById('local-controls');
+  const youtubeControls = document.getElementById('youtube-controls');
+  const categorySelect = document.getElementById('categorySelect');
+  const localVideoInput = document.getElementById('local-video-input');
+  const youtubeUrlInput = document.getElementById('youtube-url-input');
+  const youtubePlaylistInput = document.getElementById('youtube-playlist-input');
+  const addYoutubeButton = document.getElementById('add-youtube-button');
+  const importPlaylistButton = document.getElementById('import-playlist-button');
+  const pickerStatus = document.getElementById('picker-status');
+  const grid = document.getElementById('single-video-grid');
+  const backButton = document.getElementById('back-to-source-button');
+  const startButton = document.getElementById('start-look-video-button');
+  const videoStage = document.getElementById('video-stage');
+  const videoFrame = document.getElementById('look-video-frame');
+  const video = document.getElementById('look-video');
+  const youtubeDiv = document.getElementById('youtube-player');
+  const lookZone = document.getElementById('look-zone');
+  const lookStatus = document.getElementById('look-status');
+  const gazePointer = document.getElementById('gazePointer');
+  const languageToggle = document.getElementById('language-toggle');
+
+  const LOOK_AWAY_GRACE_MS = 2000;
+  const STORAGE_KEY = 'lookToPlayYoutubeChoices';
+  const supportedSources = ['local', 'youtube', 'library'];
+
+  let currentSource = null;
+  let currentCategory = 'all';
+  let selectedChoice = null;
+  let localObjectUrl = null;
+  let youtubeChoices = [];
+  let youtubePlayer = null;
+  let youtubeApiReady = Boolean(window.YT && window.YT.Player);
+  let pendingYoutubeVideoId = null;
+  let pauseTimer = null;
+  let isLooking = false;
+  let isPlaying = false;
+
+  window.onYouTubeIframeAPIReady = () => {
+    youtubeApiReady = true;
+    if (pendingYoutubeVideoId) {
+      loadYoutubeVideo(pendingYoutubeVideoId);
+    }
+  };
+
+  function setStatus(message = '') {
+    pickerStatus.textContent = message;
+  }
+
+  function setLookStatus(fr, en = fr, ja = en) {
+    lookStatus.textContent = fr;
+    lookStatus.dataset.fr = fr;
+    lookStatus.dataset.en = en;
+    lookStatus.dataset.ja = ja;
+  }
+
+  function ensureFullscreen() {
+    const root = document.documentElement;
+    if (!document.fullscreenElement && root.requestFullscreen) {
+      root.requestFullscreen().catch(() => {});
+    }
+  }
+
+  function updatePointer(event) {
+    if (!gazePointer) return;
+    gazePointer.style.transform = `translate(${event.clientX}px, ${event.clientY}px)`;
+  }
+
+  function categoriesInclude(choice, category) {
+    if (category === 'all') return true;
+    const categories = Array.isArray(choice.category) ? choice.category : [choice.category];
+    return categories.includes(category);
+  }
+
+  function isYouTubeUrl(url) {
+    return /^(https?:\/\/)?(www\.|m\.)?((youtube\.com\/\S+)|(youtu\.be\/\S+))$/.test(url);
+  }
+
+  function getYouTubeId(url) {
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname.includes('youtu.be')) return parsed.pathname.slice(1).split(/[?&]/)[0];
+      const id = parsed.searchParams.get('v');
+      if (id) return id;
+      const shorts = parsed.pathname.match(/\/shorts\/([a-zA-Z0-9_-]+)/);
+      if (shorts) return shorts[1];
+      const embed = parsed.pathname.match(/\/embed\/([a-zA-Z0-9_-]+)/);
+      return embed ? embed[1] : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function getPlaylistIdFromUrl(url) {
+    try {
+      const parsed = new URL(url);
+      return parsed.searchParams.get('list');
+    } catch {
+      const match = String(url).match(/[?&]list=([a-zA-Z0-9_-]+)/);
+      return match ? match[1] : null;
+    }
+  }
+
+  async function fetchVideoTitle(url) {
+    try {
+      const response = await fetch(`https://noembed.com/embed?url=${encodeURIComponent(url)}`);
+      if (response.ok) {
+        const data = await response.json();
+        if (data?.title) return data.title;
+      }
+    } catch {}
+    return url;
+  }
+
+  function saveYoutubeChoices() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(youtubeChoices.map(choice => choice.video)));
+    } catch {}
+  }
+
+  async function loadYoutubeChoices() {
+    try {
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      for (const url of saved) {
+        const id = getYouTubeId(url);
+        if (!id || youtubeChoices.some(choice => choice.video === url)) continue;
+        youtubeChoices.push({
+          name: await fetchVideoTitle(url),
+          image: `https://img.youtube.com/vi/${id}/mqdefault.jpg`,
+          video: url,
+          type: 'youtube',
+        });
+      }
+    } catch {}
+  }
+
+  async function addYoutubeUrl(url) {
+    const cleanUrl = url.trim();
+    const id = getYouTubeId(cleanUrl);
+    if (!id || !isYouTubeUrl(cleanUrl)) {
+      setStatus('URL YouTube invalide / Invalid YouTube URL');
+      return;
+    }
+
+    const canonicalUrl = `https://www.youtube.com/watch?v=${id}`;
+    let choice = youtubeChoices.find(item => item.video === canonicalUrl);
+    if (!choice) {
+      choice = {
+        name: await fetchVideoTitle(canonicalUrl),
+        image: `https://img.youtube.com/vi/${id}/mqdefault.jpg`,
+        video: canonicalUrl,
+        type: 'youtube',
+      };
+      youtubeChoices.push(choice);
+      saveYoutubeChoices();
+    }
+
+    selectedChoice = choice;
+    setStatus('Vidéo YouTube ajoutée. / YouTube video added.');
+    renderGrid();
+    updateStartButton();
+  }
+
+  async function fetchPlaylistVideoIds(apiKey, playlistId) {
+    const ids = [];
+    let pageToken = '';
+    do {
+      const url = new URL('https://www.googleapis.com/youtube/v3/playlistItems');
+      url.searchParams.set('part', 'contentDetails');
+      url.searchParams.set('maxResults', '50');
+      url.searchParams.set('playlistId', playlistId);
+      url.searchParams.set('key', apiKey);
+      if (pageToken) url.searchParams.set('pageToken', pageToken);
+      const response = await fetch(url);
+      const data = await response.json();
+      if (!response.ok) throw new Error(data?.error?.message || `HTTP ${response.status}`);
+      data.items?.forEach(item => {
+        if (item?.contentDetails?.videoId) ids.push(item.contentDetails.videoId);
+      });
+      pageToken = data.nextPageToken || '';
+    } while (pageToken);
+    return ids;
+  }
+
+  async function importPlaylist() {
+    const playlistId = getPlaylistIdFromUrl(youtubePlaylistInput.value.trim());
+    const apiKey = window.YT_API_KEY;
+    if (!playlistId) {
+      setStatus("URL de playlist invalide. / Invalid playlist URL.");
+      return;
+    }
+    if (!apiKey) {
+      setStatus('Clé API YouTube absente. / Missing YouTube API key.');
+      return;
+    }
+
+    importPlaylistButton.disabled = true;
+    setStatus('Importation de la playlist... / Importing playlist...');
+    try {
+      const ids = await fetchPlaylistVideoIds(apiKey, playlistId);
+      for (const id of ids) {
+        const url = `https://www.youtube.com/watch?v=${id}`;
+        if (!youtubeChoices.some(choice => choice.video === url)) {
+          youtubeChoices.push({
+            name: await fetchVideoTitle(url),
+            image: `https://img.youtube.com/vi/${id}/mqdefault.jpg`,
+            video: url,
+            type: 'youtube',
+          });
+        }
+      }
+      saveYoutubeChoices();
+      setStatus(`${ids.length} vidéos importées. / ${ids.length} videos imported.`);
+      renderGrid();
+    } catch (error) {
+      setStatus(`Import échoué: ${error.message}`);
+    } finally {
+      importPlaylistButton.disabled = false;
+    }
+  }
+
+  function choicesForCurrentSource() {
+    if (currentSource === 'library') {
+      return (Array.isArray(window.mediaChoices) ? window.mediaChoices : mediaChoices)
+        .filter(choice => categoriesInclude(choice, currentCategory))
+        .map(choice => ({ ...choice, type: 'file' }));
+    }
+    if (currentSource === 'youtube') return youtubeChoices;
+    if (currentSource === 'local' && selectedChoice) return [selectedChoice];
+    return [];
+  }
+
+  function renderGrid() {
+    grid.innerHTML = '';
+    const choices = choicesForCurrentSource();
+
+    choices.forEach(choice => {
+      const tile = document.createElement('button');
+      tile.type = 'button';
+      tile.className = 'tile';
+      if (selectedChoice?.video === choice.video) tile.classList.add('selected');
+      if (choice.image) tile.style.backgroundImage = `url(${choice.image})`;
+      tile.innerHTML = `<span class="caption"></span>`;
+      tile.querySelector('.caption').textContent = choice.name || 'Vidéo';
+      tile.addEventListener('click', () => {
+        selectedChoice = choice;
+        renderGrid();
+        updateStartButton();
+      });
+      grid.appendChild(tile);
+    });
+
+    if (!choices.length) {
+      const empty = document.createElement('p');
+      empty.className = 'status-note';
+      empty.textContent = currentSource === 'local'
+        ? 'Choisissez un fichier vidéo. / Choose a video file.'
+        : 'Aucune vidéo à afficher. / No videos to show.';
+      grid.appendChild(empty);
+    }
+  }
+
+  function updateStartButton() {
+    startButton.disabled = !selectedChoice?.video;
+  }
+
+  function resetPickerForSource(source) {
+    currentSource = source;
+    selectedChoice = null;
+    currentCategory = 'all';
+    if (categorySelect) categorySelect.value = 'all';
+    setStatus('');
+
+    libraryControls.style.display = source === 'library' ? 'flex' : 'none';
+    localControls.style.display = source === 'local' ? 'flex' : 'none';
+    youtubeControls.style.display = source === 'youtube' ? 'block' : 'none';
+
+    sourceButtons.forEach(button => {
+      button.classList.toggle('selected', button.dataset.source === source);
+    });
+
+    sourceModal.style.display = 'none';
+    pickerModal.style.display = 'flex';
+    renderGrid();
+    updateStartButton();
+  }
+
+  function clearPauseTimer() {
+    if (pauseTimer) {
+      clearTimeout(pauseTimer);
+      pauseTimer = null;
+    }
+  }
+
+  function playSelectedMedia() {
+    clearPauseTimer();
+    if (!selectedChoice) return;
+    setLookStatus('Lecture...', 'Playing...', '再生中...');
+    if (selectedChoice.type === 'youtube') {
+      try { youtubePlayer?.playVideo(); isPlaying = true; } catch {}
+    } else {
+      video.play().then(() => { isPlaying = true; }).catch(() => {
+        setLookStatus('Cliquez ou regardez de nouveau pour jouer', 'Click or look again to play', 'クリックするか、もう一度見て再生します');
+      });
+    }
+  }
+
+  function pauseSelectedMedia() {
+    clearPauseTimer();
+    if (selectedChoice?.type === 'youtube') {
+      try { youtubePlayer?.pauseVideo(); } catch {}
+    } else {
+      video.pause();
+    }
+    isPlaying = false;
+    setLookStatus('Regardez la vidéo pour jouer', 'Look at the video to play', '動画を見ると再生します');
+  }
+
+  function scheduleGracePause() {
+    clearPauseTimer();
+    setLookStatus('Pause dans 2 secondes...', 'Pausing in 2 seconds...', '2秒後に一時停止...');
+    pauseTimer = setTimeout(() => {
+      if (!isLooking) pauseSelectedMedia();
+    }, LOOK_AWAY_GRACE_MS);
+  }
+
+  function handleLookStart() {
+    isLooking = true;
+    playSelectedMedia();
+  }
+
+  function handleLookEnd() {
+    isLooking = false;
+    if (isPlaying) scheduleGracePause();
+  }
+
+  function resetPlayers() {
+    clearPauseTimer();
+    isLooking = false;
+    isPlaying = false;
+    try { youtubePlayer?.stopVideo(); } catch {}
+    video.pause();
+    video.removeAttribute('src');
+    video.load();
+    youtubeDiv.style.display = 'none';
+    video.style.display = 'block';
+  }
+
+  function loadYoutubeVideo(videoId) {
+    pendingYoutubeVideoId = videoId;
+    if (!youtubeApiReady) return;
+    pendingYoutubeVideoId = null;
+    video.style.display = 'none';
+    youtubeDiv.style.display = 'block';
+    if (!youtubePlayer) {
+      youtubePlayer = new YT.Player('youtube-player', {
+        host: 'https://www.youtube-nocookie.com',
+        videoId,
+        playerVars: { controls: 0, disablekb: 1, modestbranding: 1, rel: 0, playsinline: 1 },
+        events: {
+          onReady: () => {
+            if (isLooking) playSelectedMedia();
+          },
+          onStateChange: event => {
+            if (event.data === YT.PlayerState.ENDED) {
+              isPlaying = false;
+              setLookStatus('Vidéo terminée', 'Video ended', '動画が終了しました');
+            }
+          },
+        },
+      });
+    } else {
+      youtubePlayer.loadVideoById(videoId);
+      youtubePlayer.pauseVideo();
+    }
+  }
+
+  function startExperience() {
+    if (!selectedChoice?.video) return;
+    pickerModal.style.display = 'none';
+    sourceModal.style.display = 'none';
+    if (languageToggle) languageToggle.style.display = 'none';
+    resetPlayers();
+
+    if (selectedChoice.type === 'youtube') {
+      const videoId = getYouTubeId(selectedChoice.video);
+      loadYoutubeVideo(videoId);
+    } else {
+      video.src = selectedChoice.video;
+      video.load();
+    }
+
+    videoStage.style.display = 'flex';
+    setLookStatus('Regardez la vidéo pour jouer', 'Look at the video to play', '動画を見ると再生します');
+    ensureFullscreen();
+  }
+
+  function returnToPicker() {
+    resetPlayers();
+    videoStage.style.display = 'none';
+    pickerModal.style.display = 'flex';
+    if (languageToggle) languageToggle.style.display = '';
+  }
+
+  sourceButtons.forEach(button => {
+    button.addEventListener('click', async () => {
+      const source = button.dataset.source;
+      if (!supportedSources.includes(source)) return;
+      if (source === 'youtube' && youtubeChoices.length === 0) {
+        await loadYoutubeChoices();
+      }
+      resetPickerForSource(source);
+    });
+  });
+
+  backButton.addEventListener('click', () => {
+    pickerModal.style.display = 'none';
+    sourceModal.style.display = 'flex';
+  });
+
+  categorySelect.addEventListener('change', event => {
+    currentCategory = event.target.value;
+    selectedChoice = null;
+    renderGrid();
+    updateStartButton();
+  });
+
+  localVideoInput.addEventListener('change', event => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    if (localObjectUrl) URL.revokeObjectURL(localObjectUrl);
+    localObjectUrl = URL.createObjectURL(file);
+    selectedChoice = {
+      name: file.name,
+      image: '../../images/localvideosmultiplechoices.png',
+      video: localObjectUrl,
+      type: 'file',
+    };
+    setStatus('Vidéo locale prête. / Local video ready.');
+    renderGrid();
+    updateStartButton();
+  });
+
+  addYoutubeButton.addEventListener('click', () => addYoutubeUrl(youtubeUrlInput.value));
+  youtubeUrlInput.addEventListener('keydown', event => {
+    if (event.key === 'Enter') addYoutubeUrl(youtubeUrlInput.value);
+  });
+  importPlaylistButton.addEventListener('click', importPlaylist);
+  startButton.addEventListener('click', startExperience);
+
+  lookZone.addEventListener('pointerenter', handleLookStart);
+  lookZone.addEventListener('pointermove', event => {
+    updatePointer(event);
+    if (!isLooking) handleLookStart();
+  });
+  lookZone.addEventListener('pointerleave', handleLookEnd);
+  videoFrame.addEventListener('click', () => {
+    isLooking = true;
+    playSelectedMedia();
+  });
+
+  document.addEventListener('pointermove', updatePointer);
+  document.addEventListener('keydown', event => {
+    if (videoStage.style.display === 'flex' && (event.key === 'Escape' || event.key === 'Backspace')) {
+      event.preventDefault();
+      returnToPicker();
+    }
+  });
+
+  video.addEventListener('ended', () => {
+    isPlaying = false;
+    setLookStatus('Vidéo terminée', 'Video ended', '動画が終了しました');
+  });
+
+  window.addEventListener('beforeunload', () => {
+    if (localObjectUrl) URL.revokeObjectURL(localObjectUrl);
+  });
+});

--- a/js/lookToPlayVideo.js
+++ b/js/lookToPlayVideo.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const languageToggle = document.getElementById('language-toggle');
 
   const LOOK_AWAY_GRACE_MS = 2000;
+  const ZERO_MOVEMENT_PAUSE_MS = 3000;
   const YOUTUBE_STORAGE_KEY = 'lookToPlayYoutubeUrls';
   const VIDEO_RX = /\.(mp4|webm|ogg|ogv|mov|m4v)$/i;
   const sourceLabels = {
@@ -45,6 +46,8 @@ document.addEventListener('DOMContentLoaded', () => {
   let youtubeApiReady = Boolean(window.YT && window.YT.Player);
   let pendingYoutubeVideoId = null;
   let pauseTimer = null;
+  let noMovementTimer = null;
+  let lastMovementPosition = null;
   let isLooking = false;
   let isPlaying = false;
 
@@ -96,6 +99,42 @@ document.addEventListener('DOMContentLoaded', () => {
   function setPointerPos(x, y) {
     if (!gazePointer) return;
     gazePointer.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)`;
+  }
+
+  function isVideoVisible() {
+    return videoContainer.style.display === 'flex';
+  }
+
+  function clearNoMovementTimer() {
+    if (noMovementTimer) {
+      clearTimeout(noMovementTimer);
+      noMovementTimer = null;
+    }
+  }
+
+  function scheduleNoMovementPause() {
+    clearNoMovementTimer();
+    if (!isVideoVisible()) return;
+    noMovementTimer = setTimeout(() => {
+      isLooking = false;
+      pauseCurrentVideo();
+    }, ZERO_MOVEMENT_PAUSE_MS);
+  }
+
+  function trackPointerMovement(event) {
+    const currentPosition = { x: event.clientX, y: event.clientY };
+    setPointerPos(currentPosition.x, currentPosition.y);
+
+    const moved = !lastMovementPosition ||
+      currentPosition.x !== lastMovementPosition.x ||
+      currentPosition.y !== lastMovementPosition.y;
+
+    if (moved) {
+      lastMovementPosition = currentPosition;
+      scheduleNoMovementPause();
+    }
+
+    return moved;
   }
 
   function setSource(source) {
@@ -391,6 +430,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function playCurrentVideo() {
     clearPauseTimer();
+    scheduleNoMovementPause();
     if (!selectedChoice) return;
     setLookStatus({ fr: 'Lecture...', en: 'Playing...', ja: '再生中...' });
 
@@ -410,6 +450,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function pauseCurrentVideo() {
     clearPauseTimer();
+    clearNoMovementTimer();
     if (selectedChoice?.sourceType === 'youtube') {
       try { youtubePlayer?.pauseVideo(); } catch {}
     } else {
@@ -421,6 +462,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function schedulePauseAfterGrace() {
     clearPauseTimer();
+    clearNoMovementTimer();
     setLookStatus({ fr: 'Pause dans 2 secondes...', en: 'Pausing in 2 seconds...', ja: '2秒後に一時停止...' });
     pauseTimer = setTimeout(() => {
       if (!isLooking) pauseCurrentVideo();
@@ -439,6 +481,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function resetPlayback() {
     clearPauseTimer();
+    clearNoMovementTimer();
+    lastMovementPosition = null;
     isLooking = false;
     isPlaying = false;
     try { youtubePlayer?.stopVideo(); } catch {}
@@ -486,6 +530,7 @@ document.addEventListener('DOMContentLoaded', () => {
     gameOptionsModal.style.display = 'none';
     videoContainer.style.display = 'flex';
     if (languageToggle) languageToggle.style.display = 'none';
+    document.body.classList.add('look-video-active');
     gazePointer?.classList.add('look-visible', 'gp-dwell');
 
     if (selectedChoice.sourceType === 'youtube') {
@@ -508,6 +553,7 @@ document.addEventListener('DOMContentLoaded', () => {
     videoContainer.style.display = 'none';
     tilePickerModal.style.display = 'flex';
     if (languageToggle) languageToggle.style.display = '';
+    document.body.classList.remove('look-video-active');
     gazePointer?.classList.remove('look-visible', 'gp-dwell');
   }
 
@@ -547,13 +593,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   lookZone.addEventListener('pointerenter', handleLookStart);
   lookZone.addEventListener('pointermove', event => {
-    setPointerPos(event.clientX, event.clientY);
+    trackPointerMovement(event);
     if (!isLooking) handleLookStart();
   });
   lookZone.addEventListener('pointerleave', handleLookEnd);
 
   document.addEventListener('pointermove', event => {
-    setPointerPos(event.clientX, event.clientY);
+    trackPointerMovement(event);
   });
 
   document.addEventListener('keydown', event => {
@@ -568,7 +614,10 @@ document.addEventListener('DOMContentLoaded', () => {
     setLookStatus({ fr: 'Vidéo terminée', en: 'Video ended', ja: '動画が終了しました' });
   });
 
-  window.addEventListener('beforeunload', revokeLocalChoices);
+  window.addEventListener('beforeunload', () => {
+    clearNoMovementTimer();
+    revokeLocalChoices();
+  });
 
   ensurePointerOverlay();
   setSource('library');


### PR DESCRIPTION
### Motivation
- Provide a new gaze-driven video playback experience that plays videos only while the user is looking at the video area and supports local files, YouTube links, and a media library.
- Integrate the feature into the existing eyegaze app menu so it is discoverable alongside other eye-controlled activities.

### Description
- Added a new tile in `eyegaze/index.html` linking to the Look-to-Play page and created the page at `eyegaze/regarder-video/index.html` containing the UI, styles, and markup for source selection and the video stage.
- Implemented the playback logic in a new script `js/lookToPlayVideo.js`, which supports `local`, `youtube`, and `library` sources, local file handling via `URL.createObjectURL`, YouTube playback via the IFrame API, playlist import using `window.YT_API_KEY`, and persisting YouTube choices to `localStorage`.
- Implemented gaze interaction via a `#look-zone` and pointer events to treat pointer hover/movement as gaze, with a 2s grace period before pausing when looking away, plus a visual gaze pointer and status messages with translation attributes.
- Wired in existing modules by loading `choiceArray.js`, `config.js`, and `translationmain.js`, added a language toggle, and included Google Analytics via `gtag` on the new page.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb85a8010c83259094d20191b5f45f)