### PR TITLE
Improve YouTube switch choice experience

### DIFF
--- a/css/choix.css
+++ b/css/choix.css
@@ -935,3 +935,146 @@ hr.section-divider {
   border: 1px solid #00796B;
   border-radius: 5px;
 }
+
+/* YouTube choice page growth/retention helpers */
+#yt-growth-panel {
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 16px;
+  width: min(100%, 980px);
+  margin: 0 auto 14px;
+  padding: 14px 16px;
+  border: 2px solid rgba(0, 150, 136, 0.25);
+  border-radius: 18px;
+  background: linear-gradient(135deg, #f2fffd 0%, #ffffff 62%, #e8f5e9 100%);
+  box-shadow: 0 8px 24px rgba(0, 77, 64, 0.08);
+  box-sizing: border-box;
+  text-align: left;
+}
+
+#yt-growth-panel .eyebrow {
+  margin: 0 0 4px;
+  color: #00796B;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+#yt-growth-panel h3 {
+  margin: 0 0 6px;
+  color: #003f38;
+  font-size: clamp(18px, 2vw, 24px);
+  line-height: 1.15;
+}
+
+#yt-growth-panel p {
+  margin: 0;
+  color: #28534f;
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+.yt-growth-copy {
+  flex: 1 1 56%;
+}
+
+.yt-benefits {
+  display: grid;
+  align-content: center;
+  gap: 8px;
+  flex: 0 0 220px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.yt-benefits li {
+  position: relative;
+  padding: 8px 12px 8px 32px;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #004d40;
+  font-size: 13px;
+  font-weight: 700;
+  box-shadow: inset 0 0 0 1px rgba(0, 150, 136, 0.22);
+}
+
+.yt-benefits li::before {
+  content: "✓";
+  position: absolute;
+  left: 12px;
+  color: #009688;
+  font-weight: 900;
+}
+
+#yt-library-count {
+  color: #00796B;
+  font-weight: 700;
+}
+
+.yt-url-row {
+  align-items: stretch;
+}
+
+#add-video-url-input.control-panel-input {
+  min-height: 52px;
+  resize: vertical;
+  border-radius: 18px;
+  font-family: inherit;
+  line-height: 1.3;
+}
+
+.yt-import-status {
+  min-height: 22px;
+  margin: 8px 0 0;
+  color: #333;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.yt-import-status[data-tone="success"] {
+  color: #00796B;
+}
+
+.yt-import-status[data-tone="warning"] {
+  color: #d84315;
+}
+
+.secondary-button {
+  background-color: #455A64;
+}
+
+.secondary-button:hover:enabled {
+  background-color: #263238;
+}
+
+.button:disabled,
+.button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 820px) {
+  #yt-growth-panel {
+    flex-direction: column;
+  }
+
+  .yt-benefits {
+    grid-template-columns: 1fr;
+    flex-basis: auto;
+  }
+}

