### PR TITLE
Custom YouTube picker: add search, bulk-URL import and selection toolbar

### DIFF
--- a/js/switch-two-player-custom.js
+++ b/js/switch-two-player-custom.js
@@ -30,6 +30,16 @@ function getYouTubeId(url) {
   return match ? match[1] : null;
 }
 
+function normalizeYouTubeUrl(url) {
+  const id = getYouTubeId(url);
+  return id ? `https://www.youtube.com/watch?v=${id}` : url;
+}
+
+function extractUrlsFromText(text) {
+  const urlMatches = String(text || '').match(/https?:\/\/[^\s<>'"]+/gi) || [];
+  return urlMatches.map(url => url.replace(/[),.;]+$/, ''));
+}
+
 // ---------- NEW: YouTube thumbnail helpers (no-API fallback) ----------
 function getYouTubeThumbCandidates(id) {
   return [
@@ -454,6 +464,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   const ytPlaylistInput = document.getElementById('yt-playlist-url-input');
   const ytPlaylistBtn = document.getElementById('yt-playlist-import-button');
   const ytPlaylistStatus = document.getElementById('yt-playlist-status');
+  const videoSearchInput = document.getElementById('video-search-input');
+  const videoSelectionCount = document.getElementById('video-selection-count');
+  const selectVisibleButton = document.getElementById('select-visible-button');
+  const deselectVisibleButton = document.getElementById('deselect-visible-button');
   const localImportStatus = document.getElementById('local-import-status');
   const clearAllButton = document.getElementById('clear-all-button');
   const categoriesToggle = document.getElementById('categories-toggle');
@@ -1194,6 +1208,40 @@ document.addEventListener('DOMContentLoaded', async () => {
     return keptUrls;
   }
 
+  function getVisibleVideoCards() {
+    return Array.from(document.querySelectorAll('.video-card'))
+      .filter(card => !card.classList.contains('filtered-out'));
+  }
+
+  function updateSelectionCount() {
+    if (!videoSelectionCount) return;
+    const cards = Array.from(document.querySelectorAll('.video-card'));
+    const visibleCards = getVisibleVideoCards();
+    const selectedVisible = visibleCards.filter(card => card.classList.contains('selected')).length;
+    const hiddenCount = cards.length - visibleCards.length;
+    const suffix = hiddenCount ? ` (${hiddenCount} filtrée${hiddenCount > 1 ? 's' : ''})` : '';
+    videoSelectionCount.textContent = `${selectedVisible} sélectionnée${selectedVisible > 1 ? 's' : ''} / ${visibleCards.length}${suffix}`;
+  }
+
+  function applyVideoSearchFilter() {
+    const query = (videoSearchInput?.value || '').trim().toLowerCase();
+    Array.from(document.querySelectorAll('.video-card')).forEach(card => {
+      const title = card.querySelector('.video-name')?.textContent || '';
+      const url = card.dataset.src || '';
+      const matches = !query || `${title} ${url}`.toLowerCase().includes(query);
+      card.classList.toggle('filtered-out', !matches);
+    });
+    updateSelectionCount();
+  }
+
+  function setVisibleSelection(selected) {
+    getVisibleVideoCards().forEach(card => {
+      card.classList.toggle('selected', selected);
+      card.classList.toggle('deselected', !selected);
+    });
+    updateSelectedMedia();
+  }
+
   async function loadStoredYoutubeUrls() {
     if (!urlVideoList) return;
     const state = getCategoryState();
@@ -1242,6 +1290,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     card.append(badge, img, cap);
     (urlVideoList || videoSelectionDiv).appendChild(card);
     initCard(card);
+    refreshVideoSelectionTools();
     if (!opts.skipCategoryAssign) {
       assignUrlToCategories(url);
       applyCategoryButtons(card);
@@ -1252,6 +1301,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       fetchVideoTitle(url).then(title => {
         cap.textContent = title;
         cap.title = title;
+        applyVideoSearchFilter();
       }).catch(()=>{});
     }
 
@@ -1267,6 +1317,50 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Non-YouTube URL: no thumbnail here
       img.remove();
     }
+  }
+
+  function refreshVideoSelectionTools() {
+    applyVideoSearchFilter();
+    updateSelectionCount();
+  }
+
+  async function addUrlsFromText(text) {
+    const urls = uniquePreserveOrder(extractUrlsFromText(text).map(normalizeYouTubeUrl));
+    if (!urls.length) return 0;
+    const existing = new Set(getCurrentUrlListFromDom());
+    let added = 0;
+    let skipped = 0;
+
+    for (const url of urls) {
+      if (existing.has(url)) {
+        skipped++;
+        continue;
+      }
+
+      if (isYouTubeUrl(url) && window.YT_API_KEY) {
+        try {
+          const { ok, reason } = await validateSingleYouTubeUrl(url, window.YT_API_KEY);
+          if (!ok) {
+            skipped++;
+            console.warn(`Skipped YouTube URL (${reason}):`, url);
+            continue;
+          }
+        } catch {}
+      }
+
+      await addYoutubeUrlCard(url);
+      existing.add(url);
+      added++;
+    }
+
+    renumberCards();
+    updateSelectedMedia();
+    if (urlVideoList) saveYoutubeUrls();
+    if (ytPlaylistStatus && (added || skipped)) {
+      ytPlaylistStatus.textContent = `${added} URL ajoutée${added > 1 ? 's' : ''}${skipped ? `, ${skipped} ignorée${skipped > 1 ? 's' : ''}` : ''}.`;
+    }
+    refreshVideoSelectionTools();
+    return added;
   }
 
   function getCurrentUrlListFromDom() {
@@ -1407,6 +1501,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   let videoCardsArray = Array.from(document.querySelectorAll('.video-card'));
   videoCardsArray.forEach(initCard);
   renumberCards();
+  refreshVideoSelectionTools();
 
   // Apply saved local order on startup (after cards exist)
   loadLocalOrderForCurrentSet();
@@ -1514,28 +1609,30 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   }
 
-  // Add single URL (with validation)
+  // Add one or many URLs pasted into the URL field (with validation when configured)
   if (addVideoUrlButton && addVideoUrlInput) {
     addVideoUrlButton.addEventListener('click', async () => {
-      const url = addVideoUrlInput.value.trim();
-      if (!url) return;
+      const text = addVideoUrlInput.value.trim();
+      if (!text) return;
 
-      if (isYouTubeUrl(url) && window.YT_API_KEY) {
-        try {
-          const { ok, reason } = await validateSingleYouTubeUrl(url, window.YT_API_KEY);
-          if (!ok) {
-            alert(`Cette vidéo ne peut pas être intégrée (${reason}).`);
-            addVideoUrlInput.value = '';
-            return; // DO NOT add card
-          }
-        } catch {}
+      addVideoUrlButton.disabled = true;
+      if (ytPlaylistStatus) ytPlaylistStatus.textContent = 'Ajout en cours…';
+      try {
+        const added = await addUrlsFromText(text);
+        if (!added && ytPlaylistStatus) ytPlaylistStatus.textContent = 'Aucune nouvelle URL valide trouvée.';
+        addVideoUrlInput.value = '';
+      } finally {
+        addVideoUrlButton.disabled = false;
       }
-
-      await addYoutubeUrlCard(url);
-      addVideoUrlInput.value = '';
-      renumberCards();
-      updateSelectedMedia();
-      if (urlVideoList) saveYoutubeUrls();
+    });
+    addVideoUrlInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        addVideoUrlButton.click();
+      }
+    });
+    addVideoUrlInput.addEventListener('paste', () => {
+      if (ytPlaylistStatus) ytPlaylistStatus.textContent = 'Astuce: collez plusieurs URLs, puis cliquez Ajouter URL.';
     });
   }
 
@@ -1572,6 +1669,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           renumberCards();
           updateSelectedMedia();
           if (urlVideoList) saveYoutubeUrls();
+          refreshVideoSelectionTools();
           ytPlaylistStatus.textContent = `Import terminé: ${added} ajouté(s)${refused ? `, ${refused} ignoré(s)` : ''}.`;
         }
       } catch (err) {
@@ -1598,6 +1696,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   }
 
