### PR TITLE
Promote custom YouTube switch activity

### DIFF
--- a/switch/index.html
+++ b/switch/index.html
@@ -8,6 +8,57 @@
   <link rel="stylesheet" href="../css/global.css">
   <link rel="stylesheet" href="../css/layout.css">
   <link rel="stylesheet" href="../css/components.css">
+  <style>
+    .tile.recommended-tile {
+        border-color: #D36135;
+        box-shadow: 0 10px 24px rgba(211, 97, 53, 0.32);
+        transform: translateY(-6px);
+        overflow: visible;
+    }
+
+    .tile.recommended-tile a {
+        color: inherit;
+        text-decoration: none;
+    }
+
+    .recommended-badge {
+        position: absolute;
+        top: -14px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 2;
+        padding: 6px 14px;
+        border-radius: 999px;
+        background: #D36135;
+        color: #ffffff;
+        font-weight: bold;
+        font-size: 0.9rem;
+        box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+        white-space: nowrap;
+    }
+
+    .recommended-benefits {
+        margin: 8px 0 0;
+        padding: 10px 16px 12px 28px;
+        background: rgba(255, 255, 255, 0.92);
+        color: #294936;
+        border-top: 2px solid #D36135;
+        border-radius: 0 0 8px 8px;
+        font-size: 0.92rem;
+        line-height: 1.35;
+    }
+
+    .recommended-benefits li + li {
+        margin-top: 4px;
+    }
+
+    @media (max-width: 600px) {
+        .tile.recommended-tile {
+            transform: none;
+            margin-top: 12px;
+        }
+    }
+  </style>
 
 </head>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-B45TJG4GBJ"></script>
@@ -37,22 +88,28 @@
             data-ja="スイッチやその他の適応コントローラー向けゲーム（音楽・ビデオクリップ）">
             Jeux pour switch et autres interrupteurs adaptés (musique, vidéoclips)
         </h1>
-<h3 
-  data-fr="Note: vu la possibilité d'ajouter des vidéos youtube ou locales, aucun jeu ne sera ajouté ici à l'avenir. Cependant, si pour une raison quelconque vous souhaitez voir un jeu spécifique ici, n'hésitez pas à nous contacter." 
-  data-en="Note: given the ability to add YouTube or local videos, no new games will be added here in the future. However, if for any reason you would like to see a specific game here, feel free to contact us." 
-  data-ja="注: YouTube またはローカル動画を追加できるため、今後ここに新しいゲームが追加されることはありません。ただし、特定のゲームをここに掲載してほしい場合は、遠慮なくご連絡ください。">
-    Sélectionnez un jeu pour commencer à jouer !
+<h3
+  data-fr="Créez une activité YouTube personnalisée: importez vos listes de lecture, lancez des vidéos accessibles au switch et retrouvez vos favoris en un clic."
+  data-en="Create a custom YouTube activity: import playlists, launch switch-accessible videos, and find favorites again in one click."
+  data-ja="カスタムYouTubeアクティビティを作成しましょう。プレイリストをインポートし、スイッチで操作しやすい動画を再生し、お気に入りをワンクリックで見つけられます。">
+    Créez une activité YouTube personnalisée: importez vos listes de lecture, lancez des vidéos accessibles au switch et retrouvez vos favoris en un clic.
 </h3>
 
     </div>    
 
     <div class="tile-container">
 
-        <div class="tile">
-            <a href="custom-youtube/index.html">
+        <div class="tile recommended-tile">
+            <a href="custom-youtube/index.html" aria-label="Vidéos YouTube - option recommandée">
+                <div class="recommended-badge" data-fr="Recommandé" data-en="Recommended" data-ja="おすすめ">Recommandé</div>
                 <img src="../images/ghibli/ghibliyoutube.png" alt="Vidéos YouTube">
                 <div class="tile-title">
                     <h3 data-fr="Vidéos YouTube" data-en="YouTube Videos" data-ja="YouTube動画">Vidéos YouTube</h3>
+                    <ul class="recommended-benefits">
+                        <li data-fr="Import de listes de lecture" data-en="Playlist import" data-ja="プレイリストのインポート">Import de listes de lecture</li>
+                        <li data-fr="Lecture accessible au switch" data-en="Switch-accessible playback" data-ja="スイッチで操作しやすい再生">Lecture accessible au switch</li>
+                        <li data-fr="Listes locales sauvegardées" data-en="Saved local lists" data-ja="保存されたローカルリスト">Listes locales sauvegardées</li>
+                    </ul>
                 </div>
             </a>
         </div>


### PR DESCRIPTION
### Motivation
- Surface the custom YouTube activity as the recommended/default option on the Switch portal so users find playlist import and switch-accessible playback features more easily.
- Replace a neutral informational note with a short promotional explanation that highlights the new custom YouTube workflow.
- Keep all translation attributes (`data-fr`, `data-en`, `data-ja`) consistent so the page remains localizable.

### Description
- Replaced the neutral note around the hero with promotional copy for the custom YouTube activity in `switch/index.html` (updated `data-fr`, `data-en`, `data-ja`).
- Added inline styles in `switch/index.html` to visually emphasize the tile by introducing `.tile.recommended-tile`, a `.recommended-badge`, and `.recommended-benefits` styling for responsive presentation.
- Updated the `custom-youtube/index.html` tile in `switch/index.html` to include the `recommended-tile` class, an accessible `aria-label`, a translated badge (`data-fr`/`data-en`/`data-ja`), and a translated list of benefit bullets (playlist import, switch-accessible playback, saved local lists).

### Testing
- Ran an HTML parse with `python3` using `html.parser` which successfully parsed `switch/index.html`.
- Ran a small Python check that verifies all translated elements include `data-fr`, `data-en`, and `data-ja`, which passed.
- Located the updated tile string with `rg -n "Vidéos YouTube" switch/index.html`, which confirmed the change.
- Attempted to run `npx --yes playwright --version` to capture a screenshot for visual verification, but the npm registry request was blocked with `403 Forbidden`, so automated screenshot tooling was not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd01e35c0c83258624278dffca9c0f)