--- a/js/choix.js
+++ b/js/choix.js
@@ -172,18 +172,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function preloadVideos(videoUrls, loadingIndicator) {
     let loaded = 0;
+    const markLoaded = () => {
+      loaded++;
+      loadingIndicator.textContent = `Chargement... (${loaded}/${videoUrls.length})`;
+    };
     return Promise.all(videoUrls.map(url => new Promise(resolve => {
+      if (isYouTubeUrl(url)) {
+        markLoaded();
+        resolve();
+        return;
+      }
       const vid = document.createElement('video');
       vid.preload = 'auto';
       vid.src = url;
       vid.addEventListener('canplaythrough', () => {
-        loaded++;
-        loadingIndicator.textContent = `Chargement... (${loaded}/${videoUrls.length})`;
+        markLoaded();
         resolve();
       });
       vid.addEventListener('error', () => {
-        loaded++;
-        loadingIndicator.textContent = `Chargement... (${loaded}/${videoUrls.length})`;
+        markLoaded();
         console.error("Error preloading", url);
         resolve();
       });

--- a/js/customYoutubeChoices.js
+++ b/js/customYoutubeChoices.js
@@ -1,24 +1,98 @@
 // Builds mediaChoices from YouTube URLs or playlists
 const mediaChoices = [];
 const YT_STORAGE_KEY = 'choiceYoutubeUrls';
+const YT_SHARE_PARAM = 'videos';
+const YT_STATUS_TIMEOUT_MS = 5000;
+let ytStatusTimer = null;
 
 function isYouTubeUrl(url) {
   return /^(https?:\/\/)?(www\.|m\.)?((youtube\.com\/\S+)|(youtu\.be\/\S+))$/.test(url);
 }
 
-function getYouTubeId(url) {
+function normalizeYouTubeUrl(urlOrId) {
+  const id = getYouTubeId(urlOrId);
+  return id ? `https://www.youtube.com/watch?v=${id}` : null;
+}
+
+function getYouTubeId(urlOrId) {
+  const value = String(urlOrId || '').trim();
+  if (/^[a-zA-Z0-9_-]{11}$/.test(value)) return value;
   try {
-    const u = new URL(url);
+    const u = new URL(value);
     if (u.hostname.includes('youtu.be')) {
-      return u.pathname.slice(1);
+      const id = u.pathname.split('/').filter(Boolean)[0];
+      return id || null;
     }
     const id = u.searchParams.get('v');
     if (id) return id;
-    const m = url.match(/\/embed\/([a-zA-Z0-9_-]+)/);
-    return m ? m[1] : null;
+    const shorts = u.pathname.match(/\/shorts\/([a-zA-Z0-9_-]{11})/);
+    if (shorts) return shorts[1];
+    const embed = u.pathname.match(/\/embed\/([a-zA-Z0-9_-]{11})/);
+    return embed ? embed[1] : null;
   } catch {
-    return null;
+    const m = value.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/))([a-zA-Z0-9_-]{11})/);
+    return m ? m[1] : null;
   }
+}
+
+function extractYouTubeIds(text) {
+  const ids = [];
+  const seen = new Set();
+  const parts = String(text || '')
+    .split(/[\s,]+/)
+    .map(part => part.trim())
+    .filter(Boolean);
+
+  for (const part of parts) {
+    const id = getYouTubeId(part);
+    if (id && !seen.has(id)) {
+      ids.push(id);
+      seen.add(id);
+    }
+  }
+  return ids;
+}
+
+function getStoredVideoIds() {
+  const saved = localStorage.getItem(YT_STORAGE_KEY);
+  if (!saved) return [];
+  const urls = JSON.parse(saved);
+  return Array.isArray(urls) ? urls.map(getYouTubeId).filter(Boolean) : [];
+}
+
+function getIdsFromShareUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get(YT_SHARE_PARAM);
+  if (!value) return [];
+  return value.split(',').map(getYouTubeId).filter(Boolean);
+}
+
+function hasVideoId(id) {
+  return mediaChoices.some(choice => getYouTubeId(choice.video) === id);
+}
+
+function setImportStatus(message, tone = 'info') {
+  const status = document.getElementById('yt-import-status');
+  if (!status) return;
+  status.textContent = message;
+  status.dataset.tone = tone;
+  if (ytStatusTimer) clearTimeout(ytStatusTimer);
+  if (message) {
+    ytStatusTimer = setTimeout(() => {
+      status.textContent = '';
+      status.dataset.tone = '';
+    }, YT_STATUS_TIMEOUT_MS);
+  }
+}
+
+function updateYoutubeLibraryCount() {
+  const countEl = document.getElementById('yt-library-count');
+  const shareButton = document.getElementById('share-youtube-setup-button');
+  if (countEl) {
+    const count = mediaChoices.length;
+    countEl.textContent = count ? ` • ${count} vidéo${count > 1 ? 's' : ''} enregistrée${count > 1 ? 's' : ''}` : ' • 0 vidéo enregistrée';
+  }
+  if (shareButton) shareButton.disabled = mediaChoices.length === 0;
 }
 
 async function fetchVideoTitle(url) {
@@ -43,7 +117,7 @@ function getPlaylistIdFromUrl(url) {
   return null;
 }
 
-async function fetchPlaylistVideoIds(apiKey, playlistId) {
+async function fetchPlaylistVideoIds(apiKey, playlistId, onProgress) {
   const ids = [];
   let pageToken = '';
   while (true) {
@@ -68,6 +142,7 @@ async function fetchPlaylistVideoIds(apiKey, playlistId) {
       const vid = it?.contentDetails?.videoId;
       if (vid) ids.push(vid);
     });
+    if (typeof onProgress === 'function') onProgress(ids.length);
     pageToken = data.nextPageToken || '';
     if (!pageToken) break;
   }
@@ -93,7 +168,8 @@ async function validateEmbeddableIds(apiKey, ids) {
   return ok;
 }
 
-async function addVideoById(id) {
+async function addVideoById(id, { silent = false } = {}) {
+  if (!id || hasVideoId(id)) return false;
   const url = `https://www.youtube.com/watch?v=${id}`;
   const title = await fetchVideoTitle(url);
   mediaChoices.push({
@@ -103,27 +179,71 @@ async function addVideoById(id) {
     category: 'custom'
   });
   saveYoutubeUrls();
+  updateYoutubeLibraryCount();
+  if (!silent) setImportStatus(`Ajouté: ${title}`, 'success');
+  return true;
+}
+
+async function addVideosByIds(ids, { silent = false } = {}) {
+  let added = 0;
+  let skipped = 0;
+  for (const id of ids) {
+    if (await addVideoById(id, { silent: true })) added++;
+    else skipped++;
+  }
+  if (!silent) {
+    const parts = [`${added} vidéo${added > 1 ? 's' : ''} ajoutée${added > 1 ? 's' : ''}`];
+    if (skipped) parts.push(`${skipped} doublon${skipped > 1 ? 's' : ''} ignoré${skipped > 1 ? 's' : ''}`);
+    setImportStatus(parts.join(' • '), added ? 'success' : 'warning');
+  }
+  updateYoutubeLibraryCount();
+  return added;
 }
 
 function saveYoutubeUrls() {
   try {
-    const urls = mediaChoices.map(m => m.video);
+    const urls = mediaChoices.map(m => normalizeYouTubeUrl(m.video)).filter(Boolean);
     localStorage.setItem(YT_STORAGE_KEY, JSON.stringify(urls));
   } catch {}
 }
 
 async function loadStoredYoutubeUrls() {
-  const saved = localStorage.getItem(YT_STORAGE_KEY);
-  if (!saved) return;
+  let ids = [];
   try {
-    const urls = JSON.parse(saved);
-    for (const url of urls) {
-      const id = getYouTubeId(url);
-      if (id) await addVideoById(id);
-    }
+    ids = [...getStoredVideoIds(), ...getIdsFromShareUrl()];
   } catch (e) {
     console.error('Failed to load stored YouTube URLs', e);
   }
+  await addVideosByIds(ids, { silent: true });
+  if (getIdsFromShareUrl().length) {
+    setImportStatus('Configuration chargée depuis le lien partagé.', 'success');
+  }
+}
+
+function buildShareUrl() {
+  const ids = mediaChoices.map(choice => getYouTubeId(choice.video)).filter(Boolean);
+  const url = new URL(window.location.href);
+  if (ids.length) url.searchParams.set(YT_SHARE_PARAM, ids.join(','));
+  else url.searchParams.delete(YT_SHARE_PARAM);
+  return url.toString();
+}
+
+async function copyShareUrl() {
+  const shareUrl = buildShareUrl();
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(shareUrl);
+  } else {
+    const scratch = document.createElement('textarea');
+    scratch.value = shareUrl;
+    scratch.setAttribute('readonly', '');
+    scratch.style.position = 'fixed';
+    scratch.style.left = '-9999px';
+    document.body.appendChild(scratch);
+    scratch.select();
+    document.execCommand('copy');
+    document.body.removeChild(scratch);
+  }
+  setImportStatus('Lien copié. Vous pouvez le partager avec une famille, une classe ou un collègue.', 'success');
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -132,18 +252,34 @@ document.addEventListener('DOMContentLoaded', async () => {
   const playlistBtn = document.getElementById('yt-playlist-import-button');
   const playlistInput = document.getElementById('yt-playlist-url-input');
   const clearButton = document.getElementById('clear-videos-button');
+  const shareButton = document.getElementById('share-youtube-setup-button');
 
   await loadStoredYoutubeUrls();
+  updateYoutubeLibraryCount();
   if (typeof populateTilePickerGrid === 'function') populateTilePickerGrid();
 
   if (addUrlBtn && addUrlInput) {
-    addUrlBtn.addEventListener('click', async () => {
-      const url = addUrlInput.value.trim();
-      const id = getYouTubeId(url);
-      if (!id) { console.error('URL YouTube invalide'); return; }
-      await addVideoById(id);
-      addUrlInput.value = '';
-      if (typeof populateTilePickerGrid === 'function') populateTilePickerGrid();
+    const addFromInput = async () => {
+      const ids = extractYouTubeIds(addUrlInput.value);
+      if (!ids.length) {
+        setImportStatus('Collez au moins une URL YouTube valide.', 'warning');
+        return;
+      }
+      addUrlBtn.disabled = true;
+      try {
+        await addVideosByIds(ids);
+        addUrlInput.value = '';
+        if (typeof populateTilePickerGrid === 'function') populateTilePickerGrid();
+      } finally {
+        addUrlBtn.disabled = false;
+      }
+    };
+    addUrlBtn.addEventListener('click', addFromInput);
+    addUrlInput.addEventListener('keydown', event => {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+        event.preventDefault();
+        addFromInput();
+      }
     });
   }
 
@@ -152,23 +288,34 @@ document.addEventListener('DOMContentLoaded', async () => {
       const url = playlistInput.value.trim();
       const pid = getPlaylistIdFromUrl(url);
       const apiKey = window.YT_API_KEY;
-      if (!url) { console.error('Veuillez entrer une URL de playlist.'); return; }
-      if (!pid) { console.error("URL invalide: impossible d'extraire l'identifiant de playlist."); return; }
-      if (!apiKey) { console.error('Clé API absente (window.YT_API_KEY).'); return; }
+      if (!url) { setImportStatus('Veuillez entrer une URL de playlist.', 'warning'); return; }
+      if (!pid) { setImportStatus("URL invalide: impossible d'extraire l'identifiant de playlist.", 'warning'); return; }
+      if (!apiKey) { setImportStatus('Clé API absente (window.YT_API_KEY).', 'warning'); return; }
       playlistBtn.disabled = true;
+      setImportStatus('Import de la playlist en cours...', 'info');
       try {
-        const ids = await fetchPlaylistVideoIds(apiKey, pid);
+        const ids = await fetchPlaylistVideoIds(apiKey, pid, count => {
+          setImportStatus(`Lecture de la playlist... ${count} vidéo${count > 1 ? 's' : ''} trouvée${count > 1 ? 's' : ''}`, 'info');
+        });
         const ok = await validateEmbeddableIds(apiKey, ids);
-        for (const id of ok) {
-          await addVideoById(id);
-        }
+        await addVideosByIds([...ok]);
+        playlistInput.value = '';
         if (typeof populateTilePickerGrid === 'function') populateTilePickerGrid();
       } catch (err) {
         console.error(err);
-        console.error('Import échoué: ' + (err?.message || 'erreur'));
+        setImportStatus('Import échoué: ' + (err?.message || 'erreur'), 'warning');
       } finally {
         playlistBtn.disabled = false;
       }
+    });
+  }
+
+  if (shareButton) {
+    shareButton.addEventListener('click', () => {
+      copyShareUrl().catch(err => {
+        console.error(err);
+        setImportStatus('Impossible de copier le lien automatiquement.', 'warning');
+      });
     });
   }
 
@@ -176,6 +323,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     clearButton.addEventListener('click', () => {
       mediaChoices.length = 0;
       try { localStorage.removeItem(YT_STORAGE_KEY); } catch {}
+      updateYoutubeLibraryCount();
+      setImportStatus('Bibliothèque YouTube effacée.', 'success');
       if (typeof populateTilePickerGrid === 'function') populateTilePickerGrid();
     });
   }

--- a/pedagogique/choix-videos-youtube/index.html
+++ b/pedagogique/choix-videos-youtube/index.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title class="translate" data-fr="Choix et scan" data-en="Choice and Scan" data-ja="選択とスキャン">Choix et scan</title>
-  <!-- Link to yo ur external CSS file -->
+  <title class="translate" data-fr="Choix et scan YouTube" data-en="YouTube Choice and Scan" data-ja="YouTube選択とスキャン">Choix et scan YouTube</title>
+  <meta name="description" content="Accessible switch activity for choosing, scanning, and playing YouTube videos with saved playlists and shareable setups." />
+  <!-- Link to your external CSS file -->
   <link rel="stylesheet" href="../../css/choix.css" />
 </head>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-B45TJG4GBJ"></script>
@@ -128,11 +129,25 @@
       </div>
 
 
+      <section id="yt-growth-panel" aria-label="YouTube activity benefits">
+        <div class="yt-growth-copy">
+          <p class="eyebrow translate" data-fr="Page populaire" data-en="Popular page" data-ja="人気ページ">Page populaire</p>
+          <h3 class="translate" data-fr="Transformez les vidéos préférées en choix accessibles" data-en="Turn favorite videos into accessible choices" data-ja="お気に入り動画をアクセシブルな選択肢に">Transformez les vidéos préférées en choix accessibles</h3>
+          <p class="translate" data-fr="Collez des liens YouTube, importez une playlist, puis partagez la configuration avec une autre classe, famille ou thérapeute." data-en="Paste YouTube links, import a playlist, then share the setup with another classroom, family, or therapist." data-ja="YouTubeリンクを貼り付け、プレイリストをインポートし、設定を共有できます。">Collez des liens YouTube, importez une playlist, puis partagez la configuration avec une autre classe, famille ou thérapeute.</p>
+        </div>
+        <ul class="yt-benefits">
+          <li class="translate" data-fr="Mémorise vos vidéos" data-en="Remembers your videos" data-ja="動画を保存">Mémorise vos vidéos</li>
+          <li class="translate" data-fr="Lien partageable" data-en="Shareable link" data-ja="共有リンク">Lien partageable</li>
+          <li class="translate" data-fr="Feedback d’import clair" data-en="Clear import feedback" data-ja="明確なインポート状態">Feedback d’import clair</li>
+        </ul>
+      </section>
+
       <!-- Instruction: how many tiles to choose -->
       <div id="control-panel-instructions" style="margin-top:10px;">
         <span class="translate" data-fr="Choisir" data-en="Choose" data-ja="選ぶ">Choisir</span>
         <span id="tile-count-display" class="no-translate"></span>
         <span class="translate" data-fr="tuiles." data-en="tiles." data-ja="タイル。"> tuiles.</span>
+        <span id="yt-library-count" class="no-translate" aria-live="polite"></span>
       </div>
 
       <!-- Grid for tile thumbnails (populated by JS) -->
@@ -141,16 +156,20 @@
       <!-- Video import controls -->
       <div id="yt-import-controls">
         <div id="yt-input-row">
-          <div class="actions-row">
-            <input id="add-video-url-input" type="text" placeholder="URL" class="control-panel-input">
+          <div class="actions-row yt-url-row">
+            <label class="sr-only" for="add-video-url-input">URL YouTube</label>
+            <textarea id="add-video-url-input" rows="2" placeholder="Collez une ou plusieurs URL YouTube" class="control-panel-input"></textarea>
             <button id="add-video-url-button" class="button" data-fr="Ajouter URL" data-en="Add URL" data-ja="URLを追加">Ajouter URL</button>
           </div>
           <div class="actions-row">
+            <label class="sr-only" for="yt-playlist-url-input">URL de playlist YouTube</label>
             <input id="yt-playlist-url-input" type="text" placeholder="URL de playlist (ex. https://www.youtube.com/playlist?list=...)" class="control-panel-input">
             <button id="yt-playlist-import-button" class="button" data-fr="Importer" data-en="Import" data-ja="インポート">Importer</button>
           </div>
         </div>
+        <p id="yt-import-status" class="yt-import-status" role="status" aria-live="polite"></p>
         <div class="actions-row">
+          <button id="share-youtube-setup-button" class="button secondary-button translate" data-fr="Copier le lien" data-en="Copy Link" data-ja="リンクをコピー">Copier le lien</button>
           <button id="clear-videos-button" class="button translate" data-fr="Tout effacer" data-en="Clear All" data-ja="すべてクリア">Tout effacer</button>
           <button id="start-game-button" class="button translate" data-fr="Commencer" data-en="Start" data-ja="開始" disabled>Commencer</button>
         </div>


### PR DESCRIPTION
### Motivation
- The YouTube choice page is the most popular switch activity, so the UI and import flow were improved to increase conversion, retention and shareability. 
- Make it easier to build and share accessible YouTube setups (multiple URLs, playlists, saved libraries) for classrooms, families and therapists.

### Description
- Added a YouTube growth/product panel and library UI in `pedagogique/choix-videos-youtube/index.html` with benefit copy, library count, a `Copy Link` button and clearer import/status elements. 
- Reworked the YouTube import logic in `js/customYoutubeChoices.js` to support multi-URL paste, robust ID extraction (`getYouTubeId`, `extractYouTubeIds`), duplicate prevention, persisted libraries (`localStorage`), loading shared `?videos=` links, playlist import progress, embeddable validation and copyable share URLs. 
- Updated the tile picker flow to surface live import feedback (`setImportStatus`), wire add/share/clear actions, and refresh the picker via `populateTilePickerGrid`. 
- Optimized startup preloading in `js/choix.js` to skip local `<video>` preloading for YouTube URLs and added responsive styling and accessibility helpers in `css/choix.css` (status message styles, textarea, sr-only labels, growth panel). 

### Testing
- Ran `node --check js/customYoutubeChoices.js` which succeeded. 
- Ran `node --check js/choix.js` which succeeded. 
- Performed an HTML parse smoke test using Python `html.parser` on `pedagogique/choix-videos-youtube/index.html` which succeeded. 
- Ran a script to ensure no merge conflict markers in modified files which succeeded; an automated check for a headless browser/screenshot tool (Playwright/Chrome) was not available in the environment so visual screenshot verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce31412e88325b607d70b3dea84a6)