### PR TITLE
Add mature-tone activities collection for older learners

### DIFF
--- a/gaming/index.html
+++ b/gaming/index.html
@@ -38,6 +38,15 @@
     <div class="tile-container">
 
         <div class="tile">
+            <a href="older-learners/index.html">
+                <img src="../images/ghibli/othergames.png" alt="Activités pour apprenants plus âgés">
+                <div class="tile-title">
+                    <h3 data-fr="Apprenants plus âgés" data-en="Older learners" data-ja="年長学習者">Apprenants plus âgés</h3>
+                </div>
+            </a>
+        </div>
+
+        <div class="tile">
             <a href="easter/index.html">
                 <img src="../images/eastermain.png" alt="Pâques">
                 <div class="tile-title">

--- a/gaming/older-learners/index.html
+++ b/gaming/older-learners/index.html
@@ -1,0 +1,471 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title data-fr="Activités pour apprenants plus âgés" data-en="Activities for Older Learners" data-ja="年長学習者向けアクティビティ">Activités pour apprenants plus âgés</title>
+  <link rel="stylesheet" href="../../css/menu.css">
+  <link rel="stylesheet" href="../../css/global.css">
+  <link rel="stylesheet" href="../../css/layout.css">
+  <link rel="stylesheet" href="../../css/components.css">
+  <style>
+    :root {
+      --older-bg: #111827;
+      --older-card: #1f2937;
+      --older-accent: #f59e0b;
+      --older-accent-2: #38bdf8;
+      --older-text: #f8fafc;
+      --older-muted: #cbd5e1;
+    }
+
+    body.menu {
+      background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 30%),
+                  linear-gradient(135deg, #0f172a, #1e293b 55%, #111827);
+      color: var(--older-text);
+    }
+
+    .older-hero {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: clamp(2rem, 6vw, 5rem) 1.25rem 1.5rem;
+      text-align: center;
+    }
+
+    .older-hero h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2.2rem, 6vw, 4.75rem);
+      line-height: 1.02;
+      letter-spacing: -0.04em;
+    }
+
+    .older-hero p {
+      margin: 0 auto;
+      max-width: 820px;
+      color: var(--older-muted);
+      font-size: clamp(1rem, 2.2vw, 1.3rem);
+      line-height: 1.55;
+    }
+
+    .activity-grid,
+    .crosslink-grid {
+      width: min(1120px, calc(100% - 2rem));
+      margin: 1.5rem auto 3rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1rem;
+    }
+
+    .activity-card,
+    .crosslink-card {
+      min-height: 260px;
+      border-radius: 24px;
+      overflow: hidden;
+      position: relative;
+      isolation: isolate;
+      background: var(--older-card);
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+    }
+
+    .activity-button {
+      width: 100%;
+      height: 100%;
+      min-height: 260px;
+      border: 0;
+      color: var(--older-text);
+      text-align: left;
+      padding: 1.35rem;
+      cursor: pointer;
+      background: linear-gradient(150deg, var(--card-a), var(--card-b));
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      gap: 1rem;
+      font: inherit;
+    }
+
+    .activity-button:focus-visible,
+    .crosslink-card a:focus-visible {
+      outline: 4px solid var(--older-accent);
+      outline-offset: -6px;
+    }
+
+    .activity-icon {
+      font-size: clamp(3rem, 8vw, 5rem);
+      filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.3));
+    }
+
+    .activity-card h2,
+    .crosslink-card h3 {
+      margin: 0;
+      font-size: clamp(1.45rem, 3vw, 2rem);
+      line-height: 1.1;
+    }
+
+    .activity-card p,
+    .crosslink-card p {
+      margin: 0.55rem 0 0;
+      color: rgba(255, 255, 255, 0.88);
+      font-size: 1rem;
+      line-height: 1.45;
+    }
+
+    .stage {
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      opacity: 0;
+      transition: opacity 220ms ease;
+      pointer-events: none;
+    }
+
+    .activity-card.is-active .stage {
+      opacity: 1;
+    }
+
+    .spotlight {
+      position: absolute;
+      top: -15%;
+      width: 36%;
+      height: 105%;
+      transform-origin: top center;
+      background: linear-gradient(to bottom, rgba(255,255,255,0.65), rgba(255,255,255,0));
+      clip-path: polygon(45% 0, 55% 0, 100% 100%, 0 100%);
+      mix-blend-mode: screen;
+      animation: sweep 1.6s ease-in-out infinite alternate;
+    }
+
+    .spotlight.one { left: 8%; transform: rotate(18deg); background-color: rgba(245, 158, 11, 0.4); }
+    .spotlight.two { right: 8%; transform: rotate(-18deg); animation-delay: 0.35s; background-color: rgba(56, 189, 248, 0.45); }
+
+    @keyframes sweep {
+      from { transform: rotate(-22deg); }
+      to { transform: rotate(22deg); }
+    }
+
+    .postcard-view,
+    .photo-view,
+    .nature-view {
+      position: absolute;
+      inset: 12px;
+      border-radius: 18px;
+      display: grid;
+      place-items: center;
+      font-size: clamp(1.5rem, 4vw, 2.4rem);
+      text-align: center;
+      padding: 1rem;
+      background: linear-gradient(135deg, rgba(255,255,255,0.94), rgba(224,242,254,0.94));
+      color: #0f172a;
+      border: 8px solid rgba(255,255,255,0.6);
+      transform: rotate(-2deg);
+    }
+
+    .flag {
+      position: absolute;
+      right: 18px;
+      top: 18px;
+      font-size: 4rem;
+      animation: wave 850ms ease-in-out infinite alternate;
+    }
+
+    .confetti {
+      position: absolute;
+      inset: 0;
+      background-image: radial-gradient(circle, #fff 0 3px, transparent 4px),
+                        radial-gradient(circle, #fbbf24 0 4px, transparent 5px),
+                        radial-gradient(circle, #38bdf8 0 3px, transparent 4px);
+      background-size: 42px 42px, 55px 55px, 70px 70px;
+      animation: confetti 900ms linear infinite;
+    }
+
+    @keyframes wave { from { transform: rotate(-12deg); } to { transform: rotate(12deg); } }
+    @keyframes confetti { from { background-position: 0 0; } to { background-position: 0 70px; } }
+
+    .camera-flash {
+      position: absolute;
+      inset: 0;
+      background: white;
+      animation: flash 1.1s ease-out infinite;
+    }
+
+    @keyframes flash { 0%, 100% { opacity: 0; } 10% { opacity: 0.9; } 30% { opacity: 0; } }
+
+    .cafe-cup {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      font-size: 7rem;
+      animation: serve 1.4s ease-in-out infinite alternate;
+    }
+
+    .steam {
+      position: absolute;
+      left: 50%;
+      top: 20%;
+      width: 10px;
+      height: 60px;
+      border-radius: 50%;
+      border-left: 4px solid rgba(255,255,255,0.8);
+      animation: steam 1.6s ease-in-out infinite;
+    }
+
+    @keyframes serve { from { transform: translateY(18px); } to { transform: translateY(-8px); } }
+    @keyframes steam { from { transform: translateY(20px); opacity: 0; } 50% { opacity: 1; } to { transform: translateY(-28px); opacity: 0; } }
+
+    .breathing-circle {
+      width: min(55vw, 180px);
+      height: min(55vw, 180px);
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(191, 219, 254, 0.98), rgba(34, 197, 94, 0.62));
+      margin: auto;
+      box-shadow: 0 0 55px rgba(125, 211, 252, 0.8);
+      animation: breathe 4s ease-in-out infinite;
+    }
+
+    @keyframes breathe { 0%, 100% { transform: scale(0.72); } 50% { transform: scale(1); } }
+
+    .section-heading {
+      width: min(1120px, calc(100% - 2rem));
+      margin: 3rem auto 1rem;
+    }
+
+    .section-heading h2 {
+      margin: 0 0 0.5rem;
+      font-size: clamp(1.8rem, 4vw, 3rem);
+    }
+
+    .section-heading p {
+      margin: 0;
+      color: var(--older-muted);
+      line-height: 1.5;
+    }
+
+    .crosslink-card a {
+      display: flex;
+      min-height: 160px;
+      height: 100%;
+      padding: 1.25rem;
+      color: var(--older-text);
+      text-decoration: none;
+      background: linear-gradient(135deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.95));
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    .access-hint {
+      width: min(1120px, calc(100% - 2rem));
+      margin: 0 auto 3rem;
+      padding: 1rem 1.25rem;
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.1);
+      color: var(--older-muted);
+      line-height: 1.5;
+    }
+  </style>
+</head>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-B45TJG4GBJ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-B45TJG4GBJ');
+</script>
+<body class="menu">
+  <nav class="top-menu">
+    <div class="top-menu-title" data-fr="Adaptatech" data-en="Adaptatech" data-ja="Adaptatech">Adaptatech</div>
+    <ul>
+      <li><a href="../../index.html" data-fr="Accueil" data-en="Home" data-ja="ホーム">Accueil</a></li>
+      <li><a href="../index.html" data-fr="Jeux pour switch" data-en="Switch games" data-ja="スイッチ用ゲーム">Jeux pour switch</a></li>
+      <li><a href="../../contact/index.html" data-fr="Contact" data-en="Contact" data-ja="お問い合わせ">Contact</a></li>
+      <li><a href="#" id="language-toggle" onclick="toggleLanguage(); return false;"></a></li>
+    </ul>
+  </nav>
+
+  <header class="older-hero">
+    <h1 data-fr="Activités à ton mature" data-en="Mature-tone activities" data-ja="落ち着いた雰囲気の活動">Activités à ton mature</h1>
+    <p data-fr="Une collection de jeux au switch avec des thèmes moins enfantins : sorties, voyages, sports, photographie, café et relaxation. Chaque carte réagit à la barre d’espace, à Entrée, au clic ou au toucher."
+       data-en="A collection of switch activities with less childlike themes: outings, travel, sports, photography, café service, and relaxation. Each card responds to Space, Enter, click, or touch."
+       data-ja="外出、旅行、スポーツ、写真、カフェ、リラクゼーションなど、子どもっぽさを抑えたスイッチ活動のコレクションです。各カードはスペース、Enter、クリック、タッチに反応します。">
+      Une collection de jeux au switch avec des thèmes moins enfantins : sorties, voyages, sports, photographie, café et relaxation.
+    </p>
+  </header>
+
+  <main>
+    <section class="activity-grid" aria-label="Older learner activities">
+      <article class="activity-card" style="--card-a:#111827;--card-b:#7c2d12;">
+        <button class="activity-button" data-activity="concert" type="button">
+          <span class="activity-icon" aria-hidden="true">🎤</span>
+          <div>
+            <h2 data-fr="Lumières de concert" data-en="Concert lights" data-ja="コンサート照明">Lumières de concert</h2>
+            <p data-fr="Le switch contrôle les projecteurs et transforme la scène." data-en="The switch controls stage lights and transforms the scene." data-ja="スイッチでステージ照明を操作します。">Le switch contrôle les projecteurs et transforme la scène.</p>
+          </div>
+        </button>
+        <div class="stage" aria-hidden="true"><span class="spotlight one"></span><span class="spotlight two"></span></div>
+      </article>
+
+      <article class="activity-card" style="--card-a:#075985;--card-b:#0f766e;">
+        <button class="activity-button" data-activity="travel" type="button">
+          <span class="activity-icon" aria-hidden="true">✈️</span>
+          <div>
+            <h2 data-fr="Carte postale voyage" data-en="Travel postcard" data-ja="旅のポストカード">Carte postale voyage</h2>
+            <p data-fr="Révèle des destinations autour du monde, comme une pile de cartes postales." data-en="Reveal destinations around the world, like a stack of postcards." data-ja="世界の目的地をポストカードのように表示します。">Révèle des destinations autour du monde.</p>
+          </div>
+        </button>
+        <div class="stage"><div class="postcard-view" data-role="travel-view">Paris · France</div></div>
+      </article>
+
+      <article class="activity-card" style="--card-a:#166534;--card-b:#1d4ed8;">
+        <button class="activity-button" data-activity="sports" type="button">
+          <span class="activity-icon" aria-hidden="true">🏟️</span>
+          <div>
+            <h2 data-fr="Partisan de sport" data-en="Sports fan" data-ja="スポーツ応援">Partisan de sport</h2>
+            <p data-fr="Appuie pour acclamer, agiter le drapeau et lancer la célébration." data-en="Press to cheer, wave the flag, and launch the celebration." data-ja="押すと歓声、旗振り、お祝いが始まります。">Appuie pour acclamer, agiter le drapeau et célébrer.</p>
+          </div>
+        </button>
+        <div class="stage"><span class="flag">🏁</span><div class="confetti"></div></div>
+      </article>
+
+      <article class="activity-card" style="--card-a:#312e81;--card-b:#be123c;">
+        <button class="activity-button" data-activity="photo" type="button">
+          <span class="activity-icon" aria-hidden="true">📷</span>
+          <div>
+            <h2 data-fr="Photographie" data-en="Photography" data-ja="写真撮影">Photographie</h2>
+            <p data-fr="Le switch prend une photo et avance dans un diaporama de scènes." data-en="The switch takes a photo and advances through a scenic slideshow." data-ja="スイッチで写真を撮り、風景スライドを進めます。">Le switch prend une photo dans un diaporama.</p>
+          </div>
+        </button>
+        <div class="stage"><div class="photo-view" data-role="photo-view">🏔️ Montagnes</div><div class="camera-flash"></div></div>
+      </article>
+
+      <article class="activity-card" style="--card-a:#78350f;--card-b:#44403c;">
+        <button class="activity-button" data-activity="cafe" type="button">
+          <span class="activity-icon" aria-hidden="true">☕</span>
+          <div>
+            <h2 data-fr="Aide au café" data-en="Café helper" data-ja="カフェのお手伝い">Aide au café</h2>
+            <p data-fr="Choisis une boisson, sers la commande et écoute une ambiance de café." data-en="Choose a drink, serve the order, and hear ambient café sounds." data-ja="飲み物を選び、注文を出し、カフェの音を聞きます。">Choisis une boisson, sers la commande et écoute le café.</p>
+          </div>
+        </button>
+        <div class="stage"><div class="cafe-cup" data-role="cafe-view">☕</div><span class="steam"></span></div>
+      </article>
+
+      <article class="activity-card" style="--card-a:#064e3b;--card-b:#0369a1;">
+        <button class="activity-button" data-activity="relax" type="button">
+          <span class="activity-icon" aria-hidden="true">🌿</span>
+          <div>
+            <h2 data-fr="Relaxation" data-en="Relaxation" data-ja="リラクゼーション">Relaxation</h2>
+            <p data-fr="Visuels de respiration, sons calmes et scènes de nature." data-en="Breathing visuals, calm sounds, and nature scenes." data-ja="呼吸の視覚効果、穏やかな音、自然の景色。">Visuels de respiration, sons calmes et scènes de nature.</p>
+          </div>
+        </button>
+        <div class="stage"><div class="nature-view"><div><div class="breathing-circle"></div><span data-role="relax-view">Respirer</span></div></div></div>
+      </article>
+    </section>
+
+    <p class="access-hint" data-fr="Astuce : si un switch envoie la barre d’espace ou Entrée, place le focus sur une carte et appuie pour déclencher l’activité. Les sons sont générés dans le navigateur après l’activation."
+       data-en="Tip: if a switch sends Space or Enter, focus a card and press to trigger the activity. Sounds are generated in the browser after activation."
+       data-ja="ヒント：スイッチがスペースまたはEnterを送信する場合、カードにフォーカスして押すと活動が始まります。音は操作後にブラウザで生成されます。">
+      Astuce : si un switch envoie la barre d’espace ou Entrée, place le focus sur une carte et appuie pour déclencher l’activité.
+    </p>
+
+    <section class="section-heading">
+      <h2 data-fr="Autres jeux POV au ton plus mature" data-en="More mature-tone POV games" data-ja="落ち着いた雰囲気のPOVゲーム">Autres jeux POV au ton plus mature</h2>
+      <p data-fr="Ces expériences à la première personne conviennent aussi aux apprenants plus âgés qui aiment les voyages, le sport et l’exploration." data-en="These first-person experiences also suit older learners who enjoy travel, sport, and exploration." data-ja="旅行、スポーツ、探検が好きな年長学習者にも合う一人称視点の体験です。">Ces expériences à la première personne conviennent aussi aux apprenants plus âgés.</p>
+    </section>
+
+    <section class="crosslink-grid" aria-label="Mature POV games">
+      <article class="crosslink-card"><a href="../../pov/train%20alpes/index.html"><h3 data-fr="Petit train des Alpes" data-en="Trolley in the Alps" data-ja="アルプスの路面電車">Petit train des Alpes</h3><p data-fr="Voyage panoramique en montagne." data-en="Scenic mountain travel." data-ja="山の景色を楽しむ旅。">Voyage panoramique en montagne.</p></a></article>
+      <article class="crosslink-card"><a href="../../pov/parkour/index.html"><h3 data-fr="Parkour" data-en="Parkour" data-ja="パルクール">Parkour</h3><p data-fr="Énergie urbaine et mouvement." data-en="Urban energy and movement." data-ja="都会的な動きとエネルギー。">Énergie urbaine et mouvement.</p></a></article>
+      <article class="crosslink-card"><a href="../../pov/ski%20alpin/index.html"><h3 data-fr="Ski alpin" data-en="Alpine skiing" data-ja="アルペンスキー">Ski alpin</h3><p data-fr="Descente sportive en montagne." data-en="Sporty mountain descent." data-ja="山のスポーツ滑走。">Descente sportive en montagne.</p></a></article>
+      <article class="crosslink-card"><a href="../../pov/spacewalk/index.html"><h3 data-fr="Sortie dans l'espace" data-en="Spacewalk" data-ja="船外活動">Sortie dans l'espace</h3><p data-fr="Exploration calme et impressionnante." data-en="Calm, impressive exploration." data-ja="静かで印象的な探検。">Exploration calme et impressionnante.</p></a></article>
+      <article class="crosslink-card"><a href="../../pov/winter%20olympic/index.html"><h3 data-fr="Jeux olympiques d'hiver" data-en="Winter Olympics" data-ja="冬季オリンピック">Jeux olympiques d'hiver</h3><p data-fr="Ambiance sportive et hivernale." data-en="Sporty winter atmosphere." data-ja="冬のスポーツの雰囲気。">Ambiance sportive et hivernale.</p></a></article>
+    </section>
+  </main>
+
+  <button id="langToggle" class="floating-button lang-toggle" title="Changer la langue / Switch language">EN</button>
+
+  <script src="../../js/translationmain.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const langBtn = document.getElementById('langToggle');
+      if (langBtn) langBtn.addEventListener('click', toggleLanguage);
+    });
+
+    const travelPlaces = ['Paris · France', 'Kyoto · Japan', 'Marrakesh · Morocco', 'Québec · Canada', 'Rio · Brazil', 'Reykjavík · Iceland'];
+    const photoScenes = ['🏔️ Montagnes', '🌅 Lever du soleil', '🌉 Pont illuminé', '🌊 Bord de mer', '🌲 Forêt calme', '🏙️ Ville de nuit'];
+    const cafeOrders = ['☕ Café', '🍵 Thé', '🥐 Croissant', '🧊 Café glacé', '🍰 Dessert'];
+    const relaxPrompts = ['Respirer', 'Inspirer', 'Expirer', 'Observer', 'Se déposer'];
+    const counters = { travel: 0, photo: 0, cafe: 0, relax: 0 };
+    let audioContext;
+
+    function getAudioContext() {
+      if (!audioContext) audioContext = new (window.AudioContext || window.webkitAudioContext)();
+      return audioContext;
+    }
+
+    function playTone(frequency, duration = 0.18, type = 'sine', gainValue = 0.05) {
+      const ctx = getAudioContext();
+      const oscillator = ctx.createOscillator();
+      const gain = ctx.createGain();
+      oscillator.type = type;
+      oscillator.frequency.value = frequency;
+      gain.gain.setValueAtTime(gainValue, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
+      oscillator.connect(gain).connect(ctx.destination);
+      oscillator.start();
+      oscillator.stop(ctx.currentTime + duration);
+    }
+
+    function playCafeNoise() {
+      playTone(220, 0.12, 'triangle', 0.035);
+      setTimeout(() => playTone(330, 0.16, 'sine', 0.025), 120);
+    }
+
+    function activate(card, activity) {
+      document.querySelectorAll('.activity-card').forEach(item => item.classList.remove('is-active'));
+      card.classList.add('is-active');
+
+      if (activity === 'concert') {
+        playTone(196, 0.18, 'sawtooth', 0.035);
+        setTimeout(() => playTone(392, 0.22, 'sawtooth', 0.03), 120);
+      }
+
+      if (activity === 'travel') {
+        const view = card.querySelector('[data-role="travel-view"]');
+        counters.travel = (counters.travel + 1) % travelPlaces.length;
+        view.textContent = travelPlaces[counters.travel];
+        playTone(523.25, 0.16, 'triangle', 0.035);
+      }
+
+      if (activity === 'sports') {
+        [330, 392, 494].forEach((note, index) => setTimeout(() => playTone(note, 0.12, 'square', 0.025), index * 90));
+      }
+
+      if (activity === 'photo') {
+        const view = card.querySelector('[data-role="photo-view"]');
+        counters.photo = (counters.photo + 1) % photoScenes.length;
+        view.textContent = photoScenes[counters.photo];
+        playTone(880, 0.08, 'square', 0.025);
+      }
+
+      if (activity === 'cafe') {
+        const view = card.querySelector('[data-role="cafe-view"]');
+        counters.cafe = (counters.cafe + 1) % cafeOrders.length;
+        view.textContent = cafeOrders[counters.cafe];
+        playCafeNoise();
+      }
+
+      if (activity === 'relax') {
+        const view = card.querySelector('[data-role="relax-view"]');
+        counters.relax = (counters.relax + 1) % relaxPrompts.length;
+        view.textContent = relaxPrompts[counters.relax];
+        playTone(261.63, 0.55, 'sine', 0.025);
+        setTimeout(() => playTone(329.63, 0.65, 'sine', 0.018), 250);
+      }
+    }
+
+    document.querySelectorAll('.activity-button').forEach(button => {
+      button.addEventListener('click', () => activate(button.closest('.activity-card'), button.dataset.activity));
+    });
+  </script>
+  <script src="../../js/home-button.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -225,6 +225,13 @@
           <div class="tile-main-title" data-fr="Jeux pour switch (divers)" data-en="Switch games (various)" data-ja="スイッチ用ゲーム（その他）"></div>
         </a>
       </div>
+
+      <div class="tile-main">
+        <a href="gaming/older-learners/index.html" class="tile-video-link" data-video="animations/othergames.mp4">
+          <img src="images/ghibli/othergames.png" alt="Older learner activities">
+          <div class="tile-main-title" data-fr="Activités à ton mature" data-en="Mature-tone activities" data-ja="落ち着いた雰囲気の活動"></div>
+        </a>
+      </div>
       
 
       <div class="tile-main">

--- a/pov/index.html
+++ b/pov/index.html
@@ -40,6 +40,16 @@
         
     </div>    
 
+
+    <section class="section-heading" style="width:min(1100px, calc(100% - 2rem)); margin: 2rem auto 0; text-align:center;">
+        <h2 data-fr="Sélection pour apprenants plus âgés" data-en="Older learner selection" data-ja="年長学習者向けセレクション">Sélection pour apprenants plus âgés</h2>
+        <p data-fr="Train, parkour, ski, sortie dans l'espace et Olympiques d'hiver sont aussi regroupés dans la collection à ton mature."
+           data-en="Train, parkour, skiing, spacewalk, and Winter Olympics are also grouped in the mature-tone collection."
+           data-ja="列車、パルクール、スキー、船外活動、冬季オリンピックは落ち着いた雰囲気のコレクションにもまとめられています。">
+            Train, parkour, ski, sortie dans l'espace et Olympiques d'hiver sont aussi regroupés dans la collection à ton mature.
+        </p>
+        <p><a href="../gaming/older-learners/index.html" data-fr="Voir la collection" data-en="View the collection" data-ja="コレクションを見る">Voir la collection</a></p>
+    </section>
     <div class="tile-container">
         <div class="tile">
             <a href="train alpes/index.html">


### PR DESCRIPTION
### Motivation
- Provide a small collection of switch-accessible activities with themes aimed at older or more mature learners (concerts, travel, sports, photography, café, relaxation).
- Surface the new collection from the games portal and the root portal and recommend relevant POV experiences for cross-navigation.

### Description
- Add a new page `gaming/older-learners/index.html` implementing six activity cards with multilingual copy, CSS styling, and in-page JS for activity activation, audio tones, rotating content, and simple animations.
- Add a tile linking to the collection in `gaming/index.html` and add a featured tile in the site root `index.html` to surface the collection on the main portal.
- Add a callout and link in `pov/index.html` that highlights POV experiences (train, parkour, skiing, spacewalk, winter Olympics) as complementary mature-tone options.
- Activities are accessible by click/keyboard (Space/Enter) and use browser `AudioContext` tones and DOM updates to simulate interactions without external assets.

### Testing
- Ran a `python3` HTMLParser smoke check against `gaming/older-learners/index.html`, `gaming/index.html`, `index.html`, and `pov/index.html`, which completed successfully.
- Ran `git diff --check`, which reported no new whitespace or syntax errors for the modified files.
- Executed a local link/image existence script that completed but reported an existing unrelated missing link (`../pedagogique/choix/index.html`) in `gaming/index.html` which predates these changes.
- Attempted a headless browser visual check but no browser runtime was available in the environment, so visual tests were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af9dcd87c83259a80bac45f0fea1a)