### PR TITLE
Add AR Face Tiles prototype (camera + FaceDetector) to Eye‑Gaze section

### DIFF
--- a/eyegaze/facetiles/index.html
+++ b/eyegaze/facetiles/index.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Face Tiles (Camera + AI Vision)</title>
+  <style>
+    :root { color-scheme: dark; }
+    body { margin: 0; font-family: Arial, sans-serif; background: #0b1020; color: #fff; }
+    .top { padding: 12px 16px; display: flex; gap: 12px; flex-wrap: wrap; align-items: center; background: #111938; }
+    button { padding: 10px 14px; border-radius: 10px; border: 0; cursor: pointer; font-weight: 700; }
+    #startBtn { background: #37c27f; color: #001b10; }
+    #homeBtn { background: #84a5ff; color: #05123d; text-decoration: none; display: inline-block; }
+    #status { opacity: .9; }
+    .stage { position: relative; width: min(100vw, 1200px); margin: 0 auto; }
+    video, canvas { width: 100%; height: auto; display: block; border-radius: 12px; }
+    #overlay { position: absolute; inset: 0; }
+    .panel { padding: 12px 16px; }
+    .hint { color: #a4c1ff; }
+  </style>
+</head>
+<body>
+  <div class="top">
+    <button id="startBtn">Start camera</button>
+    <a id="homeBtn" href="../index.html">Back to Eye-Gaze Menu</a>
+    <span id="status">Ready.</span>
+  </div>
+
+  <div class="stage">
+    <video id="camera" autoplay muted playsinline></video>
+    <canvas id="overlay"></canvas>
+  </div>
+
+  <div class="panel">
+    <strong>Idea prototype:</strong> detected faces become interactive tiles.
+    <div class="hint">Tap/click a face square to greet the person. Works best in Chromium browsers that support the Face Detection API.</div>
+    <p id="actionText">Action: none yet.</p>
+  </div>
+
+  <script>
+    const startBtn = document.getElementById('startBtn');
+    const statusEl = document.getElementById('status');
+    const actionText = document.getElementById('actionText');
+    const video = document.getElementById('camera');
+    const canvas = document.getElementById('overlay');
+    const ctx = canvas.getContext('2d');
+
+    let detector = null;
+    let lastFaces = [];
+    let running = false;
+
+    function setStatus(text) {
+      statusEl.textContent = text;
+    }
+
+    function resizeCanvas() {
+      canvas.width = video.videoWidth || 1280;
+      canvas.height = video.videoHeight || 720;
+    }
+
+    function drawFaceTiles(faces) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.lineWidth = 4;
+      ctx.font = '20px Arial';
+      ctx.textBaseline = 'top';
+
+      faces.forEach((face, index) => {
+        const { x, y, width, height } = face.boundingBox;
+        ctx.strokeStyle = '#33ff99';
+        ctx.fillStyle = 'rgba(51, 255, 153, 0.14)';
+        ctx.fillRect(x, y, width, height);
+        ctx.strokeRect(x, y, width, height);
+        ctx.fillStyle = '#ffffff';
+        ctx.fillText(`Face Tile ${index + 1}`, x + 8, y + 8);
+      });
+    }
+
+    function hitFaceTile(px, py) {
+      return lastFaces.find((face) => {
+        const box = face.boundingBox;
+        return px >= box.x && px <= box.x + box.width && py >= box.y && py <= box.y + box.height;
+      });
+    }
+
+    async function detectLoop() {
+      if (!running) return;
+
+      try {
+        const faces = await detector.detect(video);
+        lastFaces = faces;
+        drawFaceTiles(faces);
+        setStatus(`Tracking ${faces.length} face tile(s).`);
+      } catch (err) {
+        console.error(err);
+        setStatus(`Detection error: ${err.message}`);
+      }
+
+      requestAnimationFrame(detectLoop);
+    }
+
+    canvas.addEventListener('click', (event) => {
+      if (!lastFaces.length) return;
+      const rect = canvas.getBoundingClientRect();
+      const scaleX = canvas.width / rect.width;
+      const scaleY = canvas.height / rect.height;
+      const x = (event.clientX - rect.left) * scaleX;
+      const y = (event.clientY - rect.top) * scaleY;
+
+      const face = hitFaceTile(x, y);
+      if (face) {
+        actionText.textContent = 'Action: 👋 Hi! Face tile selected.';
+      }
+    });
+
+    startBtn.addEventListener('click', async () => {
+      if (!('FaceDetector' in window)) {
+        setStatus('Face Detection API not supported in this browser.');
+        return;
+      }
+
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' }, audio: false });
+        video.srcObject = stream;
+        await video.play();
+        resizeCanvas();
+
+        detector = new FaceDetector({ fastMode: true, maxDetectedFaces: 8 });
+        running = true;
+        setStatus('Camera started. Looking for faces...');
+        detectLoop();
+      } catch (err) {
+        console.error(err);
+        setStatus(`Camera error: ${err.message}`);
+      }
+    });
+
+    video.addEventListener('loadedmetadata', resizeCanvas);
+    window.addEventListener('resize', resizeCanvas);
+  </script>
+</body>
+</html>

--- a/eyegaze/facetiles/index.html
+++ b/eyegaze/facetiles/index.html
@@ -33,10 +33,11 @@
 
   <div class="panel">
     <strong>Idea prototype:</strong> detected faces become interactive tiles.
-    <div class="hint">Tap/click a face square to greet the person. Uses native FaceDetector when available, otherwise falls back to MediaPipe face detection.</div>
+    <div class="hint">Tap/click a face square to greet the person. Uses the local clmtrackr face tracker so it does not depend on experimental browser FaceDetector support.</div>
     <p id="actionText">Action: none yet.</p>
   </div>
 
+  <script src="../../lib/clmtrackr.js"></script>
   <script>
     const startBtn = document.getElementById('startBtn');
     const statusEl = document.getElementById('status');
@@ -45,16 +46,48 @@
     const canvas = document.getElementById('overlay');
     const ctx = canvas.getContext('2d');
 
-    let detector = null;
-    let detectorName = '';
+    const tracker = new clm.tracker({ useWebGL: false });
+    tracker.init();
+
     let lastFaces = [];
     let running = false;
 
     function setStatus(text) { statusEl.textContent = text; }
 
     function resizeCanvas() {
-      canvas.width = video.videoWidth || 1280;
-      canvas.height = video.videoHeight || 720;
+      const width = video.videoWidth || 1280;
+      const height = video.videoHeight || 720;
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+      }
+    }
+
+    function positionsToFaceTile(positions) {
+      if (!positions || !positions.length) return [];
+
+      const xs = positions.map((point) => point[0]);
+      const ys = positions.map((point) => point[1]);
+      const minX = Math.min(...xs);
+      const maxX = Math.max(...xs);
+      const minY = Math.min(...ys);
+      const maxY = Math.max(...ys);
+      const width = maxX - minX;
+      const height = maxY - minY;
+      const paddingX = width * 0.28;
+      const paddingTop = height * 0.45;
+      const paddingBottom = height * 0.18;
+
+      const x = Math.max(0, minX - paddingX);
+      const y = Math.max(0, minY - paddingTop);
+      return [{
+        boundingBox: {
+          x,
+          y,
+          width: Math.min(canvas.width - x, width + paddingX * 2),
+          height: Math.min(canvas.height - y, height + paddingTop + paddingBottom)
+        }
+      }];
     }
 
     function drawFaceTiles(faces) {
@@ -80,66 +113,12 @@
       });
     }
 