+  if (videoSearchInput) {
+    videoSearchInput.addEventListener('input', applyVideoSearchFilter);
+  }
+  if (selectVisibleButton) {
+    selectVisibleButton.addEventListener('click', () => setVisibleSelection(true));
+  }
+  if (deselectVisibleButton) {
+    deselectVisibleButton.addEventListener('click', () => setVisibleSelection(false));
+  }
+
   // updateSelectedMedia: reset ordering when list/order changes
   function updateSelectedMedia() {
     videoCardsArray = Array.from(document.querySelectorAll('.video-card'));
@@ -1611,6 +1719,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     renumberCards();
+    updateSelectionCount();
 
     startButton.style.display = selectedMedia.length ? 'block' : 'none';
     if (urlVideoList) saveYoutubeUrls();

--- a/switch/custom-youtube/index.html
+++ b/switch/custom-youtube/index.html
@@ -54,6 +54,39 @@
       width:100%;
     }
 
+
+    #video-selection-modal .video-tools{
+      display:grid;
+      grid-template-columns:minmax(220px, 1fr) auto;
+      gap:10px;
+      align-items:center;
+      margin:0 0 10px;
+      padding:10px;
+      border:1px solid #dcefed;
+      border-radius:16px;
+      background:#f7fbf9;
+    }
+    #video-selection-modal #video-search-input{
+      background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%2300796B' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.3-4.3'/></svg>");
+    }
+    #video-selection-modal .video-tools-actions{
+      display:flex;
+      align-items:center;
+      justify-content:flex-end;
+      gap:8px;
+      flex-wrap:wrap;
+    }
+    #video-selection-modal .selection-count{
+      color:#004d40;
+      font-size:14px;
+      font-weight:700;
+      white-space:nowrap;
+      margin-right:4px;
+    }
+    #video-selection-modal .video-card.filtered-out{
+      display:none;
+    }
+
     /* ========== Footer (two rows) ========== */
     #video-selection-modal .footer-bar{
       position:sticky;