-    async function loadScript(src) {
-      return new Promise((resolve, reject) => {
-        const s = document.createElement('script');
-        s.src = src;
-        s.onload = resolve;
-        s.onerror = () => reject(new Error(`Failed to load script: ${src}`));
-        document.head.appendChild(s);
-      });
-    }
-
-    async function createDetector() {
-      if ('FaceDetector' in window) {
-        detectorName = 'Native FaceDetector';
-        const nativeDetector = new FaceDetector({ fastMode: true, maxDetectedFaces: 8 });
-        return { detect: (input) => nativeDetector.detect(input) };
-      }
-
-      detectorName = 'MediaPipe fallback';
-      setStatus('Loading MediaPipe fallback model...');
-      await loadScript('https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14');
-
-      const vision = await window.FilesetResolver.forVisionTasks(
-        'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14/wasm'
-      );
-      const mpDetector = await window.FaceDetector.createFromOptions(vision, {
-        baseOptions: {
-          modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/face_detector/blaze_face_short_range/float16/latest/blaze_face_short_range.tflite'
-        },
-        runningMode: 'VIDEO',
-        minDetectionConfidence: 0.5
-      });
-
-      return {
-        detect: async (input) => {
-          const ts = performance.now();
-          const out = mpDetector.detectForVideo(input, ts);
-          const detections = out.detections || [];
-          return detections.map((d) => ({
-            boundingBox: {
-              x: d.boundingBox.originX,
-              y: d.boundingBox.originY,
-              width: d.boundingBox.width,
-              height: d.boundingBox.height
-            }
-          }));
-        }
-      };
-    }
-
-    async function detectLoop() {
+    function detectLoop() {
       if (!running) return;
-      try {
-        const faces = await detector.detect(video);
-        lastFaces = faces;
-        drawFaceTiles(faces);
-        setStatus(`${detectorName}: tracking ${faces.length} face tile(s).`);
-      } catch (err) {
-        console.error(err);
-        setStatus(`Detection error: ${err.message}`);
-      }
+      resizeCanvas();
+      lastFaces = positionsToFaceTile(tracker.getCurrentPosition());
+      drawFaceTiles(lastFaces);
+      setStatus(`Local tracker: tracking ${lastFaces.length} face tile(s).`);
       requestAnimationFrame(detectLoop);
     }
 
@@ -156,17 +135,24 @@
     });
 
     startBtn.addEventListener('click', async () => {
+      startBtn.disabled = true;
+      setStatus('Starting camera...');
       try {
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+          throw new Error('Camera access is not available in this browser.');
+        }
+
         const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' }, audio: false });
         video.srcObject = stream;
         await video.play();
         resizeCanvas();
-        detector = await createDetector();
+        tracker.start(video);
         running = true;
-        setStatus(`${detectorName} ready. Looking for faces...`);
+        setStatus('Local tracker ready. Looking for faces...');
         detectLoop();
       } catch (err) {
         console.error(err);
+        startBtn.disabled = false;
         setStatus(`Startup error: ${err.message}`);
       }
     });

--- a/eyegaze/facetiles/index.html
+++ b/eyegaze/facetiles/index.html
@@ -33,7 +33,7 @@
 
   <div class="panel">
     <strong>Idea prototype:</strong> detected faces become interactive tiles.
-    <div class="hint">Tap/click a face square to greet the person. Works best in Chromium browsers that support the Face Detection API.</div>
+    <div class="hint">Tap/click a face square to greet the person. Uses native FaceDetector when available, otherwise falls back to MediaPipe face detection.</div>
     <p id="actionText">Action: none yet.</p>
   </div>
 
@@ -46,12 +46,11 @@
     const ctx = canvas.getContext('2d');
 
     let detector = null;
+    let detectorName = '';
     let lastFaces = [];
     let running = false;
 
-    function setStatus(text) {
-      statusEl.textContent = text;
-    }
+    function setStatus(text) { statusEl.textContent = text; }
 
     function resizeCanvas() {
       canvas.width = video.videoWidth || 1280;
@@ -63,7 +62,6 @@
       ctx.lineWidth = 4;
       ctx.font = '20px Arial';
       ctx.textBaseline = 'top';
-
       faces.forEach((face, index) => {
         const { x, y, width, height } = face.boundingBox;
         ctx.strokeStyle = '#33ff99';
@@ -77,24 +75,71 @@
 
     function hitFaceTile(px, py) {
       return lastFaces.find((face) => {
-        const box = face.boundingBox;
-        return px >= box.x && px <= box.x + box.width && py >= box.y && py <= box.y + box.height;
+        const b = face.boundingBox;
+        return px >= b.x && px <= b.x + b.width && py >= b.y && py <= b.y + b.height;
       });
+    }
+
+    async function loadScript(src) {
+      return new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = src;
+        s.onload = resolve;
+        s.onerror = () => reject(new Error(`Failed to load script: ${src}`));
+        document.head.appendChild(s);
+      });
+    }
+
+    async function createDetector() {
+      if ('FaceDetector' in window) {
+        detectorName = 'Native FaceDetector';
+        const nativeDetector = new FaceDetector({ fastMode: true, maxDetectedFaces: 8 });
+        return { detect: (input) => nativeDetector.detect(input) };
+      }
+
+      detectorName = 'MediaPipe fallback';
+      setStatus('Loading MediaPipe fallback model...');
+      await loadScript('https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14');
+
+      const vision = await window.FilesetResolver.forVisionTasks(
+        'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14/wasm'
+      );
+      const mpDetector = await window.FaceDetector.createFromOptions(vision, {
+        baseOptions: {
+          modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/face_detector/blaze_face_short_range/float16/latest/blaze_face_short_range.tflite'
+        },
+        runningMode: 'VIDEO',
+        minDetectionConfidence: 0.5
+      });
+
+      return {
+        detect: async (input) => {
+          const ts = performance.now();
+          const out = mpDetector.detectForVideo(input, ts);
+          const detections = out.detections || [];
+          return detections.map((d) => ({
+            boundingBox: {
+              x: d.boundingBox.originX,
+              y: d.boundingBox.originY,
+              width: d.boundingBox.width,
+              height: d.boundingBox.height
+            }
+          }));
+        }
+      };
     }
 
     async function detectLoop() {
       if (!running) return;
-
       try {
         const faces = await detector.detect(video);
         lastFaces = faces;
         drawFaceTiles(faces);
-        setStatus(`Tracking ${faces.length} face tile(s).`);
+        setStatus(`${detectorName}: tracking ${faces.length} face tile(s).`);
       } catch (err) {
         console.error(err);
         setStatus(`Detection error: ${err.message}`);
       }
-
       requestAnimationFrame(detectLoop);
     }
 
@@ -105,32 +150,24 @@
       const scaleY = canvas.height / rect.height;
       const x = (event.clientX - rect.left) * scaleX;
       const y = (event.clientY - rect.top) * scaleY;
-
-      const face = hitFaceTile(x, y);
-      if (face) {
+      if (hitFaceTile(x, y)) {
         actionText.textContent = 'Action: 👋 Hi! Face tile selected.';
       }
     });
 
     startBtn.addEventListener('click', async () => {
-      if (!('FaceDetector' in window)) {
-        setStatus('Face Detection API not supported in this browser.');
-        return;
-      }
-
       try {
         const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' }, audio: false });
         video.srcObject = stream;
         await video.play();
         resizeCanvas();
-
-        detector = new FaceDetector({ fastMode: true, maxDetectedFaces: 8 });
+        detector = await createDetector();
         running = true;
-        setStatus('Camera started. Looking for faces...');
+        setStatus(`${detectorName} ready. Looking for faces...`);
         detectLoop();
       } catch (err) {
         console.error(err);
-        setStatus(`Camera error: ${err.message}`);
+        setStatus(`Startup error: ${err.message}`);
       }
     });
 