@@ -207,9 +240,13 @@
 
     /* Responsive: stack input groups on small widths */
     @media (max-width: 960px){
+      #video-selection-modal .video-tools,
       #video-selection-modal .footer-inputs{
         grid-template-columns:1fr;
         row-gap:10px;
+      }
+      #video-selection-modal .video-tools-actions{
+        justify-content:center;
       }
     }
 
@@ -437,6 +474,21 @@
           data-fr="Vidéos actives (cliquer pour sélectionner/désélectionner)"
           data-en="Active Videos (click to toggle)" data-ja="有効な動画（クリックで切り替え）">Active Videos (click to toggle)</h2>
 
+      <div class="video-tools" aria-label="Outils de sélection vidéo">
+        <input id="video-search-input" type="search" class="control-panel-input"
+               placeholder="Rechercher une vidéo"
+               data-fr-placeholder="Rechercher une vidéo"
+               data-en-placeholder="Search videos"
+               data-ja-placeholder="動画を検索">
+        <div class="video-tools-actions">
+          <span id="video-selection-count" class="selection-count">0 sélectionnée / 0</span>
+          <button id="select-visible-button" class="button outline" type="button"
+                  data-fr="Tout sélectionner" data-en="Select visible" data-ja="表示中を選択">Tout sélectionner</button>
+          <button id="deselect-visible-button" class="button outline" type="button"
+                  data-fr="Tout désélectionner" data-en="Deselect visible" data-ja="表示中の選択解除">Tout désélectionner</button>
+        </div>
+      </div>
+
     <!-- Scrollable list -->
       <div id="video-selection">
         <div class="video-section" id="url-videos-section">
@@ -450,7 +502,10 @@
         <!-- Row 1 -->
         <div class="footer-inputs">
           <div class="input-group">
-            <input id="add-video-url-input" type="text" placeholder="URL" class="control-panel-input">
+            <input id="add-video-url-input" type="text" placeholder="URL (ou coller plusieurs URLs)" class="control-panel-input"
+                   data-fr-placeholder="URL (ou coller plusieurs URLs)"
+                   data-en-placeholder="URL (or paste multiple URLs)"
+                   data-ja-placeholder="URL（複数貼り付け可）">
             <button id="add-video-url-button" class="button outline" data-fr="Ajouter URL" data-en="Add URL" data-ja="URLを追加">Add URL</button>
           </div>
 


### PR DESCRIPTION
### Motivation

- Improve curation and speed of managing many YouTube/custom video entries in the custom YouTube picker by adding search, bulk-add and visible-selection controls. 

### Description

- Add a video-management toolbar to `switch/custom-youtube/index.html` with a search input, visible-selection count and `Select visible` / `Deselect visible` buttons and responsive styling so the toolbar stacks on small screens. 
- Implement client helpers in `js/switch-two-player-custom.js` to extract URLs from pasted text, normalize YouTube links to canonical `https://www.youtube.com/watch?v=...`, de-duplicate, and bulk-add them with optional API validation. 
- Add a lightweight client-side filter that marks non-matching cards with the `.filtered-out` class and hides them, and keep the visible/selected counters in sync as thumbnails/titles load and playlists import. 
- Wire the toolbar into the existing lifecycle: new cards call `initCard`, counts/filters refresh via `refreshVideoSelectionTools()` and `applyVideoSearchFilter()`, and bulk operations update saved lists via existing persistence helpers such as `saveYoutubeUrls()` and local-order persistence. 

### Testing

- Ran static syntax check with `node --check js/switch-two-player-custom.js`; the check succeeded. 
- Ran a small Python static content assertion to verify inserted identifiers (e.g. `video-search-input`, `addUrlsFromText`); the script passed. 
- Verified in-script runtime messages and status updates (no automated browser screenshots were captured because no headless browser tooling was available in the environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce31412e88325b607d70b3dea84a6)