--- a/eyegaze/index.html
+++ b/eyegaze/index.html
@@ -37,6 +37,14 @@
 
   <div class="tile-container">
     <div class="tile">
+      <a href="facetiles/index.html">
+        <img src="../images/fireflyicon.png" alt="Face Tiles">
+        <div class="tile-title">
+          <h3 data-fr="Tuiles Visages AR" data-en="AR Face Tiles" data-ja="ARフェイスタイル">AR Face Tiles</h3>
+        </div>
+      </a>
+    </div>
+    <div class="tile">
       <a href="samuraistory/index.html">
         <img src="../images/samuraikata/scene7.jpg" alt="La puissance de l'esprit">
         <div class="tile-title">


### PR DESCRIPTION
### Motivation
- Provide a simple prototype that turns detected faces from the device camera into interactive "tiles" for AR-style interactions in the Eye‑Gaze collection.
- Explore using browser-side AI vision (`FaceDetector`) and `getUserMedia` to map faces to clickable regions that trigger actions.

### Description
- Added a new prototype page at `eyegaze/facetiles/index.html` that starts the camera, runs the browser `FaceDetector` API, and draws labeled bounding-box "face tiles" on a canvas overlay above the live video feed.
- Implemented tile interaction: clicking/tapping a face box shows an action message (`Action: 👋 Hi! Face tile selected.`) and the UI shows status and action feedback.
- The prototype includes graceful detection/browser checks and a `Start camera` button to request permission via `navigator.mediaDevices.getUserMedia`.
- Linked the prototype from the Eye‑Gaze portal by adding a new tile in `eyegaze/index.html` so the page is discoverable from the menu.

### Testing
- Verified the created files and changes with `git diff` showing the new `eyegaze/facetiles/index.html` and the insertion into `eyegaze/index.html` (succeeded).
- Staged and committed the changes with `git add` and `git commit -m "Add AR face tiles eyegaze prototype"` (succeeded).
- No automated unit/integration tests are configured for this static HTML prototype, so manual inspection of the diff and file contents was used for validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e1ce00db48325b4a7a1fd1cca14f